### PR TITLE
Enhanced bin() to ignore '_'. Ticket - https://github.com/intel/rohd/…

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -134,10 +134,10 @@ class LogicValue {
   }
 }
 
-/// Converts a binary [String] representation to a binary [int].
+/// Converts a binary [String] representation to a binary [int]. Ignores all '_' in the provided binary.
 ///
 /// Exactly equivalent to `int.parse(s, radix:2)`, but shorter to type.
-int bin(String s) => int.parse(s, radix: 2);
+int bin(String s) => int.parse(s.replaceAll('_', ''), radix: 2);
 
 /// Enum for a [LogicValue]'s value.
 enum _LogicValueEnum { zero, one, x, z }

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -134,9 +134,9 @@ class LogicValue {
   }
 }
 
-/// Converts a binary [String] representation to a binary [int]. Ignores all '_' in the provided binary.
+/// Converts a binary [String] representation to a binary [int].
 ///
-/// Exactly equivalent to `int.parse(s, radix:2)`, but shorter to type.
+/// Ignores all '_' in the provided binary.
 int bin(String s) => int.parse(s.replaceAll('_', ''), radix: 2);
 
 /// Enum for a [LogicValue]'s value.

--- a/test/logic_values_test.dart
+++ b/test/logic_values_test.dart
@@ -19,6 +19,14 @@ final lv = LogicValues.ofString;
 LogicValues large(LogicValue lv) => LogicValues.filled(100, lv);
 
 void main() {
+  test('bin with underscores', () {
+    var x = bin('11_1');
+    expect(x, equals(7));
+    x = bin('0001_0111');
+    expect(x, equals(23));
+    x = bin('0000_1000_0000');
+    expect(x, equals(128));
+  });
   group('two input bitwise', () {
     test('and2', () {
       // test z & 1 == x, rest unchanged


### PR DESCRIPTION
…issues/56

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

need to handle '_'s in the binary
https://github.com/intel/rohd/issues/56

## Related Issue(s)

https://github.com/intel/rohd/issues/56

## Testing

added tests in [test/logic_values_test.dart]

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

yes documentation updated needed and are included as part of the comments
