### PR TITLE
Add explicit width to Const generated SystemVerilog

### DIFF
--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -401,7 +401,7 @@ class _SynthModuleDefinition {
           assignments.add(_SynthAssignment(synthDriver!, synthReceiver));
         }
       } else if (driver == null && receiver.hasValidValue()) {
-        assignments.add(_SynthAssignment(receiver.valueInt, synthReceiver));
+        assignments.add(_SynthAssignment(receiver.value, synthReceiver));
       } else if (driver == null && !receiver.isFloating()) {
         // this is a signal that is *partially* invalid (e.g. 0b1z1x0)
         assignments.add(_SynthAssignment(receiver.value, synthReceiver));
@@ -627,7 +627,7 @@ class _SynthAssignment {
     } else if (_src is LogicValues) {
       return (_src as LogicValues).toString();
     } else if (_src is _SynthLogic) {
-      return _src.name;
+      return (_src as _SynthLogic).name;
     } else {
       throw Exception("Don't know how to synthesize value: $_src");
     }

--- a/lib/src/values/logic_values.dart
+++ b/lib/src/values/logic_values.dart
@@ -732,11 +732,12 @@ abstract class LogicValues {
   /// print(lv); // This prints `3b'1x0`
   /// ```
   @override
-  String toString() =>
-      "$length'b" +
-      List<String>.generate(length, (index) => this[index].toString())
-          .reversed
-          .join();
+  String toString() => isValid
+      ? "$length'h" + toInt().toRadixString(16)
+      : "$length'b" +
+          List<String>.generate(length, (index) => this[index].toString())
+              .reversed
+              .join();
 
   /// Returns the `i`th bit of this [LogicValues]
   LogicValue operator [](int index) {

--- a/test/logic_values_test.dart
+++ b/test/logic_values_test.dart
@@ -270,7 +270,7 @@ void main() {
       expect(
           // toString
           LogicValues.ofString('0').toString(),
-          equals('1\'b0'));
+          equals('1\'h0'));
       expect(
           // toList
           LogicValues.ofString('0101').toList(),


### PR DESCRIPTION

## Description & Motivation

Fix #89 which caused `Const`s in `swizzle`s to break in generated SystemVerilog.

## Related Issue(s)

#89 

## Testing

Added a new test which fails without this fix.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, but it does change the way SystemVerilog gets printed for constants.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
