### PR TITLE
Remove accidental `dontDeleteTmpFiles` for a bus test

### DIFF
--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -302,7 +302,7 @@ void main() {
       await SimCompare.checkFunctionalVector(gtm, vectors);
       final simResult = SimCompare.iverilogVector(
           gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap, dontDeleteTmpFiles: true);
+          signalToWidthMap: signalToWidthMap);
       expect(simResult, equals(true));
     });
   });


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

During development/debug, a `dontDeleteTmpFiles` was included on one of the tests which makes tests keep some temporary files around even when they pass.  This shouldn't be there.

## Related Issue(s)

N/A

## Testing

Existing tests pass.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No