### PR TITLE
`Sequential` and `Sequential.multi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ class Counter extends Module {
     // Assignment statement of nextVal to be val+1 (<= is the assignment operator)
     nextVal <= val + 1;
 
-    // `FF` is like SystemVerilog's always_ff, in this case trigger on the positive edge of clk
-    FF(clk, [
+    // `Sequential` is like SystemVerilog's always_ff, in this case trigger on the positive edge of clk
+    Sequential(clk, [
       // `If` is a conditional if statement, like `if` in SystemVerilog always blocks
       If(reset, then:[
         // the '<' operator is a conditional assignment
@@ -361,12 +361,12 @@ class MyModule extends Module {
 ```
 
 ### Sequentials
-ROHD has a basic [`FlipFlop`](https://intel.github.io/rohd/rohd/FlipFlop-class.html) module that can be used as a flip flop.  For more complex sequential logic, use the `FF` block described in the Conditionals section.
+ROHD has a basic [`FlipFlop`](https://intel.github.io/rohd/rohd/FlipFlop-class.html) module that can be used as a flip flop.  For more complex sequential logic, use the `Sequential` block described in the Conditionals section.
 
 Dart doesn't have a notion of certain signals being "clocks" vs. "not clocks".  You can use any signal as a clock input to sequential logic, and have as many clocks of as many frequencies as you want.
 
 ### Conditionals
-ROHD supports a variety of [`Conditional`](https://intel.github.io/rohd/rohd/Conditional-class.html) type statements that always must fall within a type of `_Always` block, similar to SystemVerilog.  There are two types of `_Always` blocks: [`FF`](https://intel.github.io/rohd/rohd/FF-class.html) and [`Combinational`](https://intel.github.io/rohd/rohd/Combinational-class.html), which map to SystemVerilog's `always_ff` and `always_comb`, respectively.  `Combinational` takes a list of `Conditional` statements.  Different kinds of `Conditional` statement, such as `If`, may be composed of more `Conditional` statements.  You can create `Conditional` composition chains as deep as you like.
+ROHD supports a variety of [`Conditional`](https://intel.github.io/rohd/rohd/Conditional-class.html) type statements that always must fall within a type of `_Always` block, similar to SystemVerilog.  There are two types of `_Always` blocks: [`Sequential`](https://intel.github.io/rohd/rohd/Sequential-class.html) and [`Combinational`](https://intel.github.io/rohd/rohd/Combinational-class.html), which map to SystemVerilog's `always_ff` and `always_comb`, respectively.  `Combinational` takes a list of `Conditional` statements.  Different kinds of `Conditional` statement, such as `If`, may be composed of more `Conditional` statements.  You can create `Conditional` composition chains as deep as you like.
 
 Conditional statements are executed imperatively and in order, just like the contents of `always` blocks in SystemVerilog.  `_Always` blocks in ROHD map 1-to-1 with SystemVerilog `always` statements when converted.
 
@@ -395,7 +395,7 @@ Combinational([
 #### `IfBlock`
 The [`IfBlock`](https://intel.github.io/rohd/rohd/IfBlock-class.html) makes syntax for long chains of if / else if / else chains nicer.  For example:
 ```dart
-FF(clk, [
+Sequential(clk, [
   IfBlock([
     // the first one must be Iff (yes, with 2 f's, to differentiate from If above)
     Iff(a & ~b, [
@@ -507,7 +507,7 @@ class Counter extends Module {
     // access signals directly from the interface
     nextVal <= intf.val + 1;
 
-    FF( SimpleClockGenerator(10).clk, [
+    Sequential( SimpleClockGenerator(10).clk, [
       If(intf.reset, then:[
         intf.val < 0
       ], orElse: [If(intf.en, then: [

--- a/example/example.dart
+++ b/example/example.dart
@@ -35,8 +35,8 @@ class Counter extends Module {
     // Assignment statement of nextVal to be val+1 (<= is the assignment operator)
     nextVal <= val + 1;
 
-    // `FF` is like SystemVerilog's always_ff, in this case trigger on the positive edge of clk
-    FF(clk, [
+    // `Sequential` is like SystemVerilog's always_ff, in this case trigger on the positive edge of clk
+    Sequential(clk, [
       // `If` is a conditional if statement, like `if` in SystemVerilog always blocks
       If(reset, then: [
         // the '<' operator is a conditional assignment

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -140,16 +140,18 @@ typedef FF = Sequential;
 
 /// Represents a block of sequential logic.
 ///
-/// This is similar to an `always_ff` block in SystemVerilog.  Positive edge triggered.
+/// This is similar to an `always_ff` block in SystemVerilog.  Positive edge triggered by
+/// either one trigger or multiple with [Sequential.multi].
 class Sequential extends _Always {
   /// The input clocks used in this block.
   final List<Logic> _clks = [];
 
+  /// Constructs a [Sequential] single-triggered by [clk].
   Sequential(Logic clk, List<Conditional> conditionals,
       {String name = 'sequential'})
       : this.multi([clk], conditionals, name: name);
 
-  /// Multiple triggers TODO
+  /// Constructs a [Sequential] multi-triggered by any of [clks].
   Sequential.multi(List<Logic> clks, List<Conditional> conditionals,
       {String name = 'sequential'})
       : super(conditionals, name: name) {
@@ -230,10 +232,12 @@ class Sequential extends _Always {
     bool anyClkInvalid = false;
     bool anyClkPosedge = false;
     for (var i = 0; i < _clks.length; i++) {
-      if (!_clks[i].bit.isValid || !(_preTickClkValues[i]?.isValid ?? false)) {
+      // if the pre-tick value is null, then it should have the same value as it currently does
+      if (!_clks[i].bit.isValid || !(_preTickClkValues[i]?.isValid ?? true)) {
         anyClkInvalid = true;
         break;
-      } else if (LogicValue.isPosedge(_preTickClkValues[i]!, _clks[i].bit)) {
+      } else if (_preTickClkValues[i] != null &&
+          LogicValue.isPosedge(_preTickClkValues[i]!, _clks[i].bit)) {
         anyClkPosedge = true;
         break;
       }

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -184,7 +184,7 @@ class Pipeline {
         ])
       ];
     }
-    FF(clk, ffAssignsWithStall, name: 'ff_${newLogic.name}');
+    Sequential(clk, ffAssignsWithStall, name: 'ff_${newLogic.name}');
   }
 
   /// The stage input for a signal associated with [logic] to [stageIndex].

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -77,12 +77,18 @@ class SimCompare {
         for (var signalName in vector.expectedOutputValues.keys) {
           var value = vector.expectedOutputValues[signalName];
           var o = module.output(signalName);
+          var errorReason =
+              'For vector #${vectors.indexOf(vector)} $vector, expected $o to be $value, but it was ${o.value}.';
           if (value is int) {
-            expect(o.valueInt, equals(value));
+            if (!o.value.isValid) {
+              // invalid value causes exception without helpful message, so throw it
+              throw Exception(errorReason);
+            }
+            expect(o.valueInt, equals(value), reason: errorReason);
           } else if (value is LogicValue &&
               (value == LogicValue.x || value == LogicValue.z)) {
             o.value.toList().forEach((element) {
-              expect(element, equals(value));
+              expect(element, equals(value), reason: errorReason);
             });
           } else {
             throw Exception(

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -114,8 +114,8 @@ class CombModule extends Module {
   }
 }
 
-class FFModule extends Module {
-  FFModule(Logic a, Logic b, Logic d) : super(name: 'ffmodule') {
+class SequentialModule extends Module {
+  SequentialModule(Logic a, Logic b, Logic d) : super(name: 'ffmodule') {
     a = addInput('a', a);
     b = addInput('b', b);
     var y = addOutput('y');
@@ -125,7 +125,7 @@ class FFModule extends Module {
     d = addInput('d', d, width: d.width);
     var q = addOutput('q', width: d.width);
 
-    FF(SimpleClockGenerator(10).clk, [
+    Sequential(SimpleClockGenerator(10).clk, [
       If(a, then: [
         q < d,
         y < a,
@@ -209,7 +209,7 @@ void main() {
     });
 
     test('conditional ff', () async {
-      var mod = FFModule(Logic(), Logic(), Logic(width: 8));
+      var mod = SequentialModule(Logic(), Logic(), Logic(width: 8));
       await mod.build();
       var vectors = [
         Vector({'a': 1, 'd': 1}, {}),

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -24,7 +24,7 @@ class Counter extends Module {
 
     nextVal <= val + 1;
 
-    FF((SimpleClockGenerator(10).clk | reset), [
+    Sequential((SimpleClockGenerator(10).clk | reset), [
       If(reset, then: [
         val < 0
       ], orElse: [

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -52,7 +52,7 @@ class Counter extends Module {
 
     nextVal <= intf.val + 1;
 
-    FF((SimpleClockGenerator(10).clk), [
+    Sequential((SimpleClockGenerator(10).clk), [
       If(intf.reset, then: [
         intf.val < 0
       ], orElse: [

--- a/test/translations_test.dart
+++ b/test/translations_test.dart
@@ -70,8 +70,8 @@ class FlopArray extends Module {
     var storageBank = List<Logic>.generate(
         numEntries, (i) => Logic(name: 'storageBank_$i', width: dwidth));
 
-    // FF(lclk, [  // normally this should be here
-    FF(SimpleClockGenerator(10).clk, [
+    // Sequential(lclk, [  // normally this should be here
+    Sequential(SimpleClockGenerator(10).clk, [
       //for testing purposes, easier to just plug a clock in here
       If(lrst, then: [
         ...storageBank


### PR DESCRIPTION
## Description & Motivation

- Rename `FF` to `Sequential`, since it's a better name.
- Add `Sequential.multi` for multiple triggers on one block (like `always_ff(@posedge clk or @posedge reset)`)

## Related Issue(s)

Implements a solution for #42 

## Testing

Modified a counter test to take advantage of `Sequential.multi`

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Yes
- The `clk` has been removed from the `Sequential` public API since it probably shouldn't have been exposed in the first place.
- `FF` has been deprecated, but not removed yet, to preserve backwards compatibility.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Yes, API docs are updated
