### PR TITLE
Clean up names for ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,45 +557,50 @@ Note: changing a value directly with `put()` will propogate the value, but it wi
 Many of the basic built-in gates in Dart implement custom behavior.  An implementation of the NotGate is shown below as an example.  There is different syntax for functions which can be inlined versus those which cannot (the ~ can be inlined).  In this case, the `InlineSystemVerilog` mixin is used, but if it were not inlineable, you could use `CustomSystemVerilog`.  Note that it is mandatory to provide an initial value computation when the module is first created for non-sequential modules.
 
 ```dart
+/// A gate [Module] that performs bit-wise inversion.
 class NotGate extends Module with InlineSystemVerilog {
+  /// Name for the input of this inverter.
+  late final String _inName;
 
-  /// Name for a port of this module. 
-  late final String _a, _out;
-  
+  /// Name for the output of this inverter.
+  late final String _outName;
+
   /// The input to this [NotGate].
-  Logic get a => input(_a);
+  Logic get _in => input(_inName);
 
   /// The output of this [NotGate].
-  Logic get out => output(_out);
+  Logic get out => output(_outName);
 
-  NotGate(Logic a, {String name = 'not'}) : super(name: name) {
-    _a = Module.unpreferredName(a.name);
-    _out = Module.unpreferredName('${a.name}_b');
-    addInput(_a, a, width: a.width);
-    addOutput(_out, width: a.width);
+  /// Constructs a [NotGate] with [in_] as its input.
+  ///
+  /// You can optionally set [name] to name this [Module].
+  NotGate(Logic in_, {super.name = 'not'}) {
+    _inName = Module.unpreferredName(in_.name);
+    _outName = Module.unpreferredName('${in_.name}_b');
+    addInput(_inName, in_, width: in_.width);
+    addOutput(_outName, width: in_.width);
     _setup();
   }
 
   /// Performs setup steps for custom functional behavior.
   void _setup() {
     _execute(); // for initial values
-
-    // Custom behavior should subscribe to 'glitch'
-    a.glitch.listen((args) {
+    _in.glitch.listen((args) {
       _execute();
     });
   }
 
   /// Executes the functional behavior of this gate.
   void _execute() {
-    out.put(~a.value);
+    out.put(~_in.value);
   }
 
-  // specify how to convert this behavior to Verilog
   @override
-  String inlineVerilog(Map<String,String> inputs) {
-    if(inputs.length != 1) throw Exception('Gate has exactly one input.');
-    var a = inputs[_a]!;
+  String inlineVerilog(Map<String, String> inputs) {
+    if (inputs.length != 1) {
+      throw Exception('Gate has exactly one input.');
+    }
+    final a = inputs[_inName]!;
     return '~$a';
   }
 }

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ a_lt_b    <=  a.lt(b)  // less than             NOTE: <  is for conditional assi
 a_lte_b   <=  a.lte(b) // less than or equal    NOTE: <= is for assignment
 a_gt_b    <=  (a > b)  // greater than          NOTE: careful with order of operations, > needs parentheses in this case
 a_gte_b   <=  (a >= b) // greater than or equal NOTE: careful with order of operations, >= needs parentheses in this case
+answer    <=  mux(selectA, a, b) // answer = selectA ? a : b
 ```
 
 ### Shift Operations

--- a/example/tree.dart
+++ b/example/tree.dart
@@ -68,7 +68,7 @@ Future<void> main({bool noPrint = false}) async {
   // You could instantiate this module with some code such as:
   final tree = TreeOfTwoInputModules(
       List<Logic>.generate(16, (index) => Logic(width: 8)),
-      (a, b) => Mux(a > b, a, b).y);
+      (a, b) => mux(a > b, a, b));
 
   /// This instantiation code generates a list of sixteen 8-bit logic signals.
   /// The operation to be performed (`_op`) is to create a `Mux` which returns

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -281,69 +281,69 @@ class Logic {
   Logic operator ~() => NotGate(this).out;
 
   /// Logical bitwise AND.
-  Logic operator &(Logic other) => And2Gate(this, other).y;
+  Logic operator &(Logic other) => And2Gate(this, other).out;
 
   /// Logical bitwise OR.
-  Logic operator |(Logic other) => Or2Gate(this, other).y;
+  Logic operator |(Logic other) => Or2Gate(this, other).out;
 
   /// Logical bitwise XOR.
-  Logic operator ^(Logic other) => Xor2Gate(this, other).y;
+  Logic operator ^(Logic other) => Xor2Gate(this, other).out;
 
   /// Addition.
   ///
   /// WARNING: Signed math is not fully tested.
-  Logic operator +(dynamic other) => Add(this, other).y;
+  Logic operator +(dynamic other) => Add(this, other).out;
 
   /// Subtraction.
   ///
   /// WARNING: Signed math is not fully tested.
-  Logic operator -(dynamic other) => Subtract(this, other).y;
+  Logic operator -(dynamic other) => Subtract(this, other).out;
 
   /// Multiplication.
   ///
   /// WARNING: Signed math is not fully tested.
-  Logic operator *(dynamic other) => Multiply(this, other).y;
+  Logic operator *(dynamic other) => Multiply(this, other).out;
 
   /// Division.
   ///
   /// WARNING: Signed math is not fully tested.
-  Logic operator /(dynamic other) => Divide(this, other).y;
+  Logic operator /(dynamic other) => Divide(this, other).out;
 
   /// Modulo operation.
-  Logic operator %(Logic other) => Modulo(this, other).y;
+  Logic operator %(Logic other) => Modulo(this, other).out;
 
   /// Arithmetic right-shift.
-  Logic operator >>(Logic other) => ARShift(this, other).y;
+  Logic operator >>(Logic other) => ARShift(this, other).out;
 
   /// Logical left-shift.
-  Logic operator <<(Logic other) => LShift(this, other).y;
+  Logic operator <<(Logic other) => LShift(this, other).out;
 
   /// Logical right-shift.
-  Logic operator >>>(Logic other) => RShift(this, other).y;
+  Logic operator >>>(Logic other) => RShift(this, other).out;
 
   /// Unary AND.
-  Logic and() => AndUnary(this).y;
+  Logic and() => AndUnary(this).out;
 
   /// Unary OR.
-  Logic or() => OrUnary(this).y;
+  Logic or() => OrUnary(this).out;
 
   /// Unary XOR.
-  Logic xor() => XorUnary(this).y;
+  Logic xor() => XorUnary(this).out;
 
   /// Logical equality.
-  Logic eq(dynamic other) => Equals(this, other).y;
+  Logic eq(dynamic other) => Equals(this, other).out;
 
   /// Less-than.
-  Logic lt(dynamic other) => LessThan(this, other).y;
+  Logic lt(dynamic other) => LessThan(this, other).out;
 
   /// Less-than-or-equal-to.
-  Logic lte(dynamic other) => LessThanOrEqual(this, other).y;
+  Logic lte(dynamic other) => LessThanOrEqual(this, other).out;
 
   /// Greater-than.
-  Logic operator >(dynamic other) => GreaterThan(this, other).y;
+  Logic operator >(dynamic other) => GreaterThan(this, other).out;
 
   /// Greater-than-or-equal-to.
-  Logic operator >=(dynamic other) => GreaterThanOrEqual(this, other).y;
+  Logic operator >=(dynamic other) => GreaterThanOrEqual(this, other).out;
 
   /// Conditional assignment operator.
   ///
@@ -564,11 +564,11 @@ class Logic {
           'New width $newWidth must be greater than or equal to width $width.');
     }
     return [
-      Mux(
+      mux(
         this[width - 1],
         Const(1, width: newWidth - width, fill: true),
         Const(0, width: newWidth - width),
-      ).y,
+      ),
       this,
     ].swizzle();
   }

