### PR TITLE
Various features and testing for `Logic` and `LogicValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - Fixed a bug related to zero-width construction of `LogicValue`s (https://github.com/intel/rohd/issues/90).
 - Fixed a bug where generated constants in SystemVerilog had no width, which can cause issues in some cases (e.g. swizzles) (https://github.com/intel/rohd/issues/89)
 - Added capability to convert binary strings to ints with underscore separators using `bin` (https://github.com/intel/rohd/issues/56).
+- Added `getRange` and `reversed` on `Logic` and `slice` on `LogicValue` to improve consistency.
+- Using `slice` in reverse-index order now reverses the order.
+- Added the ability to extend signals (e.g. `zeroExtend` and `signExtend`) on both `Logic` and `LogicValue` (https://github.com/intel/rohd/issues/101).
+- Improved flexibility of `IfBlock`.
+- Added `withSet` on `LogicValue` and `Logic` to make it easier to assign subsets of signals and values (https://github.com/intel/rohd/issues/101).
+- Fixed a bug where 0-bit signals would sometimes improperly generate 0-bit constants in generated SystemVerilog (https://github.com/intel/rohd/issues/122).
 
 ## 0.2.0
 - Updated implementation to avoid `Iterable.forEach` to make debug easier.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ e <= [d, c, b].swizzle();
 e <= [b, c, d].rswizzle();
 ```
 
-ROHD does not support assignment to a subset of a bus.  That is, you *cannot* do something like `e[3] <= d`.  Instead, you can use the `withSet` function to get a copy of with that subset of the bus assigned to something else.  For example:
+ROHD does not support assignment to a subset of a bus.  That is, you *cannot* do something like `e[3] <= d`.  Instead, you can use the `withSet` function to get a copy with that subset of the bus assigned to something else.  This applies for both `Logic` and `LogicValue`.  For example:
 ```dart
 // reassign the variable `e` to a new `Logic` where bit 3 is set to `d`
 e = e.withSet(3, d);

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ x.value.toInt()
 
 // a BigInt
 x.value.toBigInt()
+
+// constructing a LogicValue a handful of different ways
+LogicValue.ofString('0101xz01');                      // 0b0101xz01
+LogicValue.of([LogicValue.one, LogicValue.zero]);     // 0b10
+[LogicValue.z, LogicValue.x].swizzle();               // 0bzx
+LogicValue.ofInt(15, 4);                              // 0xf
 ```
 
 You can create `LogicValue`s using a variety of constructors including `ofInt`, `ofBigInt`, `filled` (like '0, '1, 'x, etc. in SystemVerilog), and `of` (which takes any `Iterable<LogicValue>`).
@@ -205,7 +211,8 @@ var x = Const(5, width:16);
 There is a convenience function for converting binary to an integer:
 ```dart
 // this is equvialent to and shorter than int.parse('010101', radix:2)
-bin('010101')
+// you can put underscores to help with readability, they are ignored
+bin('01_0101')
 ```
 
 ### Assignment
@@ -238,7 +245,7 @@ a_gte_b   <=  (a >= b) // greater than or equal NOTE: careful with order of oper
 ```
 
 ### Shift Operations
-Dart has [implemented the triple shift](https://github.com/dart-lang/language/blob/master/accepted/future-releases/triple-shift-operator/feature-specification.md) operator (>>>) in the opposite way as is [implemented in SystemVerilog](https://www.nandland.com/verilog/examples/example-shift-operator-verilog.html).  That is to say in Dart, >>> means *logical* shift right (fill with 0's), and >> means *arithmetic* shift right (maintaining sign).  ROHD keeps consistency with Dart's implementation to avoid introducing confusion within Dart code you write (whether ROHD or plain Dart).
+Dart has [implemented the triple shift](https://github.com/dart-lang/language/blob/master/accepted/2.14/triple-shift-operator/feature-specification.md) operator (>>>) in the opposite way as is [implemented in SystemVerilog](https://www.nandland.com/verilog/examples/example-shift-operator-verilog.html).  That is to say in Dart, >>> means *logical* shift right (fill with 0's), and >> means *arithmetic* shift right (maintaining sign).  ROHD keeps consistency with Dart's implementation to avoid introducing confusion within Dart code you write (whether ROHD or plain Dart).
 
 ```dart
 a << b    // logical shift left
@@ -247,7 +254,7 @@ a >>> b   // logical shift right
 ```
 
 ### Bus ranges and swizzling
-Multi-bit busses can be accessed by single bits and ranges or composed from multiple other signals.
+Multi-bit busses can be accessed by single bits and ranges or composed from multiple other signals.  Slicing, swizzling, etc. are also accessible on `LogicValue`s.
 ```dart
 var a = Logic(width:8),
     b = Logic(width:3),
@@ -271,7 +278,11 @@ e <= [d, c, b].swizzle();
 e <= [b, c, d].rswizzle();
 ```
 
-ROHD does not (currently) support assignment to a subset of a bus.  That is, you *cannot* do something like `e[3] <= d`.  If you need to build a bus from a collection of other signals, use swizzling.
+ROHD does not support assignment to a subset of a bus.  That is, you *cannot* do something like `e[3] <= d`.  Instead, you can use the `withSet` function to get a copy of with that subset of the bus assigned to something else.  For example:
+```dart
+// reassign the variable `e` to a new `Logic` where bit 3 is set to `d`
+e = e.withSet(3, d);
+```
 
 ### Modules
 [`Module`](https://intel.github.io/rohd/rohd/Module-class.html)s are similar to modules in SystemVerilog.  They have inputs and outputs and logic that connects them.  There are a handful of rules that *must* be followed when implementing a module.
@@ -373,7 +384,7 @@ ROHD supports a variety of [`Conditional`](https://intel.github.io/rohd/rohd/Con
 
 Conditional statements are executed imperatively and in order, just like the contents of `always` blocks in SystemVerilog.  `_Always` blocks in ROHD map 1-to-1 with SystemVerilog `always` statements when converted.
 
-Assignments within an `_Always` should be executed conditionally, so use the `<` operator which creates a [`ConditionalAssign`](https://intel.github.io/rohd/rohd/ConditionalAssign-class.html) object instead of `<=`.
+Assignments within an `_Always` should be executed conditionally, so use the `<` operator which creates a [`ConditionalAssign`](https://intel.github.io/rohd/rohd/ConditionalAssign-class.html) object instead of `<=`.  The right hand side a `ConditionalAssign` can be anything that can be `put` onto a `Logic`, which includes `int`s.  If you're looking to fill the width of something, use `Const` with the `fill = true`.
 
 #### `If`
 Below is an example of an [`If`](https://intel.github.io/rohd/rohd/If-class.html) statement in ROHD:
@@ -390,7 +401,7 @@ Combinational([
       q < 13,
   ], orElse: [
       y < 0,
-      z < 1,
+      z < Const(1, width: 4, fill: true),
   ])])
 ]);
 ```

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -433,6 +433,9 @@ class Logic {
     return BusSubset(this, startIndex, endIndex).subset;
   }
 
+  /// Returns a version of this [Logic] with the bit order reversed.
+  Logic get reversed => slice(0, width - 1);
+
   /// Returns a subset [Logic].  It is inclusive of [startIndex], exclusive of [endIndex].
   ///
   /// [startIndex] must be less than [endIndex]. If [startIndex] and [endIndex] are equal, then a

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -426,7 +426,32 @@ class Logic {
   }
 
   /// Accesses a subset of this signal from [startIndex] to [endIndex], both inclusive.
+  ///
+  /// If [endIndex] is less than [startIndex], the returned value will be reversed relative
+  /// to the original signal.
   Logic slice(int endIndex, int startIndex) {
     return BusSubset(this, startIndex, endIndex).subset;
+  }
+
+  /// Returns a subset [Logic].  It is inclusive of [startIndex], exclusive of [endIndex].
+  ///
+  /// [startIndex] must be less than [endIndex]. If [startIndex] and [endIndex] are equal, then a
+  /// zero-width signal is returned.
+  Logic getRange(int startIndex, int endIndex) {
+    if (endIndex < startIndex) {
+      throw Exception(
+          'End ($endIndex) cannot be less than start ($startIndex).');
+    }
+    if (endIndex > width) {
+      throw Exception('End ($endIndex) must be less than width ($width).');
+    }
+    if (startIndex < 0) {
+      throw Exception(
+          'Start ($startIndex) must be greater than or equal to 0.');
+    }
+    if (endIndex == startIndex) {
+      return Const(0, width: 0);
+    }
+    return slice(endIndex - 1, startIndex);
   }
 }

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -174,7 +174,7 @@ class Logic {
   Module? get parentModule => _parentModule;
   Module? _parentModule;
 
-  /// Sets the value of [parentModule] to [newParent].
+  /// Sets the value of [parentModule] to [newParentModule].
   ///
   /// This should *only* be called by [Module.build()].  It is used to optimize search.
   @protected
@@ -496,7 +496,7 @@ class Logic {
   }
 
   /// Returns a copy of this [Logic] with the bits starting from [startIndex]
-  /// up until [startIndex] + [update.width] set to [update] instead
+  /// up until [startIndex] + [update]`.width` set to [update] instead
   /// of their original value.
   ///
   /// The return signal will be the same [width].  An exception will be thrown if

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -457,4 +457,61 @@ class Logic {
     }
     return slice(endIndex - 1, startIndex);
   }
