### PR TITLE
made signal propagation more robust

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,7 @@ linter:
     - always_declare_return_types
     - prefer_single_quotes
     - unawaited_futures
+    - avoid_void_async
 
 analyzer:
 #   exclude:

--- a/example/counter.dart
+++ b/example/counter.dart
@@ -48,7 +48,7 @@ class Counter extends Module {
 }
 
 // Let's simulate with this counter a little, generate a waveform, and take a look at generated SystemVerilog.
-void main({bool noPrint=false}) async {
+Future<void> main({bool noPrint=false}) async {
   // Define some local signals.
   var   en    = Logic(name: 'en'),
         reset = Logic(name: 'reset');

--- a/example/tree.dart
+++ b/example/tree.dart
@@ -52,7 +52,7 @@ class TreeOfTwoInputModules extends Module {
   }
 }
 
-void main({bool noPrint=false}) async {
+Future<void> main({bool noPrint=false}) async {
   // You could instantiate this module with some code such as:
   var tree = TreeOfTwoInputModules(
     List<Logic>.generate(16, (index) => Logic(width: 8)),

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -125,7 +125,7 @@ class Simulator {
   /// Adds an arbitrary [action] to be executed as soon as possible, during the current
   /// simulation tick if possible.
   /// 
-  /// If the injection occurs outside of a tick ([SimulatorPhase.outOfTick]), it will trigger
+  /// If the injection occurs outside of a tick ([SimulatorPhase.outOfTick]), it will execute in
   /// a new tick in the same timestamp.
   static void injectAction(void Function() action) {
     // adds an action to be executed in the current timestamp
@@ -189,7 +189,7 @@ class Simulator {
     _postTickController.add(null); // useful for determination of signal settling
   }
 
-  /// Halts the simulation.  Allows the current [tick()] to finish, if there is one.
+  /// Halts the simulation.  Allows the current [tick] to finish, if there is one.
   static void endSimulation() {
     _simulationEndRequested = true;
   }

--- a/lib/src/utilities/synchronous_propagator.dart
+++ b/lib/src/utilities/synchronous_propagator.dart
@@ -8,20 +8,49 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 /// 
 
-//TODO: does this need reentrance detection?
-
+/// A controller for a [SynchronousEmitter] that allows for
+/// adding of events of type [T] to be emitted.
 class SynchronousPropagator<T> {
-  final SynchronousEmitter<T> _emitter = SynchronousEmitter<T>();
+  
+  /// The [SynchronousEmitter] which sends events added to this.
   SynchronousEmitter<T> get emitter => _emitter;
-  void add(T t) => _emitter._propogate(t);
+  final SynchronousEmitter<T> _emitter = SynchronousEmitter<T>();
+  
+  /// When set to `true`, will throw an exception if an event
+  /// added is reentrant.
+  bool throwOnReentrance = false;
+
+  /// Adds a new event [t] to be emitted from [emitter].
+  void add(T t)  {
+    if(throwOnReentrance && _emitter.isEmitting) {
+      throw Exception('Disallowed reentrance occurred.');
+    }
+    _emitter._propagate(t);
+  }
 }
 
+/// A stream of events of type [T] that can be synchronously listened to.
 class SynchronousEmitter<T> {
-  final List<Function(T)> _actions = <Function(T)>[];
+  
+  /// Registers a new listener [f] to be notified with an event of 
+  /// type [T] as an argument whenever that event is to be emitted.
   void listen(Function(T args) f) => _actions.add(f);
-  void _propogate(T t) {
+
+  /// A [List] of actions to perform for each event.
+  final List<Function(T)> _actions = <Function(T)>[];
+
+  /// Returns `true` iff this is currently emitting.
+  /// 
+  /// Useful for reentrance checking.
+  bool get isEmitting => _isEmitting;
+  bool _isEmitting = false;
+  
+  /// Sends out [t] to all listeners.
+  void _propagate(T t) {
+    _isEmitting = true;
     for(var action in _actions) {
       action(t);
     }
+    _isEmitting = false;
   }
 }

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -14,6 +14,10 @@ import '../example/counter.dart' as counter;
 import '../example/tree.dart' as tree;
 
 void main() {
-  test('counter example', () => counter.main(noPrint: true));
-  test('tree example', () => tree.main(noPrint: true));
+  test('counter example', () async {
+    await counter.main(noPrint: true);
+  });
+  test('tree example', () async {
+    await tree.main(noPrint: true);
+  });
 }


### PR DESCRIPTION
## Description & Motivation

Replaced glitch streams with simple signal propagator objects which are always synchronous.  Makes `put` simpler and purely synchronous, and allows simple reentrance for contention propagation.

## Related Issue(s)

N/A

## Testing

Existing tests cover it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Minor API doc updates included

