### PR TITLE
Fix LogicValues bugs #22 and #23

### DIFF
--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -27,8 +27,8 @@ import 'package:rohd/rohd.dart';
 class _SmallLogicValues extends LogicValues {
   // Each 0/1 bit in value is 0/1 if !invalid, else is x/z
 
-  final int _value;
-  final int _invalid;
+  late final int _value;
+  late final int _invalid;
   
   int get _mask => _maskOfLength(length);
   static final Map<int,int> _masksOfLength = {};
@@ -39,8 +39,10 @@ class _SmallLogicValues extends LogicValues {
     return _masksOfLength[length]!;
   }
 
-  _SmallLogicValues(this._value, this._invalid, int length) : super._(length) {
+  _SmallLogicValues(int value, int invalid, int length) : super._(length) {
     if(length > LogicValues._INT_BITS) throw Exception('_SmallLogicValues cannot be used for big values.');
+    _value = _mask & value;
+    _invalid = _mask & invalid;
   }
   
   @override
@@ -177,8 +179,8 @@ class _SmallLogicValues extends LogicValues {
 /// The implementation is similar to [_SmallLogicValues], except it uses [BigInt].
 /// 
 class _BigLogicValues extends LogicValues {
-  final BigInt _value;
-  final BigInt _invalid;
+  late final BigInt _value;
+  late final BigInt _invalid;
 
   BigInt get _mask => _maskOfLength(length);
   static final Map<int,BigInt> _masksOfLength = {};
@@ -189,8 +191,10 @@ class _BigLogicValues extends LogicValues {
     return _masksOfLength[length]!;
   }
 
-  _BigLogicValues(this._value, this._invalid, int length) : super._(length) {
+  _BigLogicValues(BigInt value, BigInt invalid, int length) : super._(length) {
     if(length <= LogicValues._INT_BITS) throw Exception('_BigLogicValues should not be used for small values.');
+    _value = _mask & value;
+    _invalid = _mask & invalid;
   }
   
   @override

--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -127,13 +127,13 @@ class _SmallLogicValues extends LogicValues {
   }
 
   @override
-  LogicValue and() => !isValid ? LogicValue.x :
-    _value ^ _mask == 0 ? LogicValue.one : 
-    LogicValue.zero;
+  LogicValue and() => (~_value & ~_invalid) & _mask != 0 ? LogicValue.zero :
+    !isValid ? LogicValue.x :
+    LogicValue.one;
 
   @override
-  LogicValue or() => !isValid ? LogicValue.x :
-    _value != 0 ? LogicValue.one :
+  LogicValue or() => (_value ^ _invalid) & _value != 0 ? LogicValue.one :
+    !isValid ? LogicValue.x :
     LogicValue.zero;
 
   @override
@@ -288,16 +288,15 @@ class _BigLogicValues extends LogicValues {
       length
     );
   }
-
+  
+  @override
+  LogicValue and() => (~_value & ~_invalid) & _mask != BigInt.zero ? LogicValue.zero :
+    !isValid ? LogicValue.x :
+    LogicValue.one;
 
   @override
-  LogicValue and() => !isValid ? LogicValue.x :
-    _value ^ _mask == BigInt.zero ? LogicValue.one : 
-    LogicValue.zero;
-
-  @override
-  LogicValue or() => !isValid ? LogicValue.x :
-    _value != BigInt.zero ? LogicValue.one :
+  LogicValue or() => (_value ^ _invalid) & _value != BigInt.zero ? LogicValue.one :
+    !isValid ? LogicValue.x :
     LogicValue.zero;
 
   @override


### PR DESCRIPTION
Fix issues related to LogicValues value comparison and unary AND and OR

## Related Issue(s)

Fix #22
Fix #23

## Testing

#21 will include tests covering the fixes

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?
No, bug fix only

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?
No
