### PR TITLE
Fix uniquified `Interface.getPorts` bug, add tests, and improve documentation

### DIFF
--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -1,0 +1,46 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// interface_test.dart
+/// Tests for Interface
+///
+/// 2021 November 30
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+enum MyDirection { dir1, dir2 }
+
+class MyModuleInterface extends Interface<MyDirection> {
+  MyModuleInterface() {
+    setPorts([Port('p1')], [MyDirection.dir1]);
+    setPorts([Port('p2')], [MyDirection.dir2]);
+  }
+}
+
+class MyModule extends Module {
+  late final MyModuleInterface i1, i2;
+  MyModule(MyModuleInterface i1, MyModuleInterface i2) {
+    this.i1 = MyModuleInterface()
+      ..connectIO(this, i1, uniquify: (oldName) => 'i1$oldName');
+    this.i2 = MyModuleInterface()
+      ..connectIO(this, i2, uniquify: (oldName) => 'i2$oldName');
+  }
+}
+
+void main() {
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  group('uniquified interfaces', () {
+    test('get uniquified ports', () async {
+      var m = MyModule(MyModuleInterface(), MyModuleInterface());
+      await m.build();
+      expect(m.i1.getPorts({MyDirection.dir1}).length, 1);
+      expect(m.i2.getPorts({MyDirection.dir2}).length, 1);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Fix #59 
- Add unit tests for `Interface`
- Improve API docs and comments

## Related Issue(s)

#59

## Testing

Added new unit test and existing unit tests pass

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No, but updated some documentation
