### PR TITLE
Fix bugs related to module naming and instantiation

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -407,6 +407,9 @@ abstract class Module {
     } else {
       if (!dontAddSignal && !isOutput(signal) && subModule == null) {
         _addInternalSignal(signal);
+        for (final dstConnection in signal.dstConnections) {
+          await _traceInputForModuleContents(dstConnection);
+        }
       }
       if (signal.srcConnection != null) {
         await _traceOutputForModuleContents(signal.srcConnection!);

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -298,19 +298,21 @@ class _SynthModuleDefinition {
   @override
   String toString() => "module name: '${module.name}'";
 
-  late final Uniquifier _synthLogicNameUniquifier;
+  /// Used to uniquify any identifiers, including signal names
+  /// and module instances.
+  late final Uniquifier _synthInstantiationNameUniquifier;
+
   String _getUniqueSynthLogicName(String? initialName, bool portName) {
     if (portName && initialName == null) {
       throw Exception('Port name cannot be null.');
     }
-    return _synthLogicNameUniquifier.getUniqueName(
+    return _synthInstantiationNameUniquifier.getUniqueName(
         initialName: initialName, reserved: portName);
   }
 
-  final Uniquifier _synthSubModuleInstantiationNameUniquifier = Uniquifier();
   String _getUniqueSynthSubModuleInstantiationName(
           String? initialName, bool reserved) =>
-      _synthSubModuleInstantiationNameUniquifier.getUniqueName(
+      _synthInstantiationNameUniquifier.getUniqueName(
           initialName: initialName, nullStarter: 'm', reserved: reserved);
 
   _SynthLogic? _getSynthLogic(Logic? logic, bool allowPortName) {
@@ -328,7 +330,7 @@ class _SynthModuleDefinition {
   }
 
   _SynthModuleDefinition(this.module) {
-    _synthLogicNameUniquifier = Uniquifier(
+    _synthInstantiationNameUniquifier = Uniquifier(
         reservedNames: {...module.inputs.keys, ...module.outputs.keys});
 
     // start by traversing output signals

--- a/test/multimodule5_test.dart
+++ b/test/multimodule5_test.dart
@@ -1,0 +1,39 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// multimodule5_test.dart
+/// Unit tests for a hierarchy of multiple modules and multiple instantiation
+/// (another type)
+///
+/// 2022 November 22
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/modules/passthrough.dart';
+import 'package:test/test.dart';
+
+class TopModule extends Module {
+  TopModule(Logic inPort) {
+    inPort = addInput('inPort', inPort);
+
+    final internalNet = Logic(name: 'internalNet');
+    final outPort = addOutput('outPort');
+
+    Combinational([internalNet < inPort]);
+    Combinational([outPort < internalNet]);
+
+    Passthrough(internalNet);
+  }
+}
+
+void main() {
+  test('multimodules5', () async {
+    final mod = TopModule(Logic());
+    await mod.build();
+
+    final sv = mod.generateSynth();
+
+    expect(sv, contains('Passthrough'));
+  });
+}

--- a/test/name_test.dart
+++ b/test/name_test.dart
@@ -71,16 +71,6 @@ class RenameableModule extends Module {
   }
 }
 
-//TODO: test conflicts:
-// - inputName, outputName, internal signal name, module instance name, module definition name
-// test list
-// -port name != internal signal name
-// -port name != module instance name [internal and top]
-// -port_name != module definition name [internal and top]
-// -internal signal name != module instance name [internal and top]
-// -internal signal name != module definition name [internal and top]
-// -module definition name != module instance name
-
 enum NameType {
   inputPort,
   outputPort,
@@ -113,7 +103,6 @@ void main() {
     }
 
     Future<void> runTestGen(Map<NameType, String> names) async =>
-        //TODO: add a check that verilog has something in it!
         runTest(RenameableModule(
           Logic(name: names[NameType.inputPort]),
           outputPortName: names[NameType.outputPort]!,

--- a/test/name_test.dart
+++ b/test/name_test.dart
@@ -64,7 +64,7 @@ class RenameableModule extends Module {
     SpeciallyNamedModule(
       ~internalSignal,
       true,
-      true,
+      false,
       name: internalModuleInstanceName,
       definitionName: internalModuleDefinitionName,
     );
@@ -193,7 +193,7 @@ void main() {
       final mod = TopModule(Logic(), false, false);
       await mod.build();
       final sv = mod.generateSynth();
-      print(sv);
+
       expect(sv, contains('specialInstanceName('));
       expect(sv, contains('specialInstanceName_0('));
     });


### PR DESCRIPTION

## Description & Motivation

- Fixed a bug where signal names and module instance names could conflict.
- Fixed a bug where in some cases modules might not be properly detected as sub-modules.

## Related Issue(s)

Fix #205 

## Testing

- Added a new test to cover the sub-module bug
- Added a new suite of tests covering combinations of names for input ports, output ports, internal signals, internal module instance names, internal module definition names, containing module definition names, and containing module instance names

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
