### PR TITLE
WaveDumper improvements and fixes

### DIFF
--- a/example/counter.dart
+++ b/example/counter.dart
@@ -69,8 +69,8 @@ void main({bool noPrint=false}) async {
   // Now let's try simulating!
 
   // Let's start off with a disabled counter and asserting reset.
-  en.put(0);
-  reset.put(1);
+  await en.inject(0);
+  await reset.inject(1);
 
   // Attach a waveform dumper so we can see what happens.
   WaveDumper(counter);

--- a/example/counter.dart
+++ b/example/counter.dart
@@ -73,7 +73,7 @@ void main({bool noPrint=false}) async {
   reset.put(1);
 
   // Attach a waveform dumper so we can see what happens.
-  Dumper(counter);
+  WaveDumper(counter);
 
   // Drop reset at time 25.
   Simulator.registerAction(25, () => reset.put(0));

--- a/lib/rohd.dart
+++ b/lib/rohd.dart
@@ -4,7 +4,7 @@
 export 'src/simulator.dart';
 export 'src/logic.dart';
 export 'src/module.dart';
-export 'src/dumper.dart';
+export 'src/wave_dumper.dart';
 export 'src/modules/modules.dart';
 export 'src/interface.dart';
 export 'src/external.dart';

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -331,8 +331,8 @@ class Logic {
   /// Injects a value onto this signal in the current [Simulator] tick.
   /// 
   /// This function calls [put()] in [Simulator.injectAction()].
-  void inject(dynamic val, {bool fill = false}) {
-    Simulator.injectAction(() => put(val, fill: fill));
+  Future<void> inject(dynamic val, {bool fill = false}) async {
+    await Simulator.injectAction(() => put(val, fill: fill));
   }
 
   /// Keeps track of whether there is an active put, to detect reentrance.

--- a/lib/src/modules/clkgen.dart
+++ b/lib/src/modules/clkgen.dart
@@ -12,7 +12,7 @@ import 'package:rohd/rohd.dart';
 
 /// A very simple clock generator.  Generates a non-synthesizable SystemVerilog representation.
 class SimpleClockGenerator extends Module with CustomSystemVerilog {
-  final double clockPeriod;
+  final int clockPeriod;
 
   /// The generated clock.
   Logic get clk => output('clk');
@@ -26,7 +26,7 @@ class SimpleClockGenerator extends Module with CustomSystemVerilog {
     addOutput('clk');
 
     clk.glitch.listen((args) {
-      Simulator.registerAction(Simulator.time + clockPeriod/2, () {
+      Simulator.registerAction(Simulator.time + clockPeriod~/2, () {
         clk.put(
           ~clk.value
         );

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -59,7 +59,7 @@ class Vector {
 class SimCompare {
   
   static Future<void> checkFunctionalVector(Module module, List<Vector> vectors) async {
-    var timestamp = 1.0;
+    var timestamp = 1;
     for(var vector in vectors) {
       // print('Running vector: $vector');
       Simulator.registerAction(timestamp, () async {

--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -573,7 +573,7 @@ abstract class LogicValues {
   /// 
   /// ```dart
   /// var stringRepresentation = '1x0';
-  /// var lv = LogicValues.fromString(it);
+  /// var lv = LogicValues.fromString(stringRepresentation);
   /// print(lv); // This prints `3b'1x0`
   /// ```
   static LogicValues fromString(String stringRepresentation) {
@@ -583,6 +583,7 @@ abstract class LogicValues {
     if(length <= _INT_BITS) {
       var value = int.parse(valueString, radix: 2);
       var invalid = int.parse(invalidString, radix: 2);
+      //TODO: check if we should use filled here
       return _SmallLogicValues(value, invalid, length);
     } else {
       var value = BigInt.parse(valueString, radix: 2);

--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -16,8 +16,8 @@ import 'package:rohd/src/utilities/uniquifier.dart';
 
 /// A waveform dumper for simulations.
 /// 
-/// Outputs to vcd format at [outputPath].  [module] must be built prior to attaching the [Dumper].
-class Dumper {
+/// Outputs to vcd format at [outputPath].  [module] must be built prior to attaching the [WaveDumper].
+class WaveDumper {
 
   /// The [Module] being dumped.
   final Module module;
@@ -36,7 +36,7 @@ class Dumper {
 
   //TODO: add unit testing for Dumper
   
-  Dumper(this.module, {this.outputPath = 'waves.vcd'}) : _outputFile = File(outputPath) {
+  WaveDumper(this.module, {this.outputPath = 'waves.vcd'}) : _outputFile = File(outputPath) {
     if(!module.hasBuilt) throw Exception('Module must be built before passed to dumper.');
 
     _collectAllSignals();
@@ -57,7 +57,10 @@ class Dumper {
       var m = modulesToParse[i];
       for(var sig in m.signals) {
         
-        if(sig is Const) continue;
+        if(sig is Const) {
+          // constant values are "boring" to inspect
+          continue;
+        }
 
         _signalToMarkerMap[sig] = 's${_signalMarkerIdx++}';
         sig.changed.listen((args) {
@@ -68,6 +71,10 @@ class Dumper {
         });
       }
       for(var subm in m.subModules) {
+        if(subm is CustomSystemVerilog) {
+          // the CustomSystemVerilog modules are "boring" to inspect
+          continue;
+        }
         modulesToParse.add(subm);
       }
     }

--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -1,7 +1,7 @@
 /// Copyright (C) 2021 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 /// 
-/// dumper.dart
+/// wave_dumper.dart
 /// Waveform dumper for a given module hierarchy, dumps to .vcd file
 /// 
 /// 2021 May 7
@@ -34,8 +34,18 @@ class WaveDumper {
   /// Stores the mapping from [Logic] to signal marker in the VCD file.
   final Map<Logic,String> _signalToMarkerMap = {};
 
-  //TODO: add unit testing for Dumper
-  
+  /// A set of all [Logic]s that have changed in this timestamp so far.
+  /// 
+  /// This spans across multiple inject or changed events if they are in the same
+  /// timestamp of the [Simulator].
+  final Set<Logic> _changedLogicsThisTimestamp = <Logic>{};
+
+  /// The timestamp which is currently being collected for a dump.
+  /// 
+  /// When the [Simulator] time progresses beyond this, it will dump all the
+  /// signals that have changed up until that point at this saved time value.
+  var _currentDumpingTimestamp = Simulator.time;
+    
   WaveDumper(this.module, {this.outputPath = 'waves.vcd'}) : _outputFile = File(outputPath) {
     if(!module.hasBuilt) throw Exception('Module must be built before passed to dumper.');
 
@@ -43,10 +53,19 @@ class WaveDumper {
     
     _writeHeader();
     _writeScope();
-    _captureTimestamp();
     
     Simulator.preTick.listen((args) {
-      _captureTimestamp();
+      if(Simulator.time != _currentDumpingTimestamp) {
+        if(_changedLogicsThisTimestamp.isNotEmpty) {
+          // no need to write blank timestamps
+          _captureTimestamp(_currentDumpingTimestamp);
+        }
+        _currentDumpingTimestamp = Simulator.time;
+      }
+    });
+
+    Simulator.simulationEnded.then((args) {
+      _captureTimestamp(Simulator.time);
     });
   }
 
@@ -64,15 +83,12 @@ class WaveDumper {
 
         _signalToMarkerMap[sig] = 's${_signalMarkerIdx++}';
         sig.changed.listen((args) {
-          _writeSignalValueUpdate(sig);
-        });
-        Simulator.simulationEnded.then((args) {
-          _writeSignalValueUpdate(sig);
+          _changedLogicsThisTimestamp.add(sig);
         });
       }
       for(var subm in m.subModules) {
-        if(subm is CustomSystemVerilog) {
-          // the CustomSystemVerilog modules are "boring" to inspect
+        if(subm is InlineSystemVerilog) {
+          // the InlineSystemVerilog modules are "boring" to inspect
           continue;
         }
         modulesToParse.add(subm);
@@ -116,6 +132,7 @@ class WaveDumper {
     var moduleSignalUniquifier = Uniquifier();
     var padding = List.filled(indent, '  ').join();
     var scopeString = '$padding\$scope module ${m.uniqueInstanceName} \$end\n';
+    var innerScopeString = '';
     for(var sig in m.signals) {
       
       if(!_signalToMarkerMap.containsKey(sig)) continue;
@@ -124,19 +141,29 @@ class WaveDumper {
       var marker = _signalToMarkerMap[sig];
       var signalName = Sanitizer.sanitizeSV(sig.name);
       signalName = moduleSignalUniquifier.getUniqueName(initialName: signalName, reserved: sig.isPort);
-      scopeString += '  $padding\$var wire $width $marker $signalName \$end\n';
+      innerScopeString += '  $padding\$var wire $width $marker $signalName \$end\n';
     }
     for(var subModule in m.subModules) {
-      scopeString += _computeScopeString(subModule, indent: indent + 1);
+      innerScopeString += _computeScopeString(subModule, indent: indent + 1);
     }
+    if(innerScopeString.isEmpty) {
+      // no need to dump empty scopes
+      return '';
+    }
+    scopeString += innerScopeString;
     scopeString += '$padding\$upscope \$end\n';
     return scopeString;
   }
 
   /// Writes the current timestamp to the VCD.
-  void _captureTimestamp() {
-    var timestampString = '#${Simulator.time.toInt()}\n';
+  void _captureTimestamp(int timestamp) {
+    var timestampString = '#$timestamp\n';
     _outputFile.writeAsStringSync(timestampString, mode: FileMode.append);
+
+    for(var signal in _changedLogicsThisTimestamp) {
+      _writeSignalValueUpdate(signal);
+    }
+    _changedLogicsThisTimestamp.clear();
   }
 
   /// Writes the current value of [signal] to the VCD.
@@ -150,3 +177,7 @@ class WaveDumper {
   }
 
 }
+
+
+@Deprecated('Use WaveDumper instead')
+typedef Dumper = WaveDumper;

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -47,6 +47,7 @@ void main() {
     test('counter', () async {
       var mod = Counter(Logic(), Logic());
       await mod.build();
+      // WaveDumper(mod);
       // File('tmp_counter.sv').writeAsStringSync(mod.generateSynth());
       var vectors = [
         Vector({'en': 0, 'reset': 1}, {}),

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -17,15 +17,15 @@ void main() {
     Simulator.reset();
   });
 
-  test('simulator supports registration of actions at time stamps', () {
+  test('simulator supports registration of actions at time stamps', () async {
     var actionTaken = false;
     Simulator.registerAction(100, () => actionTaken = true);
-    Simulator.run();
+    await Simulator.run();
     expect(actionTaken, equals(true));
   });
 
   test('simulator stops at maximum time', () async {
-    var timeLimit = 1000.0;
+    var timeLimit = 1000;
     Simulator.setMaxSimTime(timeLimit);
     void register100inFuture() {
       // print('@${Simulator.time} registering again!');
@@ -42,7 +42,7 @@ void main() {
   test('simulator stops when endSimulation is called', () async {
     var tooFar = false;
     var farEnough = false;
-    var haltTime = 650.0;
+    var haltTime = 650;
     Simulator.registerAction(100, () => farEnough = true);
     Simulator.registerAction(1000, () => tooFar = true);
     Simulator.registerAction(haltTime, () => Simulator.endSimulation());

--- a/test/translations_test.dart
+++ b/test/translations_test.dart
@@ -111,7 +111,7 @@ void main() {
       );
       await ftm.build();
       // File('tmp.sv').writeAsStringSync(ftm.generateSynth())
-      // Dumper(ftm);
+      // WaveDumper(ftm);
       var vectors = [
         Vector({'lrst': 0}, {}),
         Vector({'lrst': 1}, {}),

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -1,0 +1,189 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+/// 
+/// wave_dumper_test.dart
+/// Tests for the WaveDumper
+/// 
+/// 2021 November 4
+/// Author: Max Korbel <max.korbel@intel.com>
+/// 
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class SimpleModule extends Module {
+  SimpleModule(Logic a) {
+    a = addInput('a', a);
+    addOutput('b') <= ~a;
+  }
+}
+
+const tempDumpDir = 'tmp_test';
+
+/// Gets the path of the VCD file based on a name.
+String temporaryDumpPath(String name) {
+  return '$tempDumpDir/temp_dump_$name.vcd';
+}
+
+/// Attaches a [WaveDumper] to [module] to VCD with [name].
+void createTemporaryDump(Module module, String name) {
+  Directory(tempDumpDir).createSync(recursive:true);
+  var tmpDumpFile = temporaryDumpPath(name);
+  WaveDumper(module, outputPath: tmpDumpFile);
+}
+
+/// Deletes the temporary VCD file associated with [name].
+void deleteTemporaryDump(String name) {
+  var tmpDumpFile = temporaryDumpPath(name);
+  File(tmpDumpFile).deleteSync();
+}
+
+/// State of VCD parsing for [confirmValue].
+enum VCDParseState {findSig, findDumpVars, findValue}
+
+/// Checks that the contents of a VCD file ([vcdContents]) have [value] on
+/// [signalName] at time [timestamp].
+/// 
+/// This function is basic and only works on flat, single modules, or at least
+/// cases where only one signal is named [signalName] across all scopes.
+bool confirmValue(String vcdContents, String signalName, int timestamp, LogicValues value) {
+  var lines = vcdContents.split('\n');
+
+  String? sigName;
+  int? width;
+  int currentTime = 0;
+  LogicValues? currentValue;
+
+  VCDParseState state = VCDParseState.findSig;
+
+  var sigNameRegexp = RegExp(r'\s*\$var\swire\s(\d+)\s(\S*)\s(\S*)\s\$end');
+  for(var line in lines) {
+
+    if(state == VCDParseState.findSig) {
+      if(sigNameRegexp.hasMatch(line)) {
+        var match = sigNameRegexp.firstMatch(line)!;
+        int w = int.parse(match.group(1)!);
+        var sName = match.group(2)!;
+        var lName = match.group(3)!;
+
+        if(lName == signalName) {
+          sigName = sName;
+          width = w;
+          state = VCDParseState.findDumpVars;
+        }
+      }
+    } else if(state == VCDParseState.findDumpVars) {
+      if(line.contains('\$dumpvars')) {
+        state = VCDParseState.findValue;
+      }
+    } else if(state == VCDParseState.findValue) {
+      if(line.startsWith('#')) {
+        currentTime = int.parse(line.substring(1));
+        if(currentTime > timestamp) {
+          return currentValue == value;
+        }
+      } else if (line.endsWith(sigName!)){
+        if(width == 1) {
+          // ex: zs1
+          currentValue = LogicValues.fromString(line[0]);
+        } else {
+          // ex: bzzzzzzzz s2
+          currentValue = LogicValues.fromString(line.split(' ')[0].substring(1));
+        }
+      }
+    }
+  }
+  return currentValue == value;
+}
+
+void main() {
+
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  test('attach dumper after put', () async {
+    var a = Logic(name: 'a');
+    var mod = SimpleModule(a);
+    await mod.build();
+
+    var dumpName = 'dumpAfterPut';
+    
+    a.put(1);
+    createTemporaryDump(mod, dumpName);
+
+    Simulator.registerAction(10, () => a.put(0));
+    await Simulator.run();
+    
+    var vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
+
+    expect(confirmValue(vcdContents, 'a', 0, LogicValues.fromString('1')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 5, LogicValues.fromString('1')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 10, LogicValues.fromString('0')), equals(true));
+
+    deleteTemporaryDump(dumpName);
+  });
+
+  test('attach dumper before put', () async {
+    var a = Logic(name: 'a');
+    var mod = SimpleModule(a);
+    await mod.build();
+
+    var dumpName = 'dumpBeforePut';
+    
+    createTemporaryDump(mod, dumpName);
+    await a.inject(1);
+
+    Simulator.registerAction(10, () => a.put(0));
+    Simulator.registerAction(20, () => a.put(1));
+    await Simulator.run();
+    
+    var vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
+
+    expect(confirmValue(vcdContents, 'a', 0, LogicValues.fromString('1')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 1, LogicValues.fromString('1')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 10, LogicValues.fromString('0')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 20, LogicValues.fromString('1')), equals(true));
+
+    deleteTemporaryDump(dumpName);
+  });
+
+  test('multiple injects in the same timestamp', () async {
+    
+    var clk = SimpleClockGenerator(10).clk;
+    var a = Logic(name: 'a');
+    var mod = SimpleModule(a);
+    a <= clk;
+
+    await mod.build();
+
+    var dumpName = 'multiInject';
+    
+    createTemporaryDump(mod, dumpName);
+
+    Simulator.setMaxSimTime(100);
+    unawaited(Simulator.run());
+
+    await clk.nextPosedge;
+    await clk.nextPosedge;
+    await clk.nextPosedge;
+
+    // inject a 0 on a when it should be 1 already from the clock
+    await a.inject(0);
+
+    await Simulator.simulationEnded;
+    
+    var vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
+
+    expect(confirmValue(vcdContents, 'a', 0, LogicValues.fromString('0')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 5, LogicValues.fromString('1')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 10, LogicValues.fromString('0')), equals(true));
+    expect(confirmValue(vcdContents, 'a', 35, LogicValues.fromString('0')), equals(true));
+
+    deleteTemporaryDump(dumpName);
+  });
+  
+}


### PR DESCRIPTION
## Description & Motivation

Various fixes to the WaveDumper:
- Renamed Dumper to WaveDumper (including a deprecation note)
- Made injection functionality asynchronous so it matches expectations
- Changed `Simulator` timestamps to `int` instead of `double`
- Remove some "boring" signals from what gets dumped by WaveDumper (#5)
- Fix bug where a signal deposition at time 0 after the WaveDumper is attached is not captured (#4)
- Fix WaveDumper functionality so that multiple signal depositions at the same timestamp will take the last one (related to #4)
- Added unit tests for WaveDumper
- Fix some minor documentation typos

## Related Issue(s)

Fix #5 
Fix #4

## Testing

Added new unit tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Yes
- Simulator timestamps are now int instead of double
- Dumper is deprecated in favor of WaveDumper
- `Logic.inject` and `Simulator.injectAction` are now asynchronous

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Minor documentation updates are included
