### PR TITLE
Added actions to execute at the end of the simulation

### DIFF
--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -8,6 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
+import 'dart:async';
+
 import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';
 
@@ -55,5 +57,26 @@ void main() {
     Simulator.registerAction(100, () => Simulator.reset());
     Simulator.registerAction(100, () => true);
     await Simulator.run();
+  });
+
+  test('simulator end of action waits before ending', () async {
+    var endOfSimActionExecuted = false;
+    Simulator.registerAction(100, () => true);
+    Simulator.registerEndOfSimulationAction(
+        () => endOfSimActionExecuted = true);
+    unawaited(Simulator.simulationEnded
+        .then((value) => expect(endOfSimActionExecuted, isTrue)));
+    await Simulator.run();
+  });
+
+  test('simulator end of action waits async before ending', () async {
+    var endOfSimActionExecuted = false;
+    Simulator.registerAction(100, () => true);
+    Simulator.registerEndOfSimulationAction(() async {
+      await Future.delayed(Duration(microseconds: 10));
+      endOfSimActionExecuted = true;
+    });
+    await Simulator.run();
+    expect(endOfSimActionExecuted, isTrue);
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Make it possible to register actions to be executed at the end of the simulation.  This is useful for "finalizing" lots of things like file IO, checking, etc. at the end of a simulation.

## Related Issue(s)

N/A

## Testing

Added new unit tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Updated doc comments
