### PR TITLE
Fix `Combinational` sensitivity detection - Issue #158

### DIFF
--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -131,7 +131,9 @@ class Swizzle extends Module with InlineSystemVerilog {
 
   /// Executes the functional behavior of this gate.
   void _execute(int startIdx, Logic swizzleInput, LogicValueChanged? args) {
-    var updatedVal = out.value.withSet(startIdx, swizzleInput.value);
+    //TODO: adjust this to get rid of unnecessary inputs
+    var updatedVal =
+        _swizzleInputs.reversed.map((e) => e.value).toList().swizzle();
     out.put(updatedVal);
   }
 

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -115,23 +115,16 @@ class Swizzle extends Module with InlineSystemVerilog {
     }
     addOutput(_out, width: outputWidth);
 
+    _execute(); // for initial values
     for (var swizzleInput in _swizzleInputs) {
-      // var startIdx = _swizzleInputs.getRange(0, _swizzleInputs.indexOf(swizzleInput)).map((e) => e.width).reduce((a, b) => a+b);
-      var startIdx = 0;
-      for (var xsi in _swizzleInputs) {
-        if (xsi == swizzleInput) break;
-        startIdx += xsi.width;
-      }
-      _execute(startIdx, swizzleInput, null); // for initial values
       swizzleInput.glitch.listen((args) {
-        _execute(startIdx, swizzleInput, args);
+        _execute();
       });
     }
   }
 
   /// Executes the functional behavior of this gate.
-  void _execute(int startIdx, Logic swizzleInput, LogicValueChanged? args) {
-    //TODO: adjust this to get rid of unnecessary inputs
+  void _execute() {
     var updatedVal =
         _swizzleInputs.reversed.map((e) => e.value).toList().swizzle();
     out.put(updatedVal);

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -135,6 +135,10 @@ class Combinational extends _Always {
     }
   }
 
+  /// Recursively collects a list of all [Logic]s that this should be sensitive to
+  /// beyond direct inputs.
+  ///
+  /// Use [alreadyParsed] to prevent searching down paths already searched.
   Set<Logic>? _collectSensitivities(Logic src, [Set<Logic>? alreadyParsed]) {
     Set<Logic>? collection;
 
@@ -177,7 +181,6 @@ class Combinational extends _Always {
           // otherwise, we have some sensitivities to send back
           collection ??= {};
           collection.addAll(subSensitivities);
-          // collection.add(dst);
           if (dst.isInput) {
             // collect all the inputs of this module too as sensitivities
             collection.addAll(dst.parentModule!.inputs.values);
@@ -201,7 +204,6 @@ class Combinational extends _Always {
     }
 
     _isExecuting = true;
-    // print('@${Simulator.time} $name executing');
 
     // combinational must always drive all outputs or else you get X!
     for (var element in _assignedReceiverToOutputMap.values) {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -147,6 +147,11 @@ class Combinational extends _Always {
 
     var dstConnections = src.dstConnections.toSet();
     if (src.isInput) {
+      if (src.parentModule! is Sequential) {
+        // sequential logic can't be a sensitivity, so ditch those
+        return null;
+      }
+
       // we're at the input to another module, grab all the outputs of it and continue searching
       dstConnections.addAll(src.parentModule!.outputs.values);
     }
@@ -196,6 +201,7 @@ class Combinational extends _Always {
     }
 
     _isExecuting = true;
+    // print('@${Simulator.time} $name executing');
 
     // combinational must always drive all outputs or else you get X!
     for (var element in _assignedReceiverToOutputMap.values) {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -135,8 +135,15 @@ class Combinational extends _Always {
     }
   }
 
-  Set<Logic>? _collectSensitivities(Logic src) {
+  Set<Logic>? _collectSensitivities(Logic src, [Set<Logic>? alreadyParsed]) {
     Set<Logic>? collection;
+
+    alreadyParsed ??= {};
+    if (alreadyParsed.contains(src)) {
+      // we're in a loop or already traversed this path, abandon it
+      return null;
+    }
+    alreadyParsed.add(src);
 
     var dstConnections = src.dstConnections.toSet();
     if (src.isInput) {
@@ -156,7 +163,7 @@ class Combinational extends _Always {
         collection ??= {};
       } else {
         // otherwise, let's look deeper to see if any others down the path are sensitivities
-        var subSensitivities = _collectSensitivities(dst);
+        var subSensitivities = _collectSensitivities(dst, alreadyParsed);
 
         if (subSensitivities == null) {
           // if we get null, then it was a dead end

--- a/test/comb_math_test.dart
+++ b/test/comb_math_test.dart
@@ -1,0 +1,138 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// comb_math_test.dart
+/// Unit tests based on UTF8 encoding example in issue 158.
+///
+/// 2022 September 20
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:io';
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class ExampleModule extends Module {
+  ExampleModule(Logic codepoint) {
+    codepoint = addInput('codepoint', codepoint, width: 21);
+    final bytes = addOutput('bytes', width: 32);
+    final count = Logic(name: 'count', width: 2);
+
+    Combinational([
+      If(codepoint.eq(0x2020), then: [
+        count < 2,
+        bytes <
+            ((codepoint >>> (Const(6, width: 5) * count.zeroExtend(5))) +
+                    Const(0xE0, width: 21))
+                .slice(7, 0)
+                .zeroExtend(32),
+        count < count - 2,
+      ]),
+    ]);
+  }
+
+  Logic get bytes => output('bytes');
+}
+
+class SimplerExample extends Module {
+  Logic get b => output('b');
+  SimplerExample(Logic a) {
+    a = addInput('a', a, width: 8);
+    addOutput('b', width: 8);
+
+    var inner = Logic(name: 'inner', width: 8);
+
+    Combinational([
+      inner < 0xf,
+      b < a & inner,
+      inner < 0,
+    ]);
+  }
+}
+
+class StagedExample extends Module {
+  Logic get b => output('b');
+  StagedExample(Logic a) {
+    a = addInput('a', a, width: 8);
+    addOutput('b', width: 8);
+
+    var inner = Logic(name: 'inner', width: 4);
+
+    Combinational([
+      inner < 0xf,
+      b < a & inner.zeroExtend(8),
+      inner < 0,
+    ]);
+  }
+}
+
+class ReducedExample extends Module {
+  ReducedExample(Logic codepoint) {
+    codepoint = addInput('codepoint', codepoint, width: 21);
+    final bytes = addOutput('bytes', width: 32);
+    final count = Logic(name: 'count', width: 2);
+
+    Combinational([
+      count < 2,
+      bytes < (codepoint >>> count).zeroExtend(32),
+    ]);
+  }
+
+  Logic get bytes => output('bytes');
+}
+
+void main() {
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  //TODO: make these tests use simcompare
+
+  // thank you to @chykon in issue #158 for providing this example!
+  test('execute math conditionally', () async {
+    final codepoint = Logic(width: 21);
+    final exampleModule = ExampleModule(codepoint);
+    await exampleModule.build();
+    final codepoints = '†† †† † † q†† †'.runes;
+    for (final inputCodepoint in codepoints) {
+      codepoint.put(inputCodepoint);
+      if (inputCodepoint == 8224) {
+        expect(exampleModule.bytes.value, equals(LogicValue.ofInt(0xe2, 32)));
+      } else {
+        expect(exampleModule.bytes.value,
+            equals(LogicValue.filled(32, LogicValue.x)));
+      }
+    }
+  });
+
+  test('reduced example', () async {
+    final codepoint = Logic(width: 21);
+    final exampleModule = ReducedExample(codepoint);
+    await exampleModule.build();
+    final codepoints = '†'.runes;
+    for (final inputCodepoint in codepoints) {
+      codepoint.put(inputCodepoint);
+    }
+    expect(exampleModule.bytes.value.isValid, isTrue);
+    expect(exampleModule.bytes.value, equals(LogicValue.ofInt(0x808, 32)));
+  });
+
+  test('simpler example', () async {
+    var a = Logic(name: 'a', width: 8);
+    var mod = SimplerExample(a);
+    await mod.build();
+    a.put(0xff);
+    expect(mod.b.value, equals(LogicValue.ofString('00001111')));
+  });
+
+  test('staged example', () async {
+    var a = Logic(name: 'a', width: 8);
+    var mod = StagedExample(a);
+    await mod.build();
+    a.put(0xff);
+    expect(mod.b.value, equals(LogicValue.ofString('00001111')));
+  });
+
+  //TODO: another test with some signals in between to test propagation
+}

--- a/test/comb_math_test.dart
+++ b/test/comb_math_test.dart
@@ -27,6 +27,9 @@ class ExampleModule extends Module {
                 .slice(7, 0)
                 .zeroExtend(32),
         count < count - 2,
+      ], orElse: [
+        // this is necessary for x's in iverilog (https://github.com/steveicarus/iverilog/issues/776)
+        bytes < LogicValue.filled(32, LogicValue.x)
       ]),
     ]);
   }
@@ -105,8 +108,6 @@ void main() {
     Simulator.reset();
   });
 
-  //TODO: make these tests use simcompare
-
   // thank you to @chykon in issue #158 for providing this example!
   test('execute math conditionally', () async {
     final codepoint = Logic(width: 21);
@@ -128,12 +129,10 @@ void main() {
 
     await SimCompare.checkFunctionalVector(mod, vectors);
 
-    //TODO: enable SV compare once bit slice on expressions is fixed
-
-    // var simResult = SimCompare.iverilogVector(
-    //     mod.generateSynth(), mod.runtimeType.toString(), vectors,
-    //     signalToWidthMap: {'codepoint': 21, 'bytes': 32});
-    // expect(simResult, equals(true));
+    var simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors,
+        signalToWidthMap: {'codepoint': 21, 'bytes': 32});
+    expect(simResult, equals(true));
   });
 
   test('reduced example', () async {

--- a/test/comb_math_test.dart
+++ b/test/comb_math_test.dart
@@ -198,6 +198,4 @@ void main() {
         signalToWidthMap: {'a': 8, 'b': 8});
     expect(simResult, equals(true));
   });
-
-  //TODO: another test with some signals in between to test propagation
 }

--- a/test/comb_mod_test.dart
+++ b/test/comb_mod_test.dart
@@ -1,0 +1,92 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// comb_mod_test.dart
+/// Unit tests related to Combinationals and other Modules.
+///
+/// 2022 September 26
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class IncrModule extends Module {
+  Logic get result => output('result');
+  IncrModule(Logic toIncr) {
+    toIncr = addInput('toIncr', toIncr, width: toIncr.width);
+    addOutput('result', width: toIncr.width);
+    result <= toIncr + 1;
+  }
+}
+
+class ReuseExample extends Module {
+  ReuseExample(Logic a) {
+    a = addInput('a', a, width: a.width);
+    var b = addOutput('b', width: a.width);
+
+    Logic intermediate = Logic(name: 'intermediate', width: a.width);
+
+    var inc = IncrModule(intermediate);
+
+    Combinational([
+      intermediate < a,
+      intermediate < inc.result,
+      intermediate < inc.result,
+    ]);
+
+    b <= intermediate;
+  }
+}
+
+class DuplicateExample extends Module {
+  DuplicateExample(Logic a) {
+    a = addInput('a', a, width: a.width);
+    var b = addOutput('b', width: a.width);
+
+    Logic intermediate = Logic(name: 'intermediate', width: a.width);
+
+    Combinational([
+      intermediate < a,
+      intermediate < IncrModule(intermediate).result,
+      intermediate < IncrModule(intermediate).result,
+    ]);
+
+    b <= intermediate;
+  }
+}
+
+void main() {
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  test('module reuse should apply twice', () async {
+    var mod = ReuseExample(Logic(width: 8));
+    await mod.build();
+
+    var vectors = [
+      Vector({'a': 3}, {'b': 5})
+    ];
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    var simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors,
+        signalToWidthMap: {'a': 8, 'b': 8});
+    expect(simResult, equals(true));
+  });
+
+  test('module duplication should apply twice', () async {
+    var mod = DuplicateExample(Logic(width: 8));
+    await mod.build();
+
+    var vectors = [
+      Vector({'a': 3}, {'b': 5})
+    ];
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    var simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors,
+        signalToWidthMap: {'a': 8, 'b': 8});
+    expect(simResult, equals(true));
+  });
+}

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -79,7 +79,5 @@ void main() {
           signalToWidthMap: {'b': 3});
       expect(simResult, equals(true));
     });
-
-    //TODO: Add a test for Logic swizzle that's not symmetric!
   });
 }

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -15,8 +15,8 @@ import 'package:test/test.dart';
 class SwizzlyModule extends Module {
   SwizzlyModule(Logic a) {
     a = addInput('a', a, width: a.width);
-    var b = addOutput('b', width: a.width + 2);
-    b <= [Const(1), a, Const(1)].swizzle();
+    var b = addOutput('b', width: a.width + 3);
+    b <= [Const(0), Const(1), a, Const(1)].swizzle();
   }
 }
 
