### PR TITLE
Increase Dart SDK version

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -22,8 +22,7 @@ class Counter extends Module {
   // This counter supports any width, determined at run-time
   final int width;
   Counter(Logic en, Logic reset, Logic clk,
-      {this.width = 8, String name = 'counter'})
-      : super(name: name) {
+      {this.width = 8, super.name = 'counter'}) {
     // Register inputs and outputs of the module in the constructor.
     // Module logic must consume registered inputs and output to registered
     // outputs.

--- a/example/fir_filter.dart
+++ b/example/fir_filter.dart
@@ -20,9 +20,8 @@ class FirFilter extends Module {
   final int bitWidth;
   final int depth;
   FirFilter(Logic en, Logic resetB, Logic clk, Logic inputVal, List<int> coef,
-      {this.bitWidth = 16, String name = 'FirFilter'})
-      : depth = coef.length,
-        super(name: name) {
+      {this.bitWidth = 16, super.name = 'FirFilter'})
+      : depth = coef.length {
     // Register inputs and outputs of the module in the constructor
     // Module logic must consume registered inputs and output to
     // registered outputs

--- a/lib/src/external.dart
+++ b/lib/src/external.dart
@@ -33,9 +33,8 @@ abstract class ExternalSystemVerilogModule extends Module
   ExternalSystemVerilogModule(
       {required this.topModuleName,
       this.parameters,
-      String name = 'external_module'})
+      super.name = 'external_module'})
       : super(
-            name: name,
             definitionName: topModuleName,
             reserveDefinitionName: true);
 

--- a/lib/src/external.dart
+++ b/lib/src/external.dart
@@ -34,9 +34,7 @@ abstract class ExternalSystemVerilogModule extends Module
       {required this.topModuleName,
       this.parameters,
       super.name = 'external_module'})
-      : super(
-            definitionName: topModuleName,
-            reserveDefinitionName: true);
+      : super(definitionName: topModuleName, reserveDefinitionName: true);
 
   @override
   String instantiationVerilog(String instanceType, String instanceName,

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -36,8 +36,7 @@ class BusSubset extends Module with InlineSystemVerilog {
   /// Constructs a [Module] that accesses a subset from [bus] which ranges
   /// from [startIndex] to [endIndex] (inclusive of both).
   BusSubset(Logic bus, this.startIndex, this.endIndex,
-      {String name = 'bussubset'})
-      : super(name: name) {
+      {super.name = 'bussubset'}) {
     // If a converted index value is still -ve then it's an Index out of bounds
     // on a Logic Bus
     if (startIndex < 0 || endIndex < 0) {
@@ -125,7 +124,7 @@ class Swizzle extends Module with InlineSystemVerilog {
   final List<Logic> _swizzleInputs = [];
 
   /// Constructs a [Module] which concatenates [signals] into one large [out].
-  Swizzle(List<Logic> signals, {String name = 'swizzle'}) : super(name: name) {
+  Swizzle(List<Logic> signals, {super.name = 'swizzle'}) {
     var idx = 0;
     var outputWidth = 0;
     for (final signal in signals.reversed) {

--- a/lib/src/modules/clkgen.dart
+++ b/lib/src/modules/clkgen.dart
@@ -26,8 +26,7 @@ class SimpleClockGenerator extends Module with CustomSystemVerilog {
   /// SystemVerilog representation.
   ///
   /// Set the frequency via [clockPeriod].
-  SimpleClockGenerator(this.clockPeriod, {String name = 'clkgen'})
-      : super(name: name) {
+  SimpleClockGenerator(this.clockPeriod, {super.name = 'clkgen'}) {
     addOutput('clk');
 
     clk.glitch.listen((args) {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -28,7 +28,7 @@ abstract class _Always extends Module with CustomSystemVerilog {
 
   final Uniquifier _portUniquifier = Uniquifier();
 
-  _Always(this.conditionals, {String name = 'always'}) : super(name: name) {
+  _Always(this.conditionals, {super.name = 'always'}) {
     // create a registration of all inputs and outputs of this module
     var idx = 0;
     for (final conditional in conditionals) {
@@ -105,8 +105,7 @@ abstract class _Always extends Module with CustomSystemVerilog {
 class Combinational extends _Always {
   /// Constructs a new [Combinational] which executes [conditionals] in order
   /// procedurally.
-  Combinational(List<Conditional> conditionals, {String name = 'combinational'})
-      : super(conditionals, name: name) {
+  Combinational(super.conditionals, {super.name = 'combinational'}) {
     _execute(); // for initial values
     for (final driver in _assignedDriverToInputMap.keys) {
       driver.glitch.listen((args) {
@@ -764,11 +763,9 @@ class CaseZ extends Case {
   /// the definition of matches allows for `z` to be a wildcard.
   ///
   /// If none of [items] match, then [defaultItem] is executed.
-  CaseZ(Logic expression, List<CaseItem> items,
-      {List<Conditional>? defaultItem,
-      ConditionalType conditionalType = ConditionalType.none})
-      : super(expression, items,
-            defaultItem: defaultItem, conditionalType: conditionalType);
+  CaseZ(super.expression, super.items,
+      {super.defaultItem,
+      super.conditionalType});
 
   @override
   String get caseType => 'casez';
@@ -1028,7 +1025,7 @@ class FlipFlop extends Module with CustomSystemVerilog {
   Logic get q => output(_q);
 
   /// Constructs a flip flop which is positive edge triggered on [clk].
-  FlipFlop(Logic clk, Logic d, {String name = 'flipflop'}) : super(name: name) {
+  FlipFlop(Logic clk, Logic d, {super.name = 'flipflop'}) {
     if (clk.width != 1) {
       throw Exception('clk must be 1 bit');
     }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -764,8 +764,7 @@ class CaseZ extends Case {
   ///
   /// If none of [items] match, then [defaultItem] is executed.
   CaseZ(super.expression, super.items,
-      {super.defaultItem,
-      super.conditionalType});
+      {super.defaultItem, super.conditionalType});
 
   @override
   String get caseType => 'casez';

--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -27,7 +27,7 @@ class NotGate extends Module with InlineSystemVerilog {
   /// Constructs a [NotGate] with [a] as its input.
   ///
   /// You can optionally set [name] to name this [Module].
-  NotGate(Logic a, {String name = 'not'}) : super(name: name) {
+  NotGate(Logic a, {super.name = 'not'}) {
     _a = Module.unpreferredName(a.name);
     _out = Module.unpreferredName('${a.name}_b');
     addInput(_a, a, width: a.width);
@@ -552,8 +552,7 @@ class Mux extends Module with InlineSystemVerilog {
 
   /// Constructs a multiplexer which passes [d0] or [d1] to [y] depending
   /// on if [control] is 0 or 1, respectively.
-  Mux(Logic control, Logic d1, Logic d0, {String name = 'mux'})
-      : super(name: name) {
+  Mux(Logic control, Logic d1, Logic d0, {super.name = 'mux'}) {
     if (control.width != 1) {
       throw Exception('Control must be single bit Logic, but found $control.');
     }

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -101,7 +101,7 @@ class Pipeline {
       List<Logic> signals = const [],
       Map<Logic, Const> resetValues = const {},
       this.reset}) {
-    _stages = stages.map((stage) => _PipeStage(stage)).toList();
+    _stages = stages.map(_PipeStage.new).toList();
     _stages.add(_PipeStage((p) => [])); // output stage
 
     if (_numStages == 0) {
@@ -271,21 +271,18 @@ class ReadyValidPipeline extends Pipeline {
   /// If contents are pushed in when the pipeline is not ready, they
   /// will be dropped.
   ReadyValidPipeline(
-    Logic clk,
+    super.clk,
     this.validPipeIn,
     this.readyPipeOut, {
     List<List<Conditional> Function(PipelineStageInfo p)> stages = const [],
-    Map<Logic, Const> resetValues = const {},
+    super.resetValues,
     List<Logic> signals = const [],
-    Logic? reset,
+    super.reset,
   }) : super(
-          clk,
           stages: stages,
           signals: [validPipeIn, ...signals],
           stalls: List.generate(
               stages.length, (index) => Logic(name: 'stall_$index')),
-          reset: reset,
-          resetValues: resetValues,
         ) {
     final valid = validPipeIn;
 

--- a/lib/src/values/small_logic_value.dart
+++ b/lib/src/values/small_logic_value.dart
@@ -41,12 +41,12 @@ class _SmallLogicValue extends LogicValue {
     return _masksOfWidth[width]!;
   }
 
-  const _SmallLogicValue(int value, int invalid, int width)
+  const _SmallLogicValue(int value, int invalid, super.width)
       : assert(width <= LogicValue._INT_BITS,
             '_SmallLogicValue should have low number of bits'),
         _value = ((1 << width) - 1) & value,
         _invalid = ((1 << width) - 1) & invalid,
-        super._(width);
+        super._();
 
   @override
   bool _equals(Object other) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/intel/rohd/issues
 documentation: https://intel.github.io/rohd/rohd/rohd-library.html
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0
@@ -17,4 +17,3 @@ dependencies:
 
 dev_dependencies:
   benchmark_harness: ^2.2.0
-  

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -40,7 +40,7 @@ class TestModule extends Module {
 enum LightStates { northFlowing, northSlowing, eastFlowing, eastSlowing }
 
 class Direction extends Const {
-  Direction._(int value) : super(value, width: 2);
+  Direction._(int super.value) : super(width: 2);
   Direction.noTraffic() : this._(bin('00'));
   Direction.northTraffic() : this._(bin('01'));
   Direction.eastTraffic() : this._(bin('10'));
@@ -48,7 +48,7 @@ class Direction extends Const {
 }
 
 class LightColor extends Const {
-  LightColor._(int value) : super(value, width: 2);
+  LightColor._(int super.value) : super(width: 2);
   LightColor.green() : this._(bin('00'));
   LightColor.yellow() : this._(bin('01'));
   LightColor.red() : this._(bin('10'));

--- a/test/sequential_test.dart
+++ b/test/sequential_test.dart
@@ -20,8 +20,7 @@ class DelaySignal extends Module {
   final int depth;
 
   DelaySignal(Logic en, Logic inputVal,
-      {this.bitWidth = 4, this.depth = 5, String name = 'movingSum'})
-      : super(name: name) {
+      {this.bitWidth = 4, this.depth = 5, super.name = 'movingSum'}) {
     en = addInput('en', en);
     inputVal = addInput('inputVal', inputVal, width: bitWidth);
     final clk = SimpleClockGenerator(10).clk;


### PR DESCRIPTION
## Description & Motivation

ROHD currently uses Dart version [2.14](https://github.com/intel/rohd/blob/6ec7ec56744c94e42d7011952fa3391bde031180/pubspec.yaml#L10). It is proposed to upgrade the version to the latest actual - [2.18](https://dart.dev/guides/language/evolution#dart-218). Among the changes, I would especially like to highlight the `super parameters` added in [2.17](https://dart.dev/guides/language/evolution#dart-217), which allow writing more compact constructors.

It also becomes possible to use `enhanced enums`, the idea of using which was mentioned here - #124.

After the version upgrade, it was necessary to use a `dart fix` to apply the recommendations related to the new language features.

## Related Issue(s)

No.

## Testing

After the changes, testing was launched, which was successfully completed.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No.
