### PR TITLE
Fix bug related to clock divider simulation, fix #191

### DIFF
--- a/test/clock_divider_test.dart
+++ b/test/clock_divider_test.dart
@@ -1,0 +1,69 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+import '../example/example.dart';
+
+class ClockDivider extends Module {
+  Logic get clkOut => output('clkOut');
+  ClockDivider(Logic clkIn, Logic reset) : super(name: 'clockDivider') {
+    clkIn = addInput('clkIn', clkIn);
+    reset = addInput('reset', reset);
+    final clkOut = addOutput('clkOut');
+
+    Sequential(clkIn, [
+      If(
+        reset,
+        then: [clkOut < 0],
+        orElse: [clkOut < ~clkOut],
+      ),
+    ]);
+  }
+}
+
+class TwoCounters extends Module {
+  TwoCounters(Logic resetClks, Logic resetCounters) {
+    resetClks = addInput('resetClks', resetClks);
+    resetCounters = addInput('resetCounters', resetCounters);
+
+    final clk = SimpleClockGenerator(10).clk;
+    final clkDiv = ClockDivider(clk, resetClks).clkOut;
+
+    addOutput('cntFast', width: 8) <=
+        Counter(Const(1), resetCounters, clk, name: 'fastCounter').val;
+    addOutput('cntSlow', width: 8) <=
+        Counter(Const(1), resetCounters, clkDiv, name: 'slowCounter').val;
+  }
+}
+
+void main() {
+  test('clock divider', () async {
+    final mod = TwoCounters(Logic(), Logic());
+    await mod.build();
+    final vectors = [
+      Vector({'resetClks': 1, 'resetCounters': 1}, {}),
+      Vector({'resetClks': 0, 'resetCounters': 1}, {}),
+      Vector({'resetClks': 0, 'resetCounters': 1}, {}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 0, 'cntFast': 0}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 1, 'cntFast': 1}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 1, 'cntFast': 2}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 2, 'cntFast': 3}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 2, 'cntFast': 4}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 3, 'cntFast': 5}),
+      Vector(
+          {'resetClks': 0, 'resetCounters': 0}, {'cntSlow': 3, 'cntFast': 6}),
+    ];
+
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    final simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors,
+        signalToWidthMap: {'cntSlow': 8, 'cntFast': 8});
+    expect(simResult, equals(true));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

If the output of one Sequential is used as a clock trigger to another Sequential, the phased simulator can sometimes detect the edge and drive the outputs of the downstream Sequential one tick late.

This is because there was a gate in the `Sequential` clock sampling logic that ignored clock toggles during the `clkStable` phase.  Instead, we should immediately execute the flop if we're already in `clkStable`.

## Related Issue(s)

Fix #191 

## Testing

Added a new test where two counters are driven by an original clock and that clock divided, respectively.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