@@ -56,8 +56,22 @@ void main() {
       var mod = SwizzlyModule(Logic());
       await mod.build();
       var vectors = [
-        Vector({'a': 0}, {'b': bin('101')}),
-        Vector({'a': 1}, {'b': bin('111')}),
+        Vector({'a': 0}, {'b': bin('0101')}),
+        Vector({'a': 1}, {'b': bin('0111')}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      var simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors,
+          signalToWidthMap: {'b': 4});
+      expect(simResult, equals(true));
+    });
+
+    test('const 0-width swizzle', () async {
+      var mod = SwizzlyModule(Const(0, width: 0));
+      await mod.build();
+      var vectors = [
+        Vector({}, {'b': bin('011')}),
+        Vector({}, {'b': bin('011')}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
       var simResult = SimCompare.iverilogVector(
@@ -66,18 +80,6 @@ void main() {
       expect(simResult, equals(true));
     });
 
-    test('const 0-width swizzle', () async {
-      var mod = SwizzlyModule(Const(0, width: 0));
-      await mod.build();
-      var vectors = [
-        Vector({}, {'b': bin('11')}),
-        Vector({}, {'b': bin('11')}),
-      ];
-      await SimCompare.checkFunctionalVector(mod, vectors);
-      var simResult = SimCompare.iverilogVector(
-          mod.generateSynth(), mod.runtimeType.toString(), vectors,
-          signalToWidthMap: {'b': 2});
-      expect(simResult, equals(true));
-    });
+    //TODO: Add a test for Logic swizzle that's not symmetric!
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Previously, ROHD's `Combinational` would look at direct input changes for its sensitivity list.  There are some cases where changes during execution of the contents of a `Combinational` would have had additional changes onto direct inputs of the `Combinational`, meaning that it should be sensitive to those inputs as well.  This PR includes fixes so that `Combinational` during `build` will find the full sensitivity list by searching for inputs potentially affected by outputs of itself.

Thank you to @chykon for finding the bug (#158) that led to this fix.

Some other bugs were filed and fixed during debug of this issue, including (#163).  This PR also includes a change to how `swizzle` executes in order to properly handle intermediate contention and constants given the increased sensitivity for `Combinational`.  This PR also includes some new tests which were created to search for other bugs (which didn't actually exist), but these confirmed more equivalence between ROHD simulation and SystemVerilog simulation.

## Related Issue(s)

Fix #158 

## Testing

Added new tests and modified some existing tests to cover the original bug, the new changes, and potential other issues.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, however it is now more important to ensure that `Combinational` is built before using it.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No.