--- a/lib/src/modules/passthrough.dart
+++ b/lib/src/modules/passthrough.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// passthrough.dart
@@ -13,22 +13,22 @@ import 'package:rohd/rohd.dart';
 /// A very simple noop module that just passes a signal through.
 class Passthrough extends Module {
   /// The input port.
-  Logic get a => input('a');
+  Logic get in_ => input('in');
 
   /// The output port.
-  Logic get b => output('b');
+  Logic get out => output('out');
 
   /// Constructs a simple pass-through module that performs no operations
-  /// between [a] and [b].
+  /// between [a] and [out].
   Passthrough(Logic a, [String name = 'passthrough']) : super(name: name) {
-    addInput('a', a);
-    addOutput('b');
+    addInput('in', a);
+    addOutput('out');
     _setup();
   }
 
   void _setup() {
     final inner = Logic(name: 'inner');
-    inner <= a;
-    b <= inner;
+    inner <= in_;
+    out <= inner;
   }
 }

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// pipeline.dart
@@ -173,7 +173,7 @@ class Pipeline {
       final stall = _stages[index].stall;
       final ffAssign = ffAssigns[index] as ConditionalAssign;
       final driver = stall != null
-          ? Mux(stall, ffAssign.receiver, ffAssign.driver).y
+          ? mux(stall, ffAssign.receiver, ffAssign.driver)
           : ffAssign.driver;
       return ffAssign.receiver < driver;
     });

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// gate_test.dart
@@ -87,7 +87,7 @@ class MuxWrapper extends Module {
     d1 = addInput('d1', d1, width: d1.width);
     final y = addOutput('y', width: d0.width);
 
-    y <= Mux(control, d1, d0).y;
+    y <= Mux(control, d1, d0).out;
   }
 }
 

--- a/test/multimodule3_test.dart
+++ b/test/multimodule3_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// multimodule3_test.dart
@@ -30,7 +30,7 @@ class InnerModule1 extends Module {
     addOutput('m');
     m <= Const(0);
     addOutput('y');
-    y <= Passthrough(InnerModule2().z).b;
+    y <= Passthrough(InnerModule2().z).out;
   }
 }
 

--- a/test/multimodule4_test.dart
+++ b/test/multimodule4_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// multimodule4_test.dart
@@ -26,7 +26,7 @@ class InnerModule1 extends Module {
   InnerModule1(Logic y) : super(name: 'innermodule1') {
     y = addInput('y', y);
     final m = Logic();
-    m <= Passthrough(InnerModule2().z).b | y;
+    m <= Passthrough(InnerModule2().z).out | y;
   }
 }
 

--- a/test/tree_test.dart
+++ b/test/tree_test.dart
@@ -49,7 +49,7 @@ void main() {
     test('tree', () async {
       final mod = TreeOfTwoInputModules(
           List<Logic>.generate(16, (index) => Logic(width: 8)),
-          (a, b) => Mux(a > b, a, b).y);
+          (a, b) => mux(a > b, a, b));
       await mod.build();
       // File('tmp_tree.sv').writeAsStringSync(mod.generateSynth());
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Make the naming of gates better and also make it easier to use a mux.

## Related Issue(s)

FIx #135
Fix #13 

## Testing

Existing tests cover it.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

**Yes!**  This changes port names and removes input port visibility (which should have been hidden anyways).

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Added deprecation notes, updated API documentation, added a line to README.  Updated README version of `NotGate`.
