### PR TITLE
"External" module updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Anyone interested in participating in ROHD is more than welcome to help!
 
 ## Code of Conduct
 
-ROHD adopts the Contributor Covenant v1.4 for the code of conduct.  It can be accessed [here](CODE_OF_CONDUCT.md).
+ROHD adopts the Contributor Covenant v1.4 for the code of conduct.  It can be accessed [here](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md).
 
 ## Getting Help
 ### Issues

--- a/README.md
+++ b/README.md
@@ -655,9 +655,9 @@ The ROHD simulator is a static class accessible as [`Simulator`](https://intel.g
 
 ## Instantiation of External Modules
 
-ROHD can instantiate external SystemVerilog modules.  The [`ExternalModule`](https://intel.github.io/rohd/rohd/ExternalModule-class.html) constructor requires the top level SystemVerilog module name.  When ROHD generates SystemVerilog for a model containing an `ExternalModule`, it will instantiate instances of the specified `topModuleName`.  This is useful for integration related activities.
+ROHD can instantiate external SystemVerilog modules.  The [`ExternalSystemVerilogModule`](https://intel.github.io/rohd/rohd/ExternalSystemVerilogModule-class.html) constructor requires the top level SystemVerilog module name.  When ROHD generates SystemVerilog for a model containing an `ExternalSystemVerilogModule`, it will instantiate instances of the specified `topModuleName`.  This is useful for integration related activities.
 
-There is an upcoming package for SystemVerilog cosimulation with ROHD which adds cosimulation capabilities to an `ExternalModule` planned for release soon.
+There is an upcoming package for SystemVerilog cosimulation with ROHD which adds cosimulation capabilities to an `ExternalSystemVerilogModule` planned for release soon.
 
 ## Unit Testing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tests](https://github.com/intel/rohd/actions/workflows/test.yml/badge.svg)](https://github.com/intel/rohd/actions/workflows/test.yml)
 [![Docs](https://github.com/intel/rohd/actions/workflows/docs.yml/badge.svg)](https://intel.github.io/rohd/rohd/rohd-library.html)
 [![License](https://img.shields.io/badge/License-BSD--3-blue)](https://github.com/intel/rohd/blob/main/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md)
 
 Rapid Open Hardware Development (ROHD) Framework
 ================================================
@@ -143,7 +143,7 @@ You can find an executable version of this counter example in [example/example.d
 
 ### A more complex example
 
-See a more advanced example of a logarithmic-depth tree of arbitrary functionality at [doc/TreeExample.md](doc/TreeExample.md).
+See a more advanced example of a logarithmic-depth tree of arbitrary functionality at [doc/TreeExample.md](https://github.com/intel/rohd/blob/main/doc/TreeExample.md).
 
 You can find an executable version of the tree example in [example/tree.dart](https://github.com/intel/rohd/blob/main/example/tree.dart).
 
@@ -669,7 +669,7 @@ Note that when unit testing with ROHD, it is important to reset the `Simulator` 
 
 ## Contributing
 
-ROHD is under active development.  If you're interested in contributing, have feedback or a question, or found a bug, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+ROHD is under active development.  If you're interested in contributing, have feedback or a question, or found a bug, please see [CONTRIBUTING.md](https://github.com/intel/rohd/blob/main/CONTRIBUTING.md).
 
 ## Comparison with Alternatives
 There are a lot of options for developing hardware.  This section briefly discusses popular alternatives to ROHD and some of their strengths and weaknesses.

--- a/lib/src/external.dart
+++ b/lib/src/external.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// external.dart
@@ -12,17 +12,16 @@ import 'package:rohd/rohd.dart';
 
 // TODO: offer a way to reference sub-module signals
 
-// TODO: add a test for externalmodule
-
-/// Represents a [Module] whose definition exists outside of this framework.
+/// Represents a [Module] whose definition exists outside of this framework in SystemVerilog.
 ///
 /// This is useful for interacting with, for example, SystemVerilog modules.
 /// You can add custom behavior for how to synthesize the generated SystemVerilog
 /// as well as extend functionality with behavior models or cosimulation.
-abstract class ExternalModule extends Module with CustomSystemVerilog {
+abstract class ExternalSystemVerilogModule extends Module
+    with CustomSystemVerilog {
   final String topModuleName;
   final Map<String, String>? parameters;
-  ExternalModule(this.topModuleName,
+  ExternalSystemVerilogModule(this.topModuleName,
       {this.parameters, String name = 'external_module'})
       : super(name: name);
 
@@ -32,6 +31,6 @@ abstract class ExternalModule extends Module with CustomSystemVerilog {
     //TODO: how to avoid module name conflicts with generated modules?
     return SystemVerilogSynthesizer.instantiationVerilogWithParameters(
         this, topModuleName, instanceName, inputs, outputs,
-        parameters: parameters);
+        parameters: parameters, forceStandardInstantiation: true);
   }
 }

--- a/lib/src/external.dart
+++ b/lib/src/external.dart
@@ -14,15 +14,21 @@ import 'package:rohd/rohd.dart';
 
 /// Represents a [Module] whose definition exists outside of this framework in SystemVerilog.
 ///
-/// This is useful for interacting with, for example, SystemVerilog modules.
+/// This is useful for interacting with SystemVerilog modules.
 /// You can add custom behavior for how to synthesize the generated SystemVerilog
-/// as well as extend functionality with behavior models or cosimulation.
+/// as well as extend functionality with behavioral models or cosimulation.
 abstract class ExternalSystemVerilogModule extends Module
     with CustomSystemVerilog {
+  /// The name of the top SystemVerilog module.
   final String topModuleName;
+
+  /// A map of parameter names and values to be passed to the SystemVerilog module.
   final Map<String, String>? parameters;
-  ExternalSystemVerilogModule(this.topModuleName,
-      {this.parameters, String name = 'external_module'})
+
+  ExternalSystemVerilogModule(
+      {required this.topModuleName,
+      this.parameters,
+      String name = 'external_module'})
       : super(name: name);
 
   @override
@@ -34,3 +40,6 @@ abstract class ExternalSystemVerilogModule extends Module
         parameters: parameters, forceStandardInstantiation: true);
   }
 }
+
+@Deprecated('Use ExternalSystemVerilogModule instead.')
+typedef ExternalModule = ExternalSystemVerilogModule;

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -191,7 +191,7 @@ class Sequential extends _Always {
     // listen to every input of this `Sequential` for changes
     for (var driverInput in _assignedDriverToInputMap.values) {
       driverInput.glitch.listen((event) {
-        if (Simulator.phase != SimulatorPhase.clksStable) {
+        if (Simulator.phase != SimulatorPhase.clkStable) {
           // if the change happens not when the clocks are stable, immediately update the map
           _inputToPreTickInputValuesMap[driverInput] = driverInput.value;
         } else {

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -13,7 +13,7 @@ import 'dart:collection';
 import 'package:logging/logging.dart';
 
 /// An enum for the various phases of the [Simulator].
-enum SimulatorPhase { outOfTick, beforeTick, mainTick, clksStable }
+enum SimulatorPhase { outOfTick, beforeTick, mainTick, clkStable }
 
 /// A functional event-based static simulator for logic behavior.
 ///
@@ -24,7 +24,7 @@ enum SimulatorPhase { outOfTick, beforeTick, mainTick, clksStable }
 /// - [startTick]                 (event): The beginning of the "meat" of the tick.
 /// - [SimulatorPhase.mainTick]   (phase): Most events happen here, lots of glitches.
 /// - [clkStable]                 (event): All glitchiness has completed, clocks should be stable now.
-/// - [SimulatorPhase.clksStable] (phase)
+/// - [SimulatorPhase.clkStable]  (phase)
 /// - [postTick]                  (event): The tick has completed, all values should be settled.
 /// - [SimulatorPhase.outOfTick]  (phase): Not during an active simulator tick.
 ///
@@ -56,8 +56,7 @@ class Simulator {
       SplayTreeMap<int, List<void Function()>>();
 
   /// Functions to be executed as soon as possible by the [Simulator].
-  static final Queue<void Function()> _injectedActions =
-      Queue<void Function()>();
+  static final Queue<Function()> _injectedActions = Queue<Function()>();
 
   /// Emits an event before any other actions take place on the tick.
   static Stream get preTick => _preTickController.stream;
@@ -83,6 +82,8 @@ class Simulator {
   /// Completes when the simulation has completed.
   static Future get simulationEnded => _simulationEndedCompleter.future;
   static Completer _simulationEndedCompleter = Completer();
+
+  static bool get simulationHasEnded => _simulationEndedCompleter.isCompleted;
 
   /// Gets the current [SimulatorPhase] of the [Simulator].
   static SimulatorPhase get phase => _phase;
@@ -136,7 +137,7 @@ class Simulator {
   ///
   /// If the injection occurs outside of a tick ([SimulatorPhase.outOfTick]), it will execute in
   /// a new tick in the same timestamp.
-  static void injectAction(void Function() action) {
+  static void injectAction(Function() action) {
     // adds an action to be executed in the current timestamp
     _injectedActions.addLast(action);
   }
@@ -148,7 +149,7 @@ class Simulator {
   static Future<void> tick() async {
     if (_injectedActions.isNotEmpty) {
       // injected actions will automatically be executed during tickExecute
-      tickExecute(() {});
+      await tickExecute(() {});
 
       // don't continue through the tick for injected actions, come back around
       return;
@@ -162,7 +163,7 @@ class Simulator {
 
     _currentTimestamp = nextTimeStamp;
     // print("Tick: $_currentTimestamp");
-    tickExecute(() {
+    await tickExecute(() {
       for (var func in _pendingTimestamps[nextTimeStamp]!) {
         func();
       }
@@ -171,28 +172,27 @@ class Simulator {
   }
 
   /// Executes all pending injected actions.
-  static void _executeInjectedActions() {
+  static Future<void> _executeInjectedActions() async {
     while (_injectedActions.isNotEmpty) {
       var injectedFunction = _injectedActions.removeFirst();
-      injectedFunction();
+      await injectedFunction();
     }
   }
 
   /// Performs the actual execution of a collection of actions for a [tick()].
-  static void tickExecute(void Function() toExecute) {
+  static Future<void> tickExecute(void Function() toExecute) async {
     _phase = SimulatorPhase.beforeTick;
     _preTickController.add(null); // useful for flop sampling
 
     _phase = SimulatorPhase.mainTick;
     _startTickController.add(
         null); // useful for things that need to trigger every tick without other input
-    _executeInjectedActions();
     toExecute();
-    _executeInjectedActions();
 
-    _phase = SimulatorPhase.clksStable;
+    _phase = SimulatorPhase.clkStable;
     _clkStableController.add(null); // useful for flop clk input stability
-    _executeInjectedActions();
+
+    await _executeInjectedActions();
 
     _phase = SimulatorPhase.outOfTick;
     _postTickController
@@ -212,7 +212,7 @@ class Simulator {
         (_maxSimTime < 0 || _currentTimestamp < _maxSimTime)) {
       await tick(); // make this async so that await-ing events works
     }
-    if (_currentTimestamp >= _maxSimTime) {
+    if (_currentTimestamp >= _maxSimTime && _maxSimTime > 0) {
       logger.warning('Simulation ended due to maximum simulation time.');
     }
     _simulationEndedCompleter.complete();

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -83,6 +83,7 @@ class Simulator {
   static Future get simulationEnded => _simulationEndedCompleter.future;
   static Completer _simulationEndedCompleter = Completer();
 
+  /// Returns true iff the simulation has completed.
   static bool get simulationHasEnded => _simulationEndedCompleter.isCompleted;
 
   /// Gets the current [SimulatorPhase] of the [Simulator].

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -36,10 +36,13 @@ class SystemVerilogSynthesizer extends Synthesizer {
       String instanceName,
       Map<String, String> inputs,
       Map<String, String> outputs,
-      {Map<String, String>? parameters}) {
-    if (module is CustomSystemVerilog) {
-      return module.instantiationVerilog(
-          instanceType, instanceName, inputs, outputs);
+      {Map<String, String>? parameters,
+      bool forceStandardInstantiation = false}) {
+    if (!forceStandardInstantiation) {
+      if (module is CustomSystemVerilog) {
+        return module.instantiationVerilog(
+            instanceType, instanceName, inputs, outputs);
+      }
     }
 
     //non-custom needs more details

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -62,4 +62,20 @@ void main() {
 
     expect(count, equals(uniquePosedgeTimestamps.length));
   });
+
+  test('injection triggers edge', () async {
+    var a = Logic();
+    a.put(0);
+
+    int numPosedges = 0;
+    a.posedge.listen((event) {
+      numPosedges += 1;
+    });
+
+    a.inject(1);
+
+    await Simulator.run();
+
+    expect(numPosedges, equals(1));
+  });
 }

--- a/test/external_test.dart
+++ b/test/external_test.dart
@@ -1,0 +1,39 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// external_test.dart
+/// Unit tests for external modules
+///
+/// 2022 January 7
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class MyExternalModule extends ExternalSystemVerilogModule {
+  MyExternalModule(Logic a, {int width = 2})
+      : super('external_module_name', parameters: {'WIDTH': '$width'}) {
+    addInput('a', a, width: width);
+    addOutput('b', width: width);
+  }
+}
+
+class TopModule extends Module {
+  TopModule(Logic a) {
+    a = addInput('a', a, width: a.width);
+    MyExternalModule(a);
+  }
+}
+
+void main() {
+  test('instantiate', () async {
+    var mod = TopModule(Logic(width: 2));
+    await mod.build();
+    var sv = mod.generateSynth();
+    expect(
+        sv,
+        contains(
+            'external_module_name #(.WIDTH(2)) external_module(.a(a),.b(b));'));
+  });
+}

--- a/test/external_test.dart
+++ b/test/external_test.dart
@@ -13,7 +13,9 @@ import 'package:test/test.dart';
 
 class MyExternalModule extends ExternalSystemVerilogModule {
   MyExternalModule(Logic a, {int width = 2})
-      : super('external_module_name', parameters: {'WIDTH': '$width'}) {
+      : super(
+            topModuleName: 'external_module_name',
+            parameters: {'WIDTH': '$width'}) {
     addInput('a', a, width: width);
     addOutput('b', width: width);
   }


### PR DESCRIPTION

## Description & Motivation

- Updated some links to documentation to resolve warnings in `dartdoc`.
- Renamed `ExternalModule` to `ExternalSystemVerilogModule` since it is specifically for SystemVerilog.  Marked `ExternalModule` as deprecated.
- Made `topModuleName` a named parameter (required) to reduce confusion when extending `ExternalSystemVerilogModule`.
- Renamed `SimulatorPhase.clksStable` to `SimulatorPhase.clkStable` for consistency.
- Added `simulationHasEnded` to `Simulator`.
- Modified `Simulator` to allow for injected actions to return `Future`s which will be `await`ed.
- Fixed bug where `Simulator` warning about maximum simulation time when not appropriate.
- Fixed a bug where SystemVerilog synthesizer could enter infinite recursion from `ExternalSystemVerilogModule`
- Improved `SimCompare` checking to properly check values for vectors at end of tick.
- Improved `SimCompare` to handle a wider variety of `LogicValue` and `LogicValues` inputs in `Vector`s.
- Added unit testing for `ExternalSystemVerilogModule`

## Related Issue(s)

N/A

## Testing

Existing tests cover a lot.  Added new tests for `ExternalSystemVerilogModule`.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Yes:
- `topModuleName` is now a `required` named argument instead of a positional argument.
- Renamed `SimulatorPhase.clksStable` to `SimulatorPhase.clkStable`

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Yes, updated README and API docs via comments.
