### PR TITLE
Fix #129, waveform dump bug for multi-bit values

### DIFF
--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -172,7 +172,10 @@ class WaveDumper {
   void _writeSignalValueUpdate(Logic signal) {
     var updateValue = signal.width > 1
         ? 'b' +
-            signal.value.reversed.toList().map((e) => e.toString()).join() +
+            signal.value.reversed
+                .toList()
+                .map((e) => e.toString(includeWidth: false))
+                .join() +
             ' '
         : signal.value.toString(includeWidth: false);
     var marker = _signalToMarkerMap[signal];


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fix a bug where multi-bit values don't properly dump into VCDs by the `WaveDumper`.

## Related Issue(s)

Fix #129 

## Testing

Added new tests to cover this scenario.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
