### PR TITLE
Module hierarchy tracing fixes

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// module.dart
@@ -231,7 +231,6 @@ abstract class Module {
 
     if (!dontAddSignal && signal.isOutput) {
       // somehow we have reached the output of a module which is not a submodule nor this module, bad!
-      //TODO: add tests that this exception hits!
       throw Exception('Violation of input/output rules in $this on $signal.'
           '  Logic within a Module should only consume inputs and drive outputs of that Module.'
           '  See https://github.com/intel/rohd#modules for more information.');
@@ -261,6 +260,12 @@ abstract class Module {
       if (!dontAddSignal && !isInput(signal) && subModule == null) {
         _addInternalSignal(signal);
       }
+
+      if (!dontAddSignal && isInput(signal)) {
+        throw Exception('Input $signal of module $this is dependent on'
+            ' another input of the same module.');
+      }
+
       for (var dstConnection in signal.dstConnections) {
         if (signal.isOutput &&
             dstConnection.isOutput &&

--- a/test/trace_bounce_test.dart
+++ b/test/trace_bounce_test.dart
@@ -1,0 +1,57 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// trace_bounce_test.dart
+///
+/// 2022 March 4
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class TopModule extends Module {
+  TopModule(Logic a) : super(name: 'topmodule') {
+    a = addInput('a_top', a);
+    var bundle = addOutput('bundle_top', width: 3);
+    bundle <= SubModule(a).bundle;
+  }
+}
+
+class SubModule extends Module {
+  Logic get bundle => output('bundle');
+  SubModule(Logic a) : super(name: 'submodule') {
+    a = addInput('a', a);
+    var b = addOutput('b');
+    var c = addOutput('c');
+    var d = addOutput('d');
+    var e = addOutput('e');
+    var bundle = addOutput('bundle', width: 3);
+
+    b <= a;
+    c <= b;
+    d <= (Logic()..gets(b));
+    e <= ~b;
+    bundle <= [c, d, e].swizzle();
+  }
+}
+
+void main() {
+  test('out depends on out', () async {
+    var mod = TopModule(Logic());
+    await mod.build();
+
+    var vectors = [
+      Vector({'a_top': 0}, {'bundle_top': 1}),
+      Vector({'a_top': 1}, {'bundle_top': 6}),
+    ];
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    var simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors,
+        signalToWidthMap: {'bundle_top': 3});
+    expect(simResult, equals(true));
+  });
+
+  //TODO: what if someone mistakenly assigns an input to another input within the module?
+}

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -1,7 +1,7 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
-/// trace_dest.dart
+/// trace_test.dart
 ///
 /// 2021 July 22
 /// Author: Max Korbel <max.korbel@intel.com>
@@ -42,6 +42,20 @@ class BadSubModuleIn extends Module {
   }
 }
 
+class DoubledInputModule extends Module {
+  DoubledInputModule(Logic a) : super(name: 'doubledinput') {
+    var aInner = addInput('a', a);
+    addInput('b', aInner);
+  }
+}
+
+class DoubledGappedInputModule extends Module {
+  DoubledGappedInputModule(Logic a) : super(name: 'doubledgappedinput') {
+    var aInner = addInput('a', a);
+    addInput('b', Logic()..gets(~aInner));
+  }
+}
+
 void main() {
   tearDown(() {
     Simulator.reset();
@@ -56,6 +70,20 @@ void main() {
 
   test('flying input', () async {
     var mod = FlyingInputModule(Logic());
+    expect(() async {
+      await mod.build();
+    }, throwsException);
+  });
+
+  test('doubled input', () async {
+    var mod = DoubledInputModule(Logic());
+    expect(() async {
+      await mod.build();
+    }, throwsException);
+  });
+
+  test('doubled gapped input', () async {
+    var mod = DoubledGappedInputModule(Logic());
     expect(() async {
       await mod.build();
     }, throwsException);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Fixes a bug (#84) where in certain scenarios with an output depending on an output of the same module the hierarchy failed to be determined.
- Added a check against inputs depending on other inputs

## Related Issue(s)

Fix #84 

## Testing

- Added new tests that reproduce #84 and confirm the fix
- Added a new test for the new input check to ensure the `Exception` was hit
- Existing test suite protects old functionality

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
