### PR TITLE
Provide the ability to reserve instance names and provide + reserve definition names

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For more information on Dart and tutorials, see https://dart.dev/ and https://da
     - vscode: https://code.visualstudio.com/
     - WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
     - Remote SSH: https://code.visualstudio.com/blogs/2019/07/25/remote-ssh
+    - Dart extension for vscode: https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code
 
 ## Getting started
 Once you have Dart installed, if you don't already have a project, you can create one using `dart create`: https://dart.dev/tools/dart-tool

--- a/lib/src/external.dart
+++ b/lib/src/external.dart
@@ -29,12 +29,14 @@ abstract class ExternalSystemVerilogModule extends Module
       {required this.topModuleName,
       this.parameters,
       String name = 'external_module'})
-      : super(name: name);
+      : super(
+            name: name,
+            definitionName: topModuleName,
+            reserveDefinitionName: true);
 
   @override
   String instantiationVerilog(String instanceType, String instanceName,
       Map<String, String> inputs, Map<String, String> outputs) {
-    //TODO: how to avoid module name conflicts with generated modules?
     return SystemVerilogSynthesizer.instantiationVerilogWithParameters(
         this, topModuleName, instanceName, inputs, outputs,
         parameters: parameters, forceStandardInstantiation: true);

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -450,6 +450,7 @@ class Logic {
 
   /// Accesses the [index]th bit of this signal.
   Logic operator [](int index) {
+    //TODO: support negative numbers to access relative from the end
     return slice(index, index);
   }
 

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -196,7 +196,8 @@ abstract class Module {
     var uniquifier = Uniquifier();
     for (var module in _modules) {
       module._uniqueInstanceName = uniquifier.getUniqueName(
-          initialName: Sanitizer.sanitizeSV(module.name));
+          initialName: Sanitizer.sanitizeSV(module.name),
+          reserved: module.reserveName);
     }
 
     _hasBuilt = true;

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -229,7 +229,6 @@ abstract class Module {
   /// signals as "unpreferred" can have the effect of making generated output easier to read.
   @protected
   static String unpreferredName(String name) {
-    //TODO: how to make sure there's no module name conflicts??
     return _unpreferredPrefix + name;
   }
 

--- a/lib/src/synthesizers/synth_builder.dart
+++ b/lib/src/synthesizers/synth_builder.dart
@@ -64,7 +64,7 @@ class SynthBuilder {
     if (_moduleToInstanceTypeMap.containsKey(module)) {
       return _moduleToInstanceTypeMap[module]!;
     }
-    var newName = module.runtimeType.toString();
+    var newName = module.definitionName;
 
     var newSynthesisResult =
         synthesizer.synthesize(module, _moduleToInstanceTypeMap);
@@ -74,7 +74,8 @@ class SynthBuilder {
           _synthesisResults.lookup(newSynthesisResult)!.module]!;
     } else {
       _synthesisResults.add(newSynthesisResult);
-      newName = _instanceTypeUniquifier.getUniqueName(initialName: newName);
+      newName = _instanceTypeUniquifier.getUniqueName(
+          initialName: newName, reserved: module.reserveDefinitionName);
     }
 
     _moduleToInstanceTypeMap[module] = newName;

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -315,7 +315,7 @@ class _SynthModuleDefinition {
   String _getUniqueSynthSubModuleInstantiationName(
       String? initialName, bool reserved) {
     return _synthSubModuleInstantiationNameUniquifier.getUniqueName(
-        initialName: initialName, nullStarter: 'm');
+        initialName: initialName, nullStarter: 'm', reserved: reserved);
   }
 
   _SynthLogic? _getSynthLogic(Logic? logic, bool allowPortName) {

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -289,7 +289,9 @@ class _SynthModuleDefinition {
       return moduleToSubModuleInstantiationMap[m]!;
     } else {
       var newSSMI = _SynthSubModuleInstantiation(
-          m, _getUniqueSynthSubModuleInstantiationName(m.uniqueInstanceName));
+          m,
+          _getUniqueSynthSubModuleInstantiationName(
+              m.uniqueInstanceName, m.reserveName));
       moduleToSubModuleInstantiationMap[m] = newSSMI;
       return newSSMI;
     }
@@ -310,7 +312,8 @@ class _SynthModuleDefinition {
   }
 
   final Uniquifier _synthSubModuleInstantiationNameUniquifier = Uniquifier();
-  String _getUniqueSynthSubModuleInstantiationName(String? initialName) {
+  String _getUniqueSynthSubModuleInstantiationName(
+      String? initialName, bool reserved) {
     return _synthSubModuleInstantiationNameUniquifier.getUniqueName(
         initialName: initialName, nullStarter: 'm');
   }

--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -753,6 +753,8 @@ abstract class LogicValues {
   /// Returns a new `LogicValues` with the order of all bits in the reverse order of this `LogicValues`
   LogicValues get reversed;
 
+  //TODO: maybe getRange end should be optional, where it returns just bit of start if no end is provided
+
   /// Returns a subset [LogicValues].  It is inclusive of [start], exclusive of [end].
   LogicValues getRange(int start, int end) {
     if (end < start) {
@@ -781,7 +783,7 @@ abstract class LogicValues {
   /// True iff all bits are `z`.
   bool get isFloating;
 
-  /// The current active value of this if it has width 1, as a [LogicValue].
+  /// The current active value of this, if it has width 1, as a [LogicValue].
   ///
   /// Throws an Exception if width is not 1.
   LogicValue get bit {

--- a/test/name_test.dart
+++ b/test/name_test.dart
@@ -1,0 +1,70 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// definition_name_test.dart
+/// Tests for definition names (including reserving them) of Modules.
+///
+/// 2022 March 7
+/// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class TopModule extends Module {
+  TopModule(Logic a, bool causeDefConflict, bool causeInstConflict)
+      : super(name: 'topModule') {
+    a = addInput('a', a);
+
+    // note: order matters
+    SpeciallyNamedModule([a, a].swizzle(), causeDefConflict, causeInstConflict);
+    SpeciallyNamedModule(a, true, causeInstConflict);
+  }
+}
+
+class SpeciallyNamedModule extends Module {
+  SpeciallyNamedModule(Logic a, bool reserveDefName, bool reserveInstanceName)
+      : super(
+          name: 'specialNameInstance',
+          reserveName: reserveInstanceName,
+          definitionName: 'specialName',
+          reserveDefinitionName: reserveDefName,
+        ) {
+    addInput('a', a, width: a.width);
+  }
+}
+
+void main() {
+  group('definition name', () {
+    test('respected with no conflicts', () async {
+      var mod = SpeciallyNamedModule(Logic(), false, false);
+      await mod.build();
+      expect(mod.generateSynth(), contains('module specialName('));
+    });
+    test('uniquified with conflicts', () async {
+      var mod = TopModule(Logic(), false, false);
+      await mod.build();
+      var sv = mod.generateSynth();
+      expect(sv, contains('module specialName('));
+      expect(sv, contains('module specialName_0('));
+    });
+    test('reserved throws exception with conflicts', () async {
+      var mod = TopModule(Logic(), true, false);
+      await mod.build();
+      expect(() => mod.generateSynth(), throwsException);
+    });
+  });
+
+  group('instance name', () {
+    test('uniquified with conflicts', () async {
+      var mod = TopModule(Logic(), false, false);
+      await mod.build();
+      var sv = mod.generateSynth();
+      expect(sv, contains('specialNameInstance('));
+      expect(sv, contains('specialNameInstance_0('));
+    });
+    test('reserved throws exception with conflicts', () async {
+      var mod = TopModule(Logic(), false, true);
+      expect(() async => await mod.build(), throwsException);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- There are some situations where it is desirable for `Module` instance names to be fixed and not uniquified.  A new flag in `Module` provides the ability to prevent an instance name from being uniquified.
- There are some situations where it is desirable for `Module` definition names to be set in generated output.  A new `String` parameter enables users to specify the desired definition name.  It can be reserved as well via flag, similar to the new capability for instance names.

## Related Issue(s)

N/A

## Testing

Added new tests for new capabilities.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

API doc comments updated
