### PR TITLE
Fix for issue #126 Simulator reset does not wait for simulation to complete and test to reproduce the issue

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -92,6 +92,8 @@ class Simulator {
   ///
   /// Note: values deposited on [Module]s from the previous simulation remain.
   static Future<void> reset() async {
+    if (_simulationEndRequested) await simulationEnded;
+
     _currentTimestamp = 0;
     _simulationEndRequested = false;
     _maxSimTime = -1;

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -49,4 +49,11 @@ void main() {
     expect(tooFar, equals(false));
     expect(farEnough, equals(true));
   });
+
+  test('simulator reset waits for simulation to complete', () async {
+    Simulator.registerAction(100, () => Simulator.endSimulation());
+    Simulator.registerAction(100, () => Simulator.reset());
+    Simulator.registerAction(100, () => true);
+    await Simulator.run();
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Simulator Bug found causing failures 

## Related Issue(s)

Fix #126 

## Testing

Added a new test to reproduce the issue

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
