### PR TITLE
update connectIO to use uniquify function, close #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ The `Port` class extends `Logic`, but has a constructor that takes width as a po
 
 When connecting an `Interface` to a `Module`, you should always create a new instance of the `Interface` so you don't modify the one being passed in through the constructor.  Modifying the same `Interface` as was passed would have negative consequences if multiple `Module`s were consuming the same `Interface`, and also breaks the rules for `Module` input and output connectivity.
 
-The `connectIO` function under the hood calls `addInput` and `addOutput` directly on the `Module` and connects those `Module` ports to the correct ports on the `Interface`s.  Connection is based on signal names.  You can use the `append` String argument in `connectIO` to uniquify inputs and outputs in case you have multiple instances of the same `Interface` connected to your module.  You can also use the `setPort` function to directly set individual ports on the `Interface` instead of via tagged set of ports.
+The `connectIO` function under the hood calls `addInput` and `addOutput` directly on the `Module` and connects those `Module` ports to the correct ports on the `Interface`s.  Connection is based on signal names.  You can use the `uniquify` Function argument in `connectIO` to uniquify inputs and outputs in case you have multiple instances of the same `Interface` connected to your module.  You can also use the `setPort` function to directly set individual ports on the `Interface` instead of via tagged set of ports.
 
 ```dart
 // Define a set of legal directions for this interface, and pass as parameter to Interface

--- a/lib/src/interface.dart
+++ b/lib/src/interface.dart
@@ -40,19 +40,22 @@ class Interface<TagType> {
   /// The [srcInterface] should be a new instance of the [Interface] to be used by [module] for
   /// all input and output connectivity.  All signals in the interface with specified [TagType]
   /// will be connected to the [Module] via [Module.addInput] or [Module.addOutput] based on
-  /// [inputTags] and [outputTags], respectively.  [append] can be used to uniquifiy port names
-  /// by appending a [String] to the end.
-  void connectIO(Module module, Interface srcInterface, {Set<TagType>? inputTags, Set<TagType>? outputTags, String append=''}) {
+  /// [inputTags] and [outputTags], respectively.  [uniquify] can be used to uniquifiy port names
+  /// by manipulating the original name of the port.
+  void connectIO(Module module, Interface srcInterface, {Set<TagType>? inputTags, Set<TagType>? outputTags, String Function(String original)? uniquify}) {
+    
+    uniquify = uniquify ?? (String original) => original;
+
     getPorts(inputTags).forEach((port) {
       setPort(
         // ignore: invalid_use_of_protected_member
-        module.addInput(port.name+append, srcInterface.port(port.name), width: port.width),
+        module.addInput(uniquify!(port.name), srcInterface.port(port.name), width: port.width),
         portName: port.name
       );
     });
     getPorts(outputTags).forEach((port) {
       // ignore: invalid_use_of_protected_member
-      var output = module.addOutput(port.name+append, width: port.width);
+      var output = module.addOutput(uniquify!(port.name), width: port.width);
       port <= output;
       srcInterface.port(port.name) <= port;
       setPort(


### PR DESCRIPTION
## Description & Motivation

The old `append` argument was limiting in how to rename signals to uniquify them.  A function is more flexible.

## Related Issue(s)

Close #6 

## Testing

Existing interface tests pass.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?
Yes, `append` is being replaced by `uniquify`.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?
Yes, API and README updated.
