### PR TITLE
Added a new test for injection on flop clocks

### DIFF
--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// conditional.dart


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Thought of a test case that might not have been covered by other tests related to simulator behavior when injecting on a flop's clock.  This test helps ensure functionality is consistent and doesn't break in the future.

## Related Issue(s)

N/A

## Testing

Added a new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