+
+  /// Returns a new [Logic] with width [newWidth] where new bits added are zeros
+  /// as the most significant bits.
+  ///
+  /// The [newWidth] must be greater than or equal to the current width or an exception
+  /// will be thrown.
+  Logic zeroExtend(int newWidth) {
+    if (newWidth < width) {
+      throw Exception(
+          'New width $newWidth must be greater than or equal to width $width.');
+    }
+    return [
+      Const(0, width: newWidth - width),
+      this,
+    ].swizzle();
+  }
+
+  /// Returns a new [Logic] with width [newWidth] where new bits added are sign bits
+  /// as the most significant bits.  The sign is determined using two's complement, so
+  /// it takes the most significant bit of the original signal and extends with that.
+  ///
+  /// The [newWidth] must be greater than or equal to the current width or an exception
+  /// will be thrown.
+  Logic signExtend(int newWidth) {
+    if (newWidth < width) {
+      throw Exception(
+          'New width $newWidth must be greater than or equal to width $width.');
+    }
+    return [
+      Mux(
+        this[width - 1],
+        Const(1, width: newWidth - width, fill: true),
+        Const(0, width: newWidth - width),
+      ).y,
+      this,
+    ].swizzle();
+  }
+
+  /// Returns a copy of this [Logic] with the bits starting from [startIndex]
+  /// up until [startIndex] + [update.width] set to [update] instead
+  /// of their original value.
+  ///
+  /// The return signal will be the same [width].  An exception will be thrown if
+  /// the position of the [update] would cause an overrun past the [width].
+  Logic withSet(int startIndex, Logic update) {
+    if (startIndex + update.width > width) {
+      throw Exception(
+          'Width of updatedValue $update at startIndex $startIndex would'
+          'overrun the width of the original ($width).');
+    }
+
+    return [
+      getRange(startIndex + update.width, width),
+      update,
+      getRange(0, startIndex),
+    ].swizzle();
+  }
 }

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -131,9 +131,8 @@ class Swizzle extends Module with InlineSystemVerilog {
 
   /// Executes the functional behavior of this gate.
   void _execute(int startIdx, Logic swizzleInput, LogicValueChanged? args) {
-    var updatedVal = out.value.toList();
-    updatedVal.setAll(startIdx, swizzleInput.value.toList());
-    out.put(LogicValue.of(updatedVal));
+    var updatedVal = out.value.withSet(startIdx, swizzleInput.value);
+    out.put(updatedVal);
   }
 
   @override

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -75,6 +75,15 @@ class BusSubset extends Module with InlineSystemVerilog {
       throw Exception('BusSubset has exactly one input, but saw $inputs.');
     }
     var a = inputs[_original]!;
+
+    // SystemVerilog doesn't allow reverse-order select to reverse a bus, so do it manually
+    if (startIndex > endIndex) {
+      return '{' +
+          List.generate(startIndex - endIndex + 1, (i) => '$a[${endIndex + i}]')
+              .join(',') +
+          '}';
+    }
+
     var sliceString =
         startIndex == endIndex ? '[$startIndex]' : '[$endIndex:$startIndex]';
     return '$a$sliceString';

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -142,7 +142,10 @@ class Swizzle extends Module with InlineSystemVerilog {
       throw Exception('This swizzle has ${_swizzleInputs.length} inputs,'
           ' but saw $inputs with ${inputs.length} values.');
     }
-    var inputStr = _swizzleInputs.reversed.map((e) => inputs[e.name]).join(',');
+    var inputStr = _swizzleInputs.reversed
+        .where((e) => e.width > 0)
+        .map((e) => inputs[e.name])
+        .join(',');
     return '{$inputStr}';
   }
 }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -650,22 +650,20 @@ class CaseZ extends Case {
 /// A conditional block to execute only if [condition] is satisified.
 ///
 /// Intended for use with [IfBlock].
-class Iff {
+class ElseIf {
   /// A condition to match against to determine if [then] should be executed.
   final Logic condition;
 
   /// The [Conditional]s to execute if [condition] is satisfied.
   final List<Conditional> then;
 
-  Iff(this.condition, this.then);
+  ElseIf(this.condition, this.then);
 }
 
 /// A conditional block to execute only if [condition] is satisified.
 ///
 /// Intended for use with [IfBlock].
-class ElseIf extends Iff {
-  ElseIf(Logic condition, List<Conditional> then) : super(condition, then);
-}
+typedef Iff = ElseIf;
 
 /// A conditional block to execute only if [condition] is satisified.
 ///
@@ -681,8 +679,9 @@ class Else extends Iff {
 class IfBlock extends Conditional {
   /// A set of conditional items to check against for execution, in order.
   ///
-  /// The first item *must* be an [Iff], and if an [Else] is included it must
-  /// be the last item.  Any other items should be [ElseIf].
+  /// The first item should be an [Iff], and if an [Else] is included it must
+  /// be the last item.  Any other items should be [ElseIf].  It is okay to make the
+  /// first item an [ElseIf], it will act just like an [Iff].
   final List<Iff> iffs;
 
   IfBlock(this.iffs);
@@ -753,12 +752,9 @@ class IfBlock extends Conditional {
       }
       var header = iff == iffs.first
           ? 'if'
-          : iff is ElseIf
-              ? 'else if'
-              : iff is Else
-                  ? 'else'
-                  : throw Exception(
-                      'Unsupported Iff type: ${iff.runtimeType}.');
+          : iff is Else
+              ? 'else'
+              : 'else if';
 
       var conditionName = inputsNameMap[driverInput(iff.condition).name];
       var ifContents = iff.then

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -621,6 +621,9 @@ abstract class LogicValue {
       throw Exception(
           'New width $newWidth must be greater than or equal to width $width.');
     }
+    if (fill.width != 1) {
+      throw Exception('The fill must be 1 bit, but got $fill.');
+    }
     return [
       LogicValue.filled(newWidth - width, fill),
       this,
@@ -647,21 +650,21 @@ abstract class LogicValue {
   }
 
   /// Returns a copy of this [LogicValue] with the bits starting from [startIndex]
-  /// up until [startIndex] + [updatedValue.width] set to [updatedValue] instead
+  /// up until [startIndex] + [update.width] set to [update] instead
   /// of their original value.
   ///
   /// The return value will be the same [width].  An exception will be thrown if
-  /// the position of the [updatedValue] would cause an overrun past the [width].
-  LogicValue withSet(int startIndex, LogicValue updatedValue) {
-    if (startIndex + updatedValue.width > width) {
+  /// the position of the [update] would cause an overrun past the [width].
+  LogicValue withSet(int startIndex, LogicValue update) {
+    if (startIndex + update.width > width) {
       throw Exception(
-          'Width of updatedValue $updatedValue at startIndex $startIndex would'
+          'Width of updatedValue $update at startIndex $startIndex would'
           'overrun the width of the original ($width).');
     }
 
     return [
-      getRange(startIndex + updatedValue.width, width),
-      updatedValue,
+      getRange(startIndex + update.width, width),
+      update,
       getRange(0, startIndex),
     ].swizzle();
   }

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -282,20 +282,23 @@ abstract class LogicValue {
   /// Returns a new [LogicValue] with the order of all bits in the reverse order of this [LogicValue]
   LogicValue get reversed;
 
-  /// Returns a subset [LogicValue].  It is inclusive of [start], exclusive of [end].
+  /// Returns a subset [LogicValue].  It is inclusive of [startIndex], exclusive of [endIndex].
   ///
-  /// If [start] and [end] are equal, then a zero-width signal is returned.
-  LogicValue getRange(int start, int end) {
-    if (end < start) {
-      throw Exception('End ($end) cannot be greater than start ($start).');
+  /// [startIndex] must be less than [endIndex]. If [startIndex] and [endIndex] are equal, then a
+  /// zero-width value is returned.
+  LogicValue getRange(int startIndex, int endIndex) {
+    if (endIndex < startIndex) {
+      throw Exception(
+          'End ($endIndex) cannot be less than start ($startIndex).');
     }
-    if (end > width) {
-      throw Exception('End ($end) must be less than width ($width).');
+    if (endIndex > width) {
+      throw Exception('End ($endIndex) must be less than width ($width).');
     }
-    if (start < 0) {
-      throw Exception('Start ($start) must be greater than or equal to 0.');
+    if (startIndex < 0) {
+      throw Exception(
+          'Start ($startIndex) must be greater than or equal to 0.');
     }
-    return _getRange(start, end);
+    return _getRange(startIndex, endIndex);
   }
 
   /// Returns a subset [LogicValue].  It is inclusive of [start], exclusive of [end].
@@ -303,6 +306,18 @@ abstract class LogicValue {
   ///
   /// If [start] and [end] are equal, then a zero-width signal is returned.
   LogicValue _getRange(int start, int end);
+
+  /// Accesses a subset of this [LogicValue] from [startIndex] to [endIndex], both inclusive.
+  ///
+  /// If [endIndex] is less than [startIndex], the returned value will be reversed relative
+  /// to the original value.
+  LogicValue slice(int endIndex, int startIndex) {
+    if (startIndex <= endIndex) {
+      return getRange(startIndex, endIndex + 1);
+    } else {
+      return getRange(endIndex, startIndex + 1).reversed;
+    }
+  }
 
   /// Converts a pair of `_value` and `_invalid` into a [LogicValue].
   LogicValue _bitsToLogicValue(bool bitValue, bool bitInvalid) => bitInvalid
@@ -594,6 +609,61 @@ abstract class LogicValue {
           'Edge detection on invalid value from $previousValue to $newValue');
     }
     return previousValue == LogicValue.one && newValue == LogicValue.zero;
+  }
+
+  /// Returns a new [LogicValue] with width [newWidth] where the most significant
+  /// bits for indices beyond the original [width] are set to [fill].
+  ///
+  /// The [newWidth] must be greater than or equal to the current width or an exception
+  /// will be thrown. [fill] must be a single bit ([width]=1).
+  LogicValue extend(int newWidth, LogicValue fill) {
+    if (newWidth < width) {
+      throw Exception(
+          'New width $newWidth must be greater than or equal to width $width.');
+    }
+    return [
+      LogicValue.filled(newWidth - width, fill),
+      this,
+    ].swizzle();
+  }
+
+  /// Returns a new [LogicValue] with width [newWidth] where new bits added are zeros
+  /// as the most significant bits.
+  ///
+  /// The [newWidth] must be greater than or equal to the current width or an exception
+  /// will be thrown.
+  LogicValue zeroExtend(int newWidth) {
+    return extend(newWidth, LogicValue.zero);
+  }
+
+  /// Returns a new [LogicValue] with width [newWidth] where new bits added are sign bits
+  /// as the most significant bits.  The sign is determined using two's complement, so
+  /// it takes the most significant bit of the original value and extends with that.
+  ///
+  /// The [newWidth] must be greater than or equal to the current width or an exception
+  /// will be thrown.
+  LogicValue signExtend(int newWidth) {
+    return extend(newWidth, this[width - 1]);
+  }
+
+  /// Returns a copy of this [LogicValue] with the bits starting from [startIndex]
+  /// up until [startIndex] + [updatedValue.width] set to [updatedValue] instead
+  /// of their original value.
+  ///
+  /// The return value will be the same [width].  An exception will be thrown if
+  /// the position of the [updatedValue] would cause an overrun past the [width].
+  LogicValue withSet(int startIndex, LogicValue updatedValue) {
+    if (startIndex + updatedValue.width > width) {
+      throw Exception(
+          'Width of updatedValue $updatedValue at startIndex $startIndex would'
+          'overrun the width of the original ($width).');
+    }
+
+    return [
+      getRange(startIndex + updatedValue.width, width),
+      updatedValue,
+      getRange(0, startIndex),
+    ].swizzle();
   }
 }
 

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -650,7 +650,7 @@ abstract class LogicValue {
   }
 
   /// Returns a copy of this [LogicValue] with the bits starting from [startIndex]
-  /// up until [startIndex] + [update.width] set to [update] instead
+  /// up until [startIndex] + [update]`.width` set to [update] instead
   /// of their original value.
   ///
   /// The return value will be the same [width].  An exception will be thrown if

--- a/lib/src/values/values.dart
+++ b/lib/src/values/values.dart
@@ -4,6 +4,8 @@
 library values;
 
 import 'package:meta/meta.dart';
+// ignore: unused_import
+import 'package:rohd/rohd.dart';
 
 part 'logic_value.dart';
 part 'small_logic_value.dart';

--- a/run_coverage.sh
+++ b/run_coverage.sh
@@ -1,0 +1,11 @@
+dart test --coverage="tmp_coverage"
+
+# requires enabling coverage via:
+# > dart pub global activate coverage
+format_coverage --lcov --in=tmp_coverage --out=tmp_coverage/coverage.lcov --packages=.packages --report-on=lib
+
+# requires installing lcov
+# > sudo apt install lcov
+genhtml tmp_coverage/coverage.lcov -o tmp_coverage
+
+echo "Open tmp_coverage/index.html to review code coverage results"

--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -18,6 +18,7 @@ class BusTestModule extends Module {
   Logic get aShrunk => output('a_shrunk');
   Logic get aRSliced => output('a_rsliced');
   Logic get aReversed => output('a_reversed');
+  Logic get aRange => output('a_range');
   Logic get aBJoined => output('a_b_joined');
   Logic get a1 => output('a1');
   Logic get aPlusB => output('a_plus_b');
@@ -37,6 +38,7 @@ class BusTestModule extends Module {
     var aShrunk = addOutput('a_shrunk', width: 3);
     var aRSliced = addOutput('a_rsliced', width: 5);
     var aReversed = addOutput('a_reversed', width: a.width);
+    var aRange = addOutput('a_range', width: 3);
     var aBJoined = addOutput('a_b_joined', width: a.width + b.width);
     var aPlusB = addOutput('a_plus_b', width: a.width);
     var a1 = addOutput('a1');
@@ -46,6 +48,7 @@ class BusTestModule extends Module {
     aShrunk <= a.slice(2, 0);
     aRSliced <= a.slice(3, 7);
     aReversed <= a.reversed;
+    aRange <= a.getRange(5, 8);
     aBJoined <= [b, a].swizzle();
     a1 <= a[1];
     aPlusB <= a + b;
@@ -143,6 +146,7 @@ void main() {
       'a_shrunk': 3,
       'a_rsliced': 5,
       'a_reversed': 8,
+      'a_range': 3,
       'a_b_joined': 16,
       'a_plus_b': 8
     };
@@ -216,6 +220,21 @@ void main() {
         Vector({'a': 0}, {'a_reversed': 0}),
         Vector({'a': 0xff}, {'a_reversed': 0xff}),
         Vector({'a': 0xf5}, {'a_reversed': 0xaf}),
+      ];
+      await SimCompare.checkFunctionalVector(gtm, vectors);
+      var simResult = SimCompare.iverilogVector(
+          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
+          signalToWidthMap: signalToWidthMap);
+      expect(simResult, equals(true));
+    });
+
+    test('Bus range', () async {
+      var gtm = BusTestModule(Logic(width: 8), Logic(width: 8));
+      await gtm.build();
+      var vectors = [
+        Vector({'a': 0}, {'a_range': 0}),
+        Vector({'a': 0xff}, {'a_range': 7}),
+        Vector({'a': bin('10100101')}, {'a_range': bin('101')}),
       ];
       await SimCompare.checkFunctionalVector(gtm, vectors);
       var simResult = SimCompare.iverilogVector(

--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -17,6 +17,7 @@ class BusTestModule extends Module {
   Logic get aAndB => output('a_and_b');
   Logic get aShrunk => output('a_shrunk');
   Logic get aRSliced => output('a_rsliced');
+  Logic get aReversed => output('a_reversed');
   Logic get aBJoined => output('a_b_joined');
   Logic get a1 => output('a1');
   Logic get aPlusB => output('a_plus_b');
@@ -35,6 +36,7 @@ class BusTestModule extends Module {
     var aAndB = addOutput('a_and_b', width: a.width);
     var aShrunk = addOutput('a_shrunk', width: 3);
     var aRSliced = addOutput('a_rsliced', width: 5);
+    var aReversed = addOutput('a_reversed', width: a.width);
     var aBJoined = addOutput('a_b_joined', width: a.width + b.width);
     var aPlusB = addOutput('a_plus_b', width: a.width);
     var a1 = addOutput('a1');
@@ -43,6 +45,7 @@ class BusTestModule extends Module {
     aAndB <= a & b;
     aShrunk <= a.slice(2, 0);
     aRSliced <= a.slice(3, 7);
+    aReversed <= a.reversed;
     aBJoined <= [b, a].swizzle();
     a1 <= a[1];
     aPlusB <= a + b;
@@ -139,6 +142,7 @@ void main() {
       'a_and_b': 8,
       'a_shrunk': 3,
       'a_rsliced': 5,
+      'a_reversed': 8,
       'a_b_joined': 16,
       'a_plus_b': 8
     };
@@ -197,6 +201,21 @@ void main() {
         Vector({'a': 0}, {'a_rsliced': 0}),
         Vector({'a': 0xff}, {'a_rsliced': bin('11111')}),
         Vector({'a': 0xf5}, {'a_rsliced': 0xf}),
+      ];
+      await SimCompare.checkFunctionalVector(gtm, vectors);
+      var simResult = SimCompare.iverilogVector(
+          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
+          signalToWidthMap: signalToWidthMap);
+      expect(simResult, equals(true));
+    });
+
+    test('Bus reversed', () async {
+      var gtm = BusTestModule(Logic(width: 8), Logic(width: 8));
+      await gtm.build();
+      var vectors = [
+        Vector({'a': 0}, {'a_reversed': 0}),
+        Vector({'a': 0xff}, {'a_reversed': 0xff}),
+        Vector({'a': 0xf5}, {'a_reversed': 0xaf}),
       ];
       await SimCompare.checkFunctionalVector(gtm, vectors);
       var simResult = SimCompare.iverilogVector(

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -81,6 +81,23 @@ class IfBlockModule extends Module {
   }
 }
 
+class ElseIfBlockModule extends Module {
+  ElseIfBlockModule(Logic a, Logic b) : super(name: 'ifblockmodule') {
+    a = addInput('a', a);
+    b = addInput('b', b);
+    var c = addOutput('c');
+    var d = addOutput('d');
+
+    Combinational([
+      IfBlock([
+        ElseIf(a & ~b, [c < 1, d < 0]),
+        ElseIf(b & ~a, [c < 1, d < 0]),
+        Else([c < 0, d < 1])
+      ])
+    ]);
+  }
+}
+
 class CombModule extends Module {
   CombModule(Logic a, Logic b, Logic d) : super(name: 'combmodule') {
     a = addInput('a', a);
@@ -178,6 +195,21 @@ void main() {
 
     test('iffblock comb', () async {
       var mod = IfBlockModule(Logic(), Logic());
+      await mod.build();
+      var vectors = [
+        Vector({'a': 0, 'b': 0}, {'c': 0, 'd': 1}),
+        Vector({'a': 0, 'b': 1}, {'c': 1, 'd': 0}),
+        Vector({'a': 1, 'b': 0}, {'c': 1, 'd': 0}),
+        Vector({'a': 1, 'b': 1}, {'c': 0, 'd': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      var simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors);
+      expect(simResult, equals(true));
+    });
+
+    test('elseifblock comb', () async {
+      var mod = ElseIfBlockModule(Logic(), Logic());
       await mod.build();
       var vectors = [
         Vector({'a': 0, 'b': 0}, {'c': 0, 'd': 1}),

--- a/test/extend_test.dart
+++ b/test/extend_test.dart
@@ -9,76 +9,164 @@
 ///
 
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
+enum ExtendType { zero, sign }
+
+class ExtendModule extends Module {
+  ExtendModule(Logic a, int newWidth, ExtendType extendType) {
+    a = addInput('a', a, width: a.width);
+    var b = addOutput('b', width: newWidth);
+
+    b <=
+        (extendType == ExtendType.zero
+            ? a.zeroExtend(newWidth)
+            : a.signExtend(newWidth));
+  }
+}
+
+class WithSetModule extends Module {
+  WithSetModule(Logic a, int startIndex, Logic b) {
+    a = addInput('a', a, width: a.width);
+    b = addInput('b', b, width: b.width);
+    var c = addOutput('c', width: a.width);
+
+    c <= a.withSet(startIndex, b);
+  }
+}
+
 void main() {
-  group('extend', () {
-    test('extend with same width returns same thing', () {
-      var original = LogicValue.ofString('0101xz0101');
-      var modified = original.extend(original.width, LogicValue.x);
-      expect(modified, equals(original));
+  group('Logic', () {
+    group('extend', () {
+      Future<void> extendVectors(
+          List<Vector> vectors, int newWidth, ExtendType extendType) async {
+        var mod = ExtendModule(Logic(width: 8), newWidth, extendType);
+        await mod.build();
+        await SimCompare.checkFunctionalVector(mod, vectors);
+        var simResult = SimCompare.iverilogVector(
+            mod.generateSynth(), mod.runtimeType.toString(), vectors,
+            signalToWidthMap: {'a': 8, 'b': newWidth});
+        expect(simResult, equals(true));
+      }
+
+      test('zero extend with same width returns same thing', () async {
+        await extendVectors([
+          Vector({'a': 0}, {'b': 0}),
+          Vector({'a': 0xff}, {'b': 0xff}),
+          Vector({'a': 0x5a}, {'b': 0x5a}),
+        ], 8, ExtendType.zero);
+      });
+      test('zero extend with less width throws exception', () {
+        expect(() => extendVectors([], 6, ExtendType.zero), throwsException);
+      });
+      test('sign extend with same width returns same thing', () async {
+        await extendVectors([
+          Vector({'a': 0}, {'b': 0}),
+          Vector({'a': 0xff}, {'b': 0xff}),
+          Vector({'a': 0x5a}, {'b': 0x5a}),
+        ], 8, ExtendType.sign);
+      });
+      test('sign extend with less width throws exception', () {
+        expect(() => extendVectors([], 6, ExtendType.sign), throwsException);
+      });
+      test('zero extend pads 0s', () async {
+        await extendVectors([
+          Vector({'a': 0xff}, {'b': 0xff}),
+          Vector({'a': 0x5a}, {'b': 0x5a}),
+        ], 12, ExtendType.zero);
+      });
+      test('sign extend for positive number pads 0s', () async {
+        await extendVectors([
+          Vector({'a': 0x5a}, {'b': 0x5a}),
+        ], 12, ExtendType.sign);
+      });
+      test('sign extend for negative number pads 1s', () async {
+        await extendVectors([
+          Vector({'a': 0xff}, {'b': 0xfff}),
+        ], 12, ExtendType.sign);
+      });
     });
-    test('extend with less width throws exception', () {
-      var original = LogicValue.ofString('0101xz0101');
-      expect(() => original.extend(original.width - 2, LogicValue.x),
-          throwsException);
-    });
-    test('extend with more width properly extends', () {
-      var original = LogicValue.ofString('0101xz0101');
-      var modified = original.extend(original.width + 3, LogicValue.x);
-      expect(modified, equals(LogicValue.ofString('xxx0101xz0101')));
-    });
-    test('zero extend pads 0s', () {
-      var original = LogicValue.ofString('0101xz0101');
-      var modified = original.zeroExtend(original.width + 3);
-      expect(modified, equals(LogicValue.ofString('0000101xz0101')));
-    });
-    test('sign extend for positive number pads 0s', () {
-      var original = LogicValue.ofString('0101xz0101');
-      var modified = original.signExtend(original.width + 3);
-      expect(modified, equals(LogicValue.ofString('0000101xz0101')));
-    });
-    test('sign extend for negative number pads 1s', () {
-      var original = LogicValue.ofString('1101xz0101');
-      var modified = original.signExtend(original.width + 3);
-      expect(modified, equals(LogicValue.ofString('1111101xz0101')));
+
+    // TODO: finish the withset stuff
+    group('withSet', () {
+      test('setting with bigger number throws exception', () {});
+      test('setting with number in middle overrun throws exception', () {});
+      test('setting same width returns only new', () {});
+      test('setting at front', () {});
+      test('setting at end', () {});
+      test('setting in the middle', () {});
     });
   });
+  group('LogicValue', () {
+    group('extend', () {
+      test('extend with same width returns same thing', () {
+        var original = LogicValue.ofString('0101xz0101');
+        var modified = original.extend(original.width, LogicValue.x);
+        expect(modified, equals(original));
+      });
+      test('extend with less width throws exception', () {
+        var original = LogicValue.ofString('0101xz0101');
+        expect(() => original.extend(original.width - 2, LogicValue.x),
+            throwsException);
+      });
+      test('extend with more width properly extends', () {
+        var original = LogicValue.ofString('0101xz0101');
+        var modified = original.extend(original.width + 3, LogicValue.x);
+        expect(modified, equals(LogicValue.ofString('xxx0101xz0101')));
+      });
+      test('zero extend pads 0s', () {
+        var original = LogicValue.ofString('0101xz0101');
+        var modified = original.zeroExtend(original.width + 3);
+        expect(modified, equals(LogicValue.ofString('0000101xz0101')));
+      });
+      test('sign extend for positive number pads 0s', () {
+        var original = LogicValue.ofString('0101xz0101');
+        var modified = original.signExtend(original.width + 3);
+        expect(modified, equals(LogicValue.ofString('0000101xz0101')));
+      });
+      test('sign extend for negative number pads 1s', () {
+        var original = LogicValue.ofString('1101xz0101');
+        var modified = original.signExtend(original.width + 3);
+        expect(modified, equals(LogicValue.ofString('1111101xz0101')));
+      });
+    });
 
-  group('withSet', () {
-    test('setting with bigger number throws exception', () {
-      var original = LogicValue.ofString('1101xz0101');
-      expect(() => original.withSet(0, LogicValue.ofString('00001101xz0101')),
-          throwsException);
-    });
-    test('setting with number in middle overrun throws exception', () {
-      var original = LogicValue.ofString('1101xz0101');
-      expect(() => original.withSet(7, LogicValue.ofString('1111')),
-          throwsException);
-    });
-    test('setting same width returns only new', () {
-      var original = LogicValue.ofString('1101xz0101');
-      var newVal = LogicValue.ofString('1111001111');
-      var modified = original.withSet(0, newVal);
-      expect(modified, equals(newVal));
-    });
-    test('setting at front', () {
-      var original = LogicValue.ofString('1101xz0101');
-      var newVal = LogicValue.ofString('1111');
-      var modified = original.withSet(0, newVal);
-      expect(modified, equals(LogicValue.ofString('1101xz1111')));
-    });
-    test('setting at end', () {
-      var original = LogicValue.ofString('xxxxxz0101');
-      var newVal = LogicValue.ofString('1111');
-      var modified = original.withSet(6, newVal);
-      expect(modified, equals(LogicValue.ofString('1111xz0101')));
-    });
-    test('setting in the middle', () {
-      var original = LogicValue.ofString('xxxxxxxxxx');
-      var newVal = LogicValue.ofString('1111');
-      var modified = original.withSet(3, newVal);
-      expect(modified, equals(LogicValue.ofString('xxx1111xxx')));
+    group('withSet', () {
+      test('setting with bigger number throws exception', () {
+        var original = LogicValue.ofString('1101xz0101');
+        expect(() => original.withSet(0, LogicValue.ofString('00001101xz0101')),
+            throwsException);
+      });
+      test('setting with number in middle overrun throws exception', () {
+        var original = LogicValue.ofString('1101xz0101');
+        expect(() => original.withSet(7, LogicValue.ofString('1111')),
+            throwsException);
+      });
+      test('setting same width returns only new', () {
+        var original = LogicValue.ofString('1101xz0101');
+        var newVal = LogicValue.ofString('1111001111');
+        var modified = original.withSet(0, newVal);
+        expect(modified, equals(newVal));
+      });
+      test('setting at front', () {
+        var original = LogicValue.ofString('1101xz0101');
+        var newVal = LogicValue.ofString('1111');
+        var modified = original.withSet(0, newVal);
+        expect(modified, equals(LogicValue.ofString('1101xz1111')));
+      });
+      test('setting at end', () {
+        var original = LogicValue.ofString('xxxxxz0101');
+        var newVal = LogicValue.ofString('1111');
+        var modified = original.withSet(6, newVal);
+        expect(modified, equals(LogicValue.ofString('1111xz0101')));
+      });
+      test('setting in the middle', () {
+        var original = LogicValue.ofString('xxxxxxxxxx');
+        var newVal = LogicValue.ofString('1111');
+        var modified = original.withSet(3, newVal);
+        expect(modified, equals(LogicValue.ofString('xxx1111xxx')));
+      });
     });
   });
 }

--- a/test/extend_test.dart
+++ b/test/extend_test.dart
@@ -1,0 +1,84 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// bus_test.dart
+/// Unit tests for bus-related operations
+///
+/// 2022 May 4
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('extend', () {
+    test('extend with same width returns same thing', () {
+      var original = LogicValue.ofString('0101xz0101');
+      var modified = original.extend(original.width, LogicValue.x);
+      expect(modified, equals(original));
+    });
+    test('extend with less width throws exception', () {
+      var original = LogicValue.ofString('0101xz0101');
+      expect(() => original.extend(original.width - 2, LogicValue.x),
+          throwsException);
+    });
+    test('extend with more width properly extends', () {
+      var original = LogicValue.ofString('0101xz0101');
+      var modified = original.extend(original.width + 3, LogicValue.x);
+      expect(modified, equals(LogicValue.ofString('xxx0101xz0101')));
+    });
+    test('zero extend pads 0s', () {
+      var original = LogicValue.ofString('0101xz0101');
+      var modified = original.zeroExtend(original.width + 3);
+      expect(modified, equals(LogicValue.ofString('0000101xz0101')));
+    });
+    test('sign extend for positive number pads 0s', () {
+      var original = LogicValue.ofString('0101xz0101');
+      var modified = original.signExtend(original.width + 3);
+      expect(modified, equals(LogicValue.ofString('0000101xz0101')));
+    });
+    test('sign extend for negative number pads 1s', () {
+      var original = LogicValue.ofString('1101xz0101');
+      var modified = original.signExtend(original.width + 3);
+      expect(modified, equals(LogicValue.ofString('1111101xz0101')));
+    });
+  });
+
+  group('withSet', () {
+    test('setting with bigger number throws exception', () {
+      var original = LogicValue.ofString('1101xz0101');
+      expect(() => original.withSet(0, LogicValue.ofString('00001101xz0101')),
+          throwsException);
+    });
+    test('setting with number in middle overrun throws exception', () {
+      var original = LogicValue.ofString('1101xz0101');
+      expect(() => original.withSet(7, LogicValue.ofString('1111')),
+          throwsException);
+    });
+    test('setting same width returns only new', () {
+      var original = LogicValue.ofString('1101xz0101');
+      var newVal = LogicValue.ofString('1111001111');
+      var modified = original.withSet(0, newVal);
+      expect(modified, equals(newVal));
+    });
+    test('setting at front', () {
+      var original = LogicValue.ofString('1101xz0101');
+      var newVal = LogicValue.ofString('1111');
+      var modified = original.withSet(0, newVal);
+      expect(modified, equals(LogicValue.ofString('1101xz1111')));
+    });
+    test('setting at end', () {
+      var original = LogicValue.ofString('xxxxxz0101');
+      var newVal = LogicValue.ofString('1111');
+      var modified = original.withSet(6, newVal);
+      expect(modified, equals(LogicValue.ofString('1111xz0101')));
+    });
+    test('setting in the middle', () {
+      var original = LogicValue.ofString('xxxxxxxxxx');
+      var newVal = LogicValue.ofString('1111');
+      var modified = original.withSet(3, newVal);
+      expect(modified, equals(LogicValue.ofString('xxx1111xxx')));
+    });
+  });
+}

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -314,6 +314,14 @@ void main() {
           equals(LogicValue.zero) // NOTE: index (length-1) refers to MSb
           );
       expect(
+          // large
+          LogicValue.ofString('01xz' * 50)[101],
+          equals(LogicValue.x));
+      expect(
+          // filled
+          LogicValue.ofString('1111')[2],
+          equals(LogicValue.one));
+      expect(
           // index - out of range
           () => LogicValue.ofString('0101')[10],
           throwsA(isA<IndexError>()));
@@ -341,6 +349,10 @@ void main() {
           // getRange - bad inputs end > length-1
           () => LogicValue.ofString('0101').getRange(0, 7),
           throwsA(isA<Exception>()));
+      expect(LogicValue.ofString('xz01').slice(2, 1),
+          equals(LogicValue.ofString('z0')));
+      expect(LogicValue.ofString('xz01').slice(1, 3),
+          equals(LogicValue.ofString('0zx')));
       expect(
           // isValid - valid
           LogicValue.ofString('0101').isValid,

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -21,6 +21,10 @@ class SwizzlyModule extends Module {
 }
 
 void main() {
+  tearDown(() {
+    Simulator.reset();
+  });
+
   group('LogicValue', () {
     test('simple swizzle', () {
       expect(
@@ -72,7 +76,7 @@ void main() {
       await SimCompare.checkFunctionalVector(mod, vectors);
       var simResult = SimCompare.iverilogVector(
           mod.generateSynth(), mod.runtimeType.toString(), vectors,
-          signalToWidthMap: {'b': 2}, dontDeleteTmpFiles: true);
+          signalToWidthMap: {'b': 2});
       expect(simResult, equals(true));
     });
   });

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -14,8 +14,8 @@ import 'package:test/test.dart';
 
 class SwizzlyModule extends Module {
   SwizzlyModule(Logic a) {
-    a = addInput('a', a);
-    var b = addOutput('b', width: 3);
+    a = addInput('a', a, width: a.width);
+    var b = addOutput('b', width: a.width + 2);
     b <= [Const(1), a, Const(1)].swizzle();
   }
 }
@@ -59,6 +59,20 @@ void main() {
       var simResult = SimCompare.iverilogVector(
           mod.generateSynth(), mod.runtimeType.toString(), vectors,
           signalToWidthMap: {'b': 3});
+      expect(simResult, equals(true));
+    });
+
+    test('const 0-width swizzle', () async {
+      var mod = SwizzlyModule(Const(0, width: 0));
+      await mod.build();
+      var vectors = [
+        Vector({}, {'b': bin('11')}),
+        Vector({}, {'b': bin('11')}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      var simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors,
+          signalToWidthMap: {'b': 2}, dontDeleteTmpFiles: true);
       expect(simResult, equals(true));
     });
   });


### PR DESCRIPTION
## Description & Motivation

Further improving the usability of and consistency between `Logic` and `LogicValue`.  Includes:
- `getRange` on `Logic`
- `zeroExtend`, and `signExtend` on `Logic` and `LogicValue`, plus `extend` on `LogicValue.
- `withSet` for `LogicValue` and `Logic`
- `reversed` on `Logic`
- `slice` on `LogicValue`
- Reverse slicing on both `Logic` and `LogicValue`
- Made `IfBlock` a little more flexible
- Improved documentation and README around these features
- Added a script to generate line coverage

## Related Issue(s)

Close #113
Improve on #91
Close #117
Close #101
Close #83
Fix #122

## Testing

Passing existing tests and added a bunch more tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Yes, documentation updated
