### PR TITLE
Fixed #79 bug related to `Sequential` sampling

### DIFF
--- a/lib/src/utilities/sanitizer.dart
+++ b/lib/src/utilities/sanitizer.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// sanitizer.dart
@@ -15,7 +15,7 @@
 /// "Sanitary" means it doesn't have any characters illegal in generated languages,
 /// doesn't collide with keywords in generated languages, and has a valid variable
 /// name in generated languages.
-class Sanitizer {
+abstract class Sanitizer {
   /// Returns true iff [name] needs no renaming to be "sanitary".
   static bool isSanitary(String name) {
     return name == sanitizeSV(name);

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// changed_test.dart

--- a/test/sequential_test.dart
+++ b/test/sequential_test.dart
@@ -1,0 +1,91 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// Copyright (C) 2021-2022 Intel Corporation
+///
+/// sequential_test.dart
+/// Unit test for Sequential
+///
+/// 2022 January 31
+/// Substantial portion of test contributed by wswongat in https://github.com/intel/rohd/issues/79
+/// Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class DelaySignal extends Module {
+  Logic get out => output('out');
+
+  final int bitWidth;
+  final int depth;
+
+  DelaySignal(Logic en, Logic inputVal,
+      {this.bitWidth = 4, this.depth = 5, name = 'movingSum'})
+      : super(name: name) {
+    en = addInput('en', en);
+    inputVal = addInput('inputVal', inputVal, width: bitWidth);
+    // clk = addInput('clk', clk);
+    var clk = SimpleClockGenerator(10).clk;
+    List<Logic> _z = List<Logic>.generate(
+        depth, (index) => Logic(width: bitWidth, name: 'z$index'));
+
+    var out = addOutput('out', width: bitWidth);
+
+    List<ConditionalAssign> _zList = [_z[0] < inputVal];
+    for (int i = 0; i < _z.length; i++) {
+      if (i == _z.length - 1) {
+        _zList.add(out < _z[i]);
+      } else {
+        _zList.add(_z[i + 1] < _z[i]);
+      }
+    }
+
+    Sequential(clk, [
+      IfBlock([
+        Iff(en, _zList),
+        Else([
+          out < 0,
+        ])
+      ])
+    ]);
+  }
+}
+
+void main() {
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  test('simple pipeline', () async {
+    var dut = DelaySignal(
+      Logic(),
+      Logic(width: 4),
+    );
+    await dut.build();
+
+    var signalToWidthMap = {'inputVal': 4, 'out': 4};
+
+    var vectors = [
+      Vector({'inputVal': 0, 'en': 1}, {}),
+      Vector({'inputVal': 1, 'en': 0}, {}),
+      Vector({'inputVal': 2, 'en': 0}, {}),
+      Vector({'inputVal': 3, 'en': 1}, {}),
+      Vector({'inputVal': 4, 'en': 1}, {}),
+      Vector({'inputVal': 5, 'en': 1}, {}),
+      Vector({'inputVal': 6, 'en': 1}, {}),
+      Vector({'inputVal': 7, 'en': 1}, {}),
+      Vector({'inputVal': 8, 'en': 1}, {'out': 0}),
+      Vector({'inputVal': 9, 'en': 1}, {'out': 3}),
+      Vector({}, {'out': 4}),
+      Vector({}, {'out': 5}),
+    ];
+    await SimCompare.checkFunctionalVector(dut, vectors);
+    var simResult = SimCompare.iverilogVector(
+      dut.generateSynth(),
+      dut.runtimeType.toString(),
+      vectors,
+      signalToWidthMap: signalToWidthMap,
+    );
+    expect(simResult, equals(true));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fixed a bug related to `Sequential` sampling, where under certain scenarios signals would pass through instead of being flopped.

## Related Issue(s)

#79 

## Testing

Added a new test based on the code sample from #79.  Thank you to @wswongat!

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
