### PR TITLE
Feature/logicvalue_ofbool

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -25,7 +25,7 @@ class LogicValue {
   static const LogicValue z = LogicValue._(_LogicValueEnum.z);
 
   /// Convert a bool to a one or zero
-  static LogicValue ofBool(bool v) => v ? one : zero;
+  static LogicValue fromBool(bool v) => v ? one : zero;
 
   final _LogicValueEnum _value;
   const LogicValue._(this._value);

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -24,6 +24,9 @@ class LogicValue {
   /// Logical value of `z`
   static const LogicValue z = LogicValue._(_LogicValueEnum.z);
 
+  /// Convert a bool to a one or zero
+  static LogicValue ofBool(bool v) => v ? one : zero;
+
   final _LogicValueEnum _value;
   const LogicValue._(this._value);
 

--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -557,6 +557,10 @@ abstract class LogicValues {
 
   const LogicValues._(this.length) : assert(length >= 0);
 
+  /// Converts `bool` [value] to a valid [LogicValues] with 1 bits either one or zero.
+  static LogicValues fromBool(bool value) =>
+      _SmallLogicValues(value ? 1 : 0, 0, 1);
+
   /// Converts `int` [value] to a valid [LogicValues] with [length] number of bits.
   ///
   /// [length] must be greater than or equal to 0.

--- a/test/logic_values_test.dart
+++ b/test/logic_values_test.dart
@@ -28,4 +28,11 @@ void main() {
           equals(LogicValues.fromString('01xx' * 100)));
     });
   });
+
+  group('logic value', () {
+    test('ofBool', () {
+      expect(LogicValue.ofBool(true), equals(LogicValue.one));
+      expect(LogicValue.ofBool(false), equals(LogicValue.zero));
+    });
+  });
 }

--- a/test/logic_values_test.dart
+++ b/test/logic_values_test.dart
@@ -30,9 +30,11 @@ void main() {
   });
 
   group('logic value', () {
-    test('ofBool', () {
-      expect(LogicValue.ofBool(true), equals(LogicValue.one));
-      expect(LogicValue.ofBool(false), equals(LogicValue.zero));
+    test('fromBool', () {
+      expect(LogicValue.fromBool(true), equals(LogicValue.one));
+      expect(LogicValue.fromBool(false), equals(LogicValue.zero));
+      expect(LogicValues.fromBool(true), equals(LogicValues.fromString('1')));
+      expect(LogicValues.fromBool(false), equals(LogicValues.fromString('0')));
     });
   });
 }


### PR DESCRIPTION
## Description & Motivation

When helping another Intel Engineer using Rohd, I found the lack of conversion from bool to a LogicValue inconvenient, so I'm proposing adding this helper function to make LogicValues slightly more convenient.

## Related Issue(s)

None

## Testing

Added new test cases in logic-values_test.dart just for this feature.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No breaking change

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Hopefully the API comment I added before the function translates properly into documentation there.  I'm not sure how to generate/test this locally.