### PR TITLE
Improvements to FF

### DIFF
--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -72,7 +72,7 @@ class Logic {
   /// The last value of this signal before the [Simulator] tick.
   /// 
   /// This is useful for detecting when to trigger an edge.
-  LogicValues _preTickValue;
+  LogicValues? _preTickValue;
   
   /// The number of bits in this signal.
   final int width;
@@ -143,8 +143,13 @@ class Logic {
         _preTickValue = value;
       });
       Simulator.postTick.listen((event) {
-        if(value != _preTickValue) {
-          _changedController.add(LogicValueChanged(value, _preTickValue));
+        if(value != _preTickValue && _preTickValue != null) {
+          _changedController.add(
+            LogicValueChanged(
+              value,
+              _preTickValue!
+            )
+          );
         }
       });
     }
@@ -209,8 +214,7 @@ class Logic {
   Logic({String? name, this.width=1}) :
       name = name ?? 's${_signalIdx++}',
       assert(width >= 0), 
-      _currentValue = LogicValues.filled(width, LogicValue.z),
-      _preTickValue = LogicValues.filled(width, LogicValue.z);
+      _currentValue = LogicValues.filled(width, LogicValue.z);
 
   @override
   String toString() {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -774,24 +774,11 @@ class FlipFlop extends Module with CustomSystemVerilog {
     _setup();
   }
 
-  late LogicValues _preTickValue; // logic or bus value, so dynamic
-  late LogicValue _preTickClkValue;
-
-//TODO: make functional implementation here just use FF for consistency!
-
   /// Performs setup for custom functional behavior.
   void _setup() {
-    Simulator.preTick.listen((args) {
-      _preTickValue = d.value;
-      _preTickClkValue = clk.bit;
-    });
-    Simulator.clkStable.listen((args) {
-      if(!_preTickClkValue.isValid || !clk.bit.isValid) {
-        q.put(LogicValue.x);
-      } else if(LogicValue.isPosedge(_preTickClkValue, clk.bit)) {
-        q.put(_preTickValue);
-      }
-    });
+    FF(clk, [
+      q < d
+    ]);
   }
 
   @override

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -166,16 +166,19 @@ class Simulator {
 
   /// Performs the actual execution of a collection of actions for a [tick()].
   static Future<void> tickExecute(Function() toExecute) async {
-    _preTickController.add(null); // useful for flop sampling
     _phase = SimulatorPhase.beforeTick;
-    _startTickController.add(null); // useful for things that need to trigger every tick without other input
+    _preTickController.add(null); // useful for flop sampling
+    
     _phase = SimulatorPhase.mainTick;
+    _startTickController.add(null); // useful for things that need to trigger every tick without other input
     await _executeInjectedActions();
     await toExecute();
     await _executeInjectedActions();
-    _clkStableController.add(null); // useful for flop clk input stability
+    
     _phase = SimulatorPhase.clksStable;
+    _clkStableController.add(null); // useful for flop clk input stability
     await _executeInjectedActions();
+
     _phase = SimulatorPhase.outOfTick;
     _postTickController.add(null); // useful for determination of signal settling
   }

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -25,7 +25,7 @@ class Counter extends Module {
     
     nextVal <= val + 1;
 
-    FF( (SimpleClockGenerator(10).clk), [
+    FF( (SimpleClockGenerator(10).clk | reset), [
       If(reset, then:[
         val < 0
       ], orElse: [If(en, then: [
@@ -50,7 +50,7 @@ void main() {
       // WaveDumper(mod);
       // File('tmp_counter.sv').writeAsStringSync(mod.generateSynth());
       var vectors = [
-        Vector({'en': 0, 'reset': 1}, {}),
+        Vector({'en': 0, 'reset': 0}, {}),
         Vector({'en': 0, 'reset': 1}, {'val': 0}),
         Vector({'en': 1, 'reset': 1}, {'val': 0}),
         Vector({'en': 1, 'reset': 0}, {'val': 0}),

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -31,7 +31,7 @@ class SimplePipelineModule extends Module {
         ],
       ]
     );
-    b <= pipeline.get(a);  //TODO FIX NAME
+    b <= pipeline.get(a);
   }
 }
 
@@ -138,7 +138,7 @@ void main() {
         Vector({'reset': 0, 'a': 0x10, 'validIn': 1, 'readyForOut': 0}, {'validOut': 0}),
         Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 0}),
         Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 0}),
-        Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 1}),
+        Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 1, 'b': 0x13}),
         Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 1}),
         Vector({'reset': 0, 'a': 0x20, 'validIn': 1, 'readyForOut': 0}, {'validOut': 1}),
         Vector({'reset': 0, 'a': 0, 'validIn': 0, 'readyForOut': 0}, {'validOut': 1}),


### PR DESCRIPTION
## Description & Motivation

Various fixes for FF/FlipFlop
- Fix asynchronous flop sampling bugs.
- Improved FF simulation performance by only executing and listening to `Simulator` events when something "interesting" is going on
- Fix `Logic.changed` calculation
- Fix `Simulator.phase` determination
- Add wave dumping option for `SimCompare` iverilog simulations

## Related Issue(s)

Fix #41
Close #11

## Testing

Existing tests cover most things
- Modified counter test to include asynchronous reset
- Modified pipeline test to be more strict on latency

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
