### PR TITLE
`_Wire`s underneath `Logic`s

### DIFF
--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -48,20 +48,17 @@ class Const extends Logic {
   }
 }
 
-/// Represents a logical signal of any width which can change values.
-class Logic {
-  /// An internal counter for encouraging unique naming of unnamed signals.
-  static int _signalIdx = 0;
+/// Represents a physical wire which shares a common value with one or
+/// more [Logic]s.
+class _Wire {
+  _Wire({required this.width})
+      : _currentValue = LogicValue.filled(width, LogicValue.z);
 
-  // special quiet flag to prevent <= and < where inappropriate
-  bool _unassignable = false;
+  /// The current active value of this signal.
+  LogicValue get value => _currentValue;
 
-  /// Makes it so that this signal cannot be assigned by any full (`<=`) or
-  /// conditional (`<`) assignment.
-  void makeUnassignable() => _unassignable = true;
-
-  /// The name of this signal.
-  final String name;
+  /// The number of bits in this signal.
+  final int width;
 
   /// The current active value of this signal.
   LogicValue _currentValue;
@@ -70,52 +67,6 @@ class Logic {
   ///
   /// This is useful for detecting when to trigger an edge.
   LogicValue? _preTickValue;
-
-  /// The number of bits in this signal.
-  final int width;
-
-  /// The current active value of this signal.
-  LogicValue get value => _currentValue;
-
-  /// The current active value of this signal if it has width 1, as
-  /// a [LogicValue].
-  ///
-  /// Throws an Exception if width is not 1.
-  @Deprecated('Use `value` instead.'
-      '  Check `width` separately to confirm single-bit.')
-  LogicValue get bit => _currentValue.bit;
-
-  /// The current valid active value of this signal as an [int].
-  ///
-  /// Throws an exception if the signal is not valid or can't be represented
-  /// as an [int].
-  @Deprecated('Use value.toInt() instead.')
-  int get valueInt => value.toInt();
-
-  /// The current valid active value of this signal as a [BigInt].
-  ///
-  /// Throws an exception if the signal is not valid.
-  @Deprecated('Use value.toBigInt() instead.')
-  BigInt get valueBigInt => value.toBigInt();
-
-  /// Returns `true` iff the value of this signal is valid (no `x` or `z`).
-  bool hasValidValue() => _currentValue.isValid;
-
-  /// Returns `true` iff *all* bits of the current value are floating (`z`).
-  bool isFloating() => value.isFloating;
-
-  /// The [Logic] signal that is driving `this`, if any.
-  Logic? get srcConnection => _srcConnection;
-  Logic? _srcConnection;
-
-  /// An [Iterable] of all [Logic]s that are being directly driven by `this`.
-  Iterable<Logic> get dstConnections => UnmodifiableListView(_dstConnections);
-  final Set<Logic> _dstConnections = {};
-
-  /// Notifies `this` that [dstConnection] is now directly connected to the
-  /// output of `this`.
-  void _registerConnection(Logic dstConnection) =>
-      _dstConnections.add(dstConnection);
 
   /// A stream of [LogicValueChanged] events for every time the signal
   /// transitions at any time during a [Simulator] tick.
@@ -181,6 +132,201 @@ class Logic {
   /// value at the end of a [Simulator] tick from `1` to `0`.
   Future<LogicValueChanged> get nextNegedge => negedge.first;
 
+  /// Injects a value onto this signal in the current [Simulator] tick.
+  ///
+  /// This function calls [put()] in [Simulator.injectAction()].
+  void inject(dynamic val, {bool fill = false}) {
+    Simulator.injectAction(() => put(val, fill: fill));
+  }
+
+  /// Keeps track of whether there is an active put, to detect reentrance.
+  bool _isPutting = false;
+
+  /// Puts a value [val] onto this signal, which may or may not be picked up
+  /// for [changed] in this [Simulator] tick.
+  ///
+  /// The type of [val] should be an `int`, [BigInt], `bool`, or [LogicValue].
+  ///
+  /// This function is used for propogating glitches through connected signals.
+  /// Use this function for custom definitions of [Module] behavior.
+  ///
+  /// If [fill] is set, all bits of the signal gets set to [val], similar
+  /// to `'` in SystemVerilog.
+  void put(dynamic val, {bool fill = false}) {
+    LogicValue newValue;
+    if (val is int) {
+      if (fill) {
+        newValue = LogicValue.filled(
+            width,
+            val == 0
+                ? LogicValue.zero
+                : val == 1
+                    ? LogicValue.one
+                    : throw Exception('Only can fill 0 or 1, but saw $val.'));
+      } else {
+        newValue = LogicValue.ofInt(val, width);
+      }
+    } else if (val is BigInt) {
+      if (fill) {
+        newValue = LogicValue.filled(
+            width,
+            val == BigInt.zero
+                ? LogicValue.zero
+                : val == BigInt.one
+                    ? LogicValue.one
+                    : throw Exception('Only can fill 0 or 1, but saw $val.'));
+      } else {
+        newValue = LogicValue.ofBigInt(val, width);
+      }
+    } else if (val is bool) {
+      newValue = LogicValue.ofInt(val ? 1 : 0, width);
+    } else if (val is LogicValue) {
+      if (val.width == 1 &&
+          (val == LogicValue.x || val == LogicValue.z || fill)) {
+        newValue = LogicValue.filled(width, val);
+      } else if (fill) {
+        throw Exception(
+            'Failed to fill value with $val.  To fill, it should be 1 bit.');
+      } else {
+        newValue = val;
+      }
+    } else {
+      throw Exception('Unrecognized value "$val" to deposit on this signal. '
+          'Unknown type ${val.runtimeType} cannot be deposited.');
+    }
+
+    if (newValue.width != width) {
+      throw Exception(
+          'Updated value width mismatch.  The width of $val should be $width.');
+    }
+
+    if (_isPutting) {
+      // if this is the result of a cycle, then contention!
+      newValue = LogicValue.filled(width, LogicValue.x);
+    }
+
+    final prevValue = _currentValue;
+    _currentValue = newValue;
+
+    // sends out a glitch if the value deposited has changed
+    if (_currentValue != prevValue) {
+      _isPutting = true;
+      _glitchController.add(LogicValueChanged(_currentValue, prevValue));
+      _isPutting = false;
+    }
+  }
+
+  /// Handles the actual connection of this [Logic] to [other].
+  void _connect(_Wire other) {
+    if (other.width != width) {
+      throw Exception('Bus widths must match.'
+          ' Cannot connect $this to $other which have different widths.');
+    }
+
+    if (value != other.value) {
+      put(other.value);
+    }
+    other.glitch.listen((args) {
+      put(other.value);
+    });
+  }
+}
+
+/// Represents a logical signal of any width which can change values.
+class Logic {
+  /// An internal counter for encouraging unique naming of unnamed signals.
+  static int _signalIdx = 0;
+
+  // special quiet flag to prevent <= and < where inappropriate
+  bool _unassignable = false;
+
+  /// Makes it so that this signal cannot be assigned by any full (`<=`) or
+  /// conditional (`<`) assignment.
+  void makeUnassignable() => _unassignable = true;
+
+  /// The name of this signal.
+  final String name;
+
+  _Wire _wire;
+
+  /// The number of bits in this signal.
+  int get width => _wire.width;
+
+  /// The current active value of this signal.
+  LogicValue get value => _wire._currentValue;
+
+  /// The current active value of this signal if it has width 1, as
+  /// a [LogicValue].
+  ///
+  /// Throws an Exception if width is not 1.
+  @Deprecated('Use `value` instead.'
+      '  Check `width` separately to confirm single-bit.')
+  LogicValue get bit => value.bit;
+
+  /// The current valid active value of this signal as an [int].
+  ///
+  /// Throws an exception if the signal is not valid or can't be represented
+  /// as an [int].
+  @Deprecated('Use value.toInt() instead.')
+  int get valueInt => value.toInt();
+
+  /// The current valid active value of this signal as a [BigInt].
+  ///
+  /// Throws an exception if the signal is not valid.
+  @Deprecated('Use value.toBigInt() instead.')
+  BigInt get valueBigInt => value.toBigInt();
+
+  /// Returns `true` iff the value of this signal is valid (no `x` or `z`).
+  bool hasValidValue() => value.isValid;
+
+  /// Returns `true` iff *all* bits of the current value are floating (`z`).
+  bool isFloating() => value.isFloating;
+
+  /// The [Logic] signal that is driving `this`, if any.
+  Logic? get srcConnection => _srcConnection;
+  Logic? _srcConnection;
+
+  /// An [Iterable] of all [Logic]s that are being directly driven by `this`.
+  Iterable<Logic> get dstConnections => UnmodifiableListView(_dstConnections);
+  final Set<Logic> _dstConnections = {};
+
+  /// Notifies `this` that [dstConnection] is now directly connected to the
+  /// output of `this`.
+  void _registerConnection(Logic dstConnection) =>
+      _dstConnections.add(dstConnection);
+
+  /// A stream of [LogicValueChanged] events for every time the signal
+  /// transitions at any time during a [Simulator] tick.
+  ///
+  /// This event can occur more than once per edge, or even if there is no edge.
+  SynchronousEmitter<LogicValueChanged> get glitch => _wire.glitch;
+
+  /// A [Stream] of [LogicValueChanged] events which triggers at most once
+  /// per [Simulator] tick, iff the value of the [Logic] has changed.
+  Stream<LogicValueChanged> get changed => _wire.changed;
+
+  /// A [Stream] of [LogicValueChanged] events which triggers at most once
+  /// per [Simulator] tick, iff the value of the [Logic] has changed
+  /// from `1` to `0`.
+  Stream<LogicValueChanged> get negedge => _wire.negedge;
+
+  /// A [Stream] of [LogicValueChanged] events which triggers at most once
+  /// per [Simulator] tick, iff the value of the [Logic] has changed
+  /// from `0` to `1`.
+  Stream<LogicValueChanged> get posedge => _wire.posedge;
+
+  /// Triggers at most once, the next time that this [Logic] changes
+  /// value at the end of a [Simulator] tick.
+  Future<LogicValueChanged> get nextChanged => _wire.changed.first;
+
+  /// Triggers at most once, the next time that this [Logic] changes
+  /// value at the end of a [Simulator] tick from `0` to `1`.
+  Future<LogicValueChanged> get nextPosedge => _wire.posedge.first;
+
+  /// Triggers at most once, the next time that this [Logic] changes
+  /// value at the end of a [Simulator] tick from `1` to `0`.
+  Future<LogicValueChanged> get nextNegedge => _wire.negedge.first;
+
   /// The [Module] that this [Logic] exists within.
   ///
   /// This only gets populated after its parent [Module], if it exists,
@@ -217,9 +363,9 @@ class Logic {
   ///
   /// The default value for [width] is 1.  The [name] should be synthesizable
   /// to the desired output (e.g. SystemVerilog).
-  Logic({String? name, this.width = 1})
+  Logic({String? name, int width = 1})
       : name = name ?? 's${_signalIdx++}',
-        _currentValue = LogicValue.filled(width, LogicValue.z) {
+        _wire = _Wire(width: width) {
     if (width < 0) {
       throw Exception('Logic width must be greater than or equal to 0.');
     }
@@ -242,6 +388,24 @@ class Logic {
     }
   }
 
+  /// Injects a value onto this signal in the current [Simulator] tick.
+  ///
+  /// This function calls [put()] in [Simulator.injectAction()].
+  void inject(dynamic val, {bool fill = false}) =>
+      _wire.inject(val, fill: fill);
+
+  /// Puts a value [val] onto this signal, which may or may not be picked up
+  /// for [changed] in this [Simulator] tick.
+  ///
+  /// The type of [val] should be an `int`, [BigInt], `bool`, or [LogicValue].
+  ///
+  /// This function is used for propogating glitches through connected signals.
+  /// Use this function for custom definitions of [Module] behavior.
+  ///
+  /// If [fill] is set, all bits of the signal gets set to [val], similar
+  /// to `'` in SystemVerilog.
+  void put(dynamic val, {bool fill = false}) => _wire.put(val, fill: fill);
+
   /// Connects this [Logic] directly to [other].
   ///
   /// Every time [other] transitions (`glitch`es), this signal will transition
@@ -257,19 +421,8 @@ class Logic {
 
   /// Handles the actual connection of this [Logic] to [other].
   void _connect(Logic other) {
-    if (other.width != width) {
-      throw Exception('Bus widths must match.'
-          ' Cannot connect $this to $other which have different widths.');
-    }
-
     _unassignable = true;
-
-    if (value != other.value) {
-      put(other.value);
-    }
-    other.glitch.listen((args) {
-      put(other.value);
-    });
+    _wire._connect(other._wire);
   }
 
   /// Connects this [Logic] directly to another [Logic].
@@ -361,90 +514,6 @@ class Logic {
       return ConditionalAssign(this, other);
     } else {
       return ConditionalAssign(this, Const(other, width: width));
-    }
-  }
-
-  /// Injects a value onto this signal in the current [Simulator] tick.
-  ///
-  /// This function calls [put()] in [Simulator.injectAction()].
-  void inject(dynamic val, {bool fill = false}) {
-    Simulator.injectAction(() => put(val, fill: fill));
-  }
-
-  /// Keeps track of whether there is an active put, to detect reentrance.
-  bool _isPutting = false;
-
-  /// Puts a value [val] onto this signal, which may or may not be picked up
-  /// for [changed] in this [Simulator] tick.
-  ///
-  /// The type of [val] should be an `int`, [BigInt], `bool`, or [LogicValue].
-  ///
-  /// This function is used for propogating glitches through connected signals.
-  /// Use this function for custom definitions of [Module] behavior.
-  ///
-  /// If [fill] is set, all bits of the signal gets set to [val], similar
-  /// to `'` in SystemVerilog.
-  void put(dynamic val, {bool fill = false}) {
-    LogicValue newValue;
-    if (val is int) {
-      if (fill) {
-        newValue = LogicValue.filled(
-            width,
-            val == 0
-                ? LogicValue.zero
-                : val == 1
-                    ? LogicValue.one
-                    : throw Exception('Only can fill 0 or 1, but saw $val.'));
-      } else {
-        newValue = LogicValue.ofInt(val, width);
-      }
-    } else if (val is BigInt) {
-      if (fill) {
-        newValue = LogicValue.filled(
-            width,
-            val == BigInt.zero
-                ? LogicValue.zero
-                : val == BigInt.one
-                    ? LogicValue.one
-                    : throw Exception('Only can fill 0 or 1, but saw $val.'));
-      } else {
-        newValue = LogicValue.ofBigInt(val, width);
-      }
-    } else if (val is bool) {
-      newValue = LogicValue.ofInt(val ? 1 : 0, width);
-    } else if (val is LogicValue) {
-      if (val.width == 1 &&
-          (val == LogicValue.x || val == LogicValue.z || fill)) {
-        newValue = LogicValue.filled(width, val);
-      } else if (fill) {
-        throw Exception(
-            'Failed to fill value with $val.  To fill, it should be 1 bit.');
-      } else {
-        newValue = val;
-      }
-    } else {
-      throw Exception('Unrecognized value "$val" to deposit on this signal. '
-          'Unknown type ${val.runtimeType} cannot be deposited.');
-    }
-
-    if (newValue.width != width) {
-      throw Exception(
-          'Updated value width mismatch.  The width of $val should be $width.');
-    }
-
-    if (_isPutting) {
-      // if this is the result of a cycle, then contention!
-      newValue = LogicValue.filled(width, LogicValue.x);
-    }
-
-    final prevValue = _currentValue;
-    _currentValue = newValue;
-
-    // sends out a glitch if the value deposited has changed
-    if (_currentValue != prevValue) {
-      _isPutting = true;
-      _glitchController.add(LogicValueChanged(_currentValue, prevValue));
-      _isPutting = false;
     }
   }
 

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -26,7 +26,7 @@ class LogicValueChanged {
 
   /// Represents the event of a [Logic] changing value from [previousValue]
   /// to [newValue].
-  LogicValueChanged(this.newValue, this.previousValue);
+  const LogicValueChanged(this.newValue, this.previousValue);
 
   @override
   String toString() => '$previousValue  -->  $newValue';

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -216,20 +216,20 @@ class _Wire {
     }
   }
 
-  /// Handles the actual connection of this [Logic] to [other].
-  void _connect(_Wire other) {
-    if (other.width != width) {
-      throw Exception('Bus widths must match.'
-          ' Cannot connect $this to $other which have different widths.');
-    }
+  // /// Handles the actual connection of this [Logic] to [other].
+  // void _connect(_Wire other) {
+  //   if (other.width != width) {
+  //     throw Exception('Bus widths must match.'
+  //         ' Cannot connect $this to $other which have different widths.');
+  //   }
 
-    if (value != other.value) {
-      put(other.value);
-    }
-    other.glitch.listen((args) {
-      put(other.value);
-    });
-  }
+  //   if (value != other.value) {
+  //     put(other.value);
+  //   }
+  //   other.glitch.listen((args) {
+  //     put(other.value);
+  //   });
+  // }
 }
 
 /// Represents a logical signal of any width which can change values.
@@ -422,7 +422,9 @@ class Logic {
   /// Handles the actual connection of this [Logic] to [other].
   void _connect(Logic other) {
     _unassignable = true;
-    _wire._connect(other._wire);
+    other._wire._glitchController.emitter
+        .adopt(_wire._glitchController.emitter);
+    _wire = other._wire;
   }
 
   /// Connects this [Logic] directly to another [Logic].

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -351,6 +351,7 @@ class Sequential extends _Always {
   void _execute() {
     var anyClkInvalid = false;
     var anyClkPosedge = false;
+    // TODO(mkorbel1): review implementing this without loop (maybe not, maybe zip)
     for (var i = 0; i < _clks.length; i++) {
       // if the pre-tick value is null, then it should have the same value as
       // it currently does

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -351,7 +351,7 @@ class Sequential extends _Always {
   void _execute() {
     var anyClkInvalid = false;
     var anyClkPosedge = false;
-    // TODO(mkorbel1): review implementing this without loop (maybe not, maybe zip)
+
     for (var i = 0; i < _clks.length; i++) {
       // if the pre-tick value is null, then it should have the same value as
       // it currently does

--- a/lib/src/utilities/synchronous_propagator.dart
+++ b/lib/src/utilities/synchronous_propagator.dart
@@ -45,12 +45,24 @@ class SynchronousEmitter<T> {
   bool get isEmitting => _isEmitting;
   bool _isEmitting = false;
 
+  bool _adopted = false;
+
   /// Sends out [t] to all listeners.
   void _propagate(T t) {
     _isEmitting = true;
     for (final action in _actions) {
       action(t);
     }
+    // TODO(mkorbel1): put some assertion/counter in here to see if we're hitting this still?
+    if (_adopted) {
+      print('reran adopted!');
+    }
     _isEmitting = false;
+  }
+
+  void adopt(SynchronousEmitter<T> other) {
+    _actions.addAll(other._actions);
+    other._actions.clear();
+    other._adopted = true;
   }
 }

--- a/lib/src/utilities/synchronous_propagator.dart
+++ b/lib/src/utilities/synchronous_propagator.dart
@@ -45,24 +45,22 @@ class SynchronousEmitter<T> {
   bool get isEmitting => _isEmitting;
   bool _isEmitting = false;
 
-  bool _adopted = false;
-
   /// Sends out [t] to all listeners.
   void _propagate(T t) {
     _isEmitting = true;
     for (final action in _actions) {
       action(t);
     }
-    // TODO(mkorbel1): put some assertion/counter in here to see if we're hitting this still?
-    if (_adopted) {
-      print('reran adopted!');
-    }
     _isEmitting = false;
   }
 
+  /// Tells this emitter to adopt all behavior of [other].
+  ///
+  /// Tells this emitter to perform all the actions of [other] each
+  /// time this would propagate.  Also clears all actions from [other]
+  /// so that it will not execute anything in the future.
   void adopt(SynchronousEmitter<T> other) {
     _actions.addAll(other._actions);
     other._actions.clear();
-    other._adopted = true;
   }
 }

--- a/lib/src/utilities/synchronous_propagator.dart
+++ b/lib/src/utilities/synchronous_propagator.dart
@@ -8,6 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
+/***/
+
 /// A controller for a [SynchronousEmitter] that allows for
 /// adding of events of type [T] to be emitted.
 class SynchronousPropagator<T> {

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -132,4 +132,41 @@ void main() {
 
     expect(detectedAChanged, isTrue);
   });
+
+  test('chain of reconnected signals still changes', () async {
+    final a = Logic(name: 'a');
+    final b = Logic(name: 'b');
+    final c = Logic(name: 'c');
+
+    var detectedAChanged = false;
+    a.changed.listen((event) {
+      detectedAChanged = true;
+    });
+
+    a <= b;
+    b <= c;
+
+    Simulator.registerAction(100, () {
+      c.put(1);
+    });
+
+    await Simulator.run();
+
+    expect(detectedAChanged, isTrue);
+  });
+
+  test('chain of reconnected signals still glitches', () async {
+    final a = Logic(name: 'a');
+    final b = Logic(name: 'b');
+    final c = Logic(name: 'c');
+
+    a.put(0);
+
+    a <= b;
+    b <= c;
+
+    c.put(1);
+
+    expect(a.value, equals(LogicValue.one));
+  });
 }

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -112,4 +112,6 @@ void main() {
 
     expect(qHadPosedge, equals(true));
   });
+
+  // TODO(mkorbel1): add tests that after merging two wires, changed and glitch and stuff still works!
 }

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -113,5 +113,23 @@ void main() {
     expect(qHadPosedge, equals(true));
   });
 
-  // TODO(mkorbel1): add tests that after merging two wires, changed and glitch and stuff still works!
+  test('reconnected signal still hits changed events', () async {
+    final a = Logic(name: 'a');
+    final b = Logic(name: 'b');
+
+    var detectedAChanged = false;
+    a.changed.listen((event) {
+      detectedAChanged = true;
+    });
+
+    a <= b;
+
+    Simulator.registerAction(100, () {
+      b.put(1);
+    });
+
+    await Simulator.run();
+
+    expect(detectedAChanged, isTrue);
+  });
 }

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -7,10 +7,8 @@
 /// 2021 May 10
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
+
 import 'dart:async';
-
-// import 'dart:io';
-
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
@@ -50,7 +48,8 @@ void main() {
       final counter = Counter(Logic(), reset);
       await counter.build();
       // WaveDumper(counter);
-      // File('tmp_counter.sv').writeAsStringSync(counter.generateSynth());
+
+      // TODO (mkorbel1): does this need to wait 1 timestep even?
 
       // check that 1 timestep after reset, the value has reset properly
       unawaited(reset.nextPosedge

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -49,13 +49,8 @@ void main() {
       await counter.build();
       // WaveDumper(counter);
 
-      // TODO (mkorbel1): does this need to wait 1 timestep even?
-
-      // check that 1 timestep after reset, the value has reset properly
       unawaited(reset.nextPosedge
-          .then((value) => Simulator.registerAction(Simulator.time + 1, () {
-                expect(counter.val.value.toInt(), equals(0));
-              })));
+          .then((value) => expect(counter.val.value.toInt(), equals(0))));
 
       final vectors = [
         Vector({'en': 0, 'reset': 0}, {}),

--- a/test/long_chain_test.dart
+++ b/test/long_chain_test.dart
@@ -1,0 +1,39 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// long_chain_test.dart
+/// Tests with long chains of combinational logic.
+///
+/// 2022 November 8
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/modules/passthrough.dart';
+import 'package:test/test.dart';
+
+class LongChain extends Module {
+  final int length;
+
+  Logic get chainOut => output('chainOut');
+
+  LongChain(Logic chainIn, {this.length = 1000}) : super(name: 'longChain') {
+    chainIn = addInput('chainIn', chainIn);
+    var intermediate = chainIn;
+    for (var i = 0; i < length; i++) {
+      intermediate = ~Passthrough(intermediate).out;
+    }
+    addOutput('chainOut') <= intermediate;
+  }
+}
+
+void main() {
+  test('long chain of combinational logic and modules', () async {
+    final chainIn = Logic(name: 'chainIn');
+    final chain = LongChain(chainIn);
+    await chain.build();
+
+    chainIn.put(0);
+    expect(chain.chainOut.value.toInt(), equals(chain.length % 2));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Refactored `Logic` to hold its value on a `_Wire` which can be shared across many `Logic`s that are connected to each other.  This has two big benefits:
- Improved simulation performance by reducing the number of `glitch`es that need to propagate during combinational logic
- Decreases the stack requirements to help mitigate this issue: #194

## Related Issue(s)

Helps mitigate #194

## Testing

- Added new tests where corner cases could have been introduced around combinational logic propagation and edge listening.
- Ran the (limited) existing benchmark suite and observed slight performance improvement.  The existing pipeline benchmark is not sufficient probably to show the true benefit for larger designs, though.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Sort of, `posedge` and `negedge` will now throw an `Exception` if the width is not 1.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
