### PR TITLE
Fix badges in readme after workflow changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Tests](https://github.com/intel/rohd/actions/workflows/test.yml/badge.svg)](https://github.com/intel/rohd/actions/workflows/test.yml)
-[![Docs](https://github.com/intel/rohd/actions/workflows/docs.yml/badge.svg)](https://intel.github.io/rohd/rohd/rohd-library.html)
+[![Tests](https://github.com/intel/rohd/actions/workflows/general.yml/badge.svg?event=push)](https://github.com/intel/rohd/actions/workflows/general.yml)
+[![API Docs](https://img.shields.io/badge/API%20Docs-generated-success)](https://intel.github.io/rohd/rohd/rohd-library.html)
 [![Chat](https://img.shields.io/discord/1001179329411166267?label=Chat)](https://discord.gg/jubxF84yGw)
 [![License](https://img.shields.io/badge/License-BSD--3-blue)](https://github.com/intel/rohd/blob/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The changed name in the workflows caused the badges in the README to break, so fixing those.

## Related Issue(s)

N/A

## Testing

Checked in preview and fork that links look good now.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No