### PR TITLE
Fix #38: `Interface.connectIO` bug with no tags specified

### DIFF
--- a/lib/src/interface.dart
+++ b/lib/src/interface.dart
@@ -47,20 +47,25 @@ class Interface<TagType> {
       String Function(String original)? uniquify}) {
     uniquify = uniquify ?? (String original) => original;
 
-    getPorts(inputTags).forEach((port) {
-      setPort(
-          // ignore: invalid_use_of_protected_member
-          module.addInput(uniquify!(port.name), srcInterface.port(port.name),
-              width: port.width),
-          portName: port.name);
-    });
-    getPorts(outputTags).forEach((port) {
-      // ignore: invalid_use_of_protected_member
-      var output = module.addOutput(uniquify!(port.name), width: port.width);
-      port <= output;
-      srcInterface.port(port.name) <= port;
-      setPort(output, portName: port.name);
-    });
+    if (inputTags != null) {
+      getPorts(inputTags).forEach((port) {
+        setPort(
+            // ignore: invalid_use_of_protected_member
+            module.addInput(uniquify!(port.name), srcInterface.port(port.name),
+                width: port.width),
+            portName: port.name);
+      });
+    }
+
+    if (outputTags != null) {
+      getPorts(outputTags).forEach((port) {
+        // ignore: invalid_use_of_protected_member
+        var output = module.addOutput(uniquify!(port.name), width: port.width);
+        port <= output;
+        srcInterface.port(port.name) <= port;
+        setPort(output, portName: port.name);
+      });
+    }
   }
 
   /// Returns all interface ports associated with the provided [tags].

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -41,6 +41,9 @@ class Counter extends Module {
           inputTags: {CounterDirection.inward},
           outputTags: {CounterDirection.outward});
 
+    // this should do nothing
+    this.intf.connectIO(this, intf);
+
     _buildLogic();
   }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fix #38 so that there aren't exceptions when no tags are provided for one or both of inputTags and outputTags.

## Related Issue(s)

#38

<!-- If there are any issues related to this PR, please link to the issues here -->

## Testing

Added a line with no tags to an existing interface test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
