### PR TITLE
Convert forEach loops to make debug easier

### DIFF
--- a/lib/src/interface.dart
+++ b/lib/src/interface.dart
@@ -61,23 +61,23 @@ class Interface<TagType> {
     uniquify = uniquify ?? (String original) => original;
 
     if (inputTags != null) {
-      getPorts(inputTags).forEach((port) {
+      for (var port in getPorts(inputTags)) {
         setPort(
             // ignore: invalid_use_of_protected_member
-            module.addInput(uniquify!(port.name), srcInterface.port(port.name),
+            module.addInput(uniquify(port.name), srcInterface.port(port.name),
                 width: port.width),
             portName: port.name);
-      });
+      }
     }
 
     if (outputTags != null) {
-      getPorts(outputTags).forEach((port) {
+      for (var port in getPorts(outputTags)) {
         // ignore: invalid_use_of_protected_member
-        var output = module.addOutput(uniquify!(port.name), width: port.width);
+        var output = module.addOutput(uniquify(port.name), width: port.width);
         port <= output;
         srcInterface.port(port.name) <= port;
         setPort(output, portName: port.name);
-      });
+      }
     }
   }
 

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -308,10 +308,10 @@ abstract class Conditional {
   ) {
     _assignedReceiverToOutputMap = assignedReceiverToOutputMap;
     _assignedDriverToInputMap = assignedDriverToInputMap;
-    getConditionals().forEach((element) {
-      element._updateAssignmentMaps(
+    for (var conditional in getConditionals()) {
+      conditional._updateAssignmentMaps(
           assignedReceiverToOutputMap, assignedDriverToInputMap);
-    });
+    }
   }
 
   /// Updates the value of [_driverValueOverrideMap] and passes it down to all
@@ -319,9 +319,9 @@ abstract class Conditional {
   void _updateOverrideMap(Map<Logic, LogicValues> driverValueOverrideMap) {
     // this is for always_ff pre-tick values
     _driverValueOverrideMap = driverValueOverrideMap;
-    getConditionals().forEach((element) {
-      element._updateOverrideMap(driverValueOverrideMap);
-    });
+    for (var conditional in getConditionals()) {
+      conditional._updateOverrideMap(driverValueOverrideMap);
+    }
   }
 
   /// Gets the value that should be used for execution for the input port associated with [driver].
@@ -485,9 +485,9 @@ class Case extends Conditional {
     //TODO: what about for CaseZ where epxressions can have Z?  BUG?
     if (!expression.value.isValid) {
       // if expression has X or Z, then propogate X's!
-      getReceivers().forEach((receiver) {
+      for (var receiver in getReceivers()) {
         receiverOutput(receiver).put(LogicValue.x);
-      });
+      }
       return [];
     }
 
@@ -703,9 +703,9 @@ class IfBlock extends Conditional {
         break;
       } else if (driverValue(iff.condition)[0] != LogicValue.zero) {
         // x and z propagation
-        getReceivers().forEach((receiver) {
+        for (var receiver in getReceivers()) {
           receiverOutput(receiver).put(driverValue(iff.condition)[0]);
-        });
+        }
         break;
       }
       // if it's 0, then continue searching down the path
@@ -833,9 +833,9 @@ class If extends Conditional {
       }
     } else {
       // x and z propagation
-      getReceivers().forEach((receiver) {
+      for (var receiver in getReceivers()) {
         receiverOutput(receiver).put(driverValue(condition)[0]);
-      });
+      }
     }
     return drivenLogics;
   }

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -87,9 +87,9 @@ class SimCompare {
             expect(o.valueInt, equals(value), reason: errorReason);
           } else if (value is LogicValue &&
               (value == LogicValue.x || value == LogicValue.z)) {
-            o.value.toList().forEach((element) {
-              expect(element, equals(value), reason: errorReason);
-            });
+            for (var oBit in o.value.toList()) {
+              expect(oBit, equals(value), reason: errorReason);
+            }
           } else {
             throw Exception(
                 'Value type ${value.runtimeType} is not supported (yet?)');


### PR DESCRIPTION
## Description & Motivation

Modified some `Iterable.forEach` loops into `for(... in ...)` loops which tend to be easier to debug.

## Related Issue(s)

N/A

## Testing

Existing tests pass

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
