### PR TITLE
Allow constants for modulo and shift operations on `Logic`

### DIFF
--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -311,7 +311,7 @@ class Logic {
   Logic operator /(dynamic other) => Divide(this, other).out;
 
   /// Modulo operation.
-  Logic operator %(Logic other) => Modulo(this, other).out;
+  Logic operator %(dynamic other) => Modulo(this, other).out;
 
   /// Arithmetic right-shift.
   Logic operator >>(Logic other) => ARShift(this, other).out;

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -314,13 +314,13 @@ class Logic {
   Logic operator %(dynamic other) => Modulo(this, other).out;
 
   /// Arithmetic right-shift.
-  Logic operator >>(Logic other) => ARShift(this, other).out;
+  Logic operator >>(dynamic other) => ARShift(this, other).out;
 
   /// Logical left-shift.
-  Logic operator <<(Logic other) => LShift(this, other).out;
+  Logic operator <<(dynamic other) => LShift(this, other).out;
 
   /// Logical right-shift.
-  Logic operator >>>(Logic other) => RShift(this, other).out;
+  Logic operator >>>(dynamic other) => RShift(this, other).out;
 
   /// Unary AND.
   Logic and() => AndUnary(this).out;

--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -530,7 +530,7 @@ class XorUnary extends _OneInputUnaryGate {
 /// A logical right-shift module.
 class RShift extends _ShiftGate {
   /// Calculates the value of [in_] shifted right (logically) by [shiftAmount].
-  RShift(Logic in_, Logic shiftAmount, {String name = 'rshift'})
+  RShift(Logic in_, dynamic shiftAmount, {String name = 'rshift'})
       : // Note: >>> vs >> is backwards for SystemVerilog and Dart
         super((a, shamt) => a >>> shamt, '>>', in_, shiftAmount, name: name);
 }
@@ -539,7 +539,7 @@ class RShift extends _ShiftGate {
 class ARShift extends _ShiftGate {
   /// Calculates the value of [in_] shifted right (arithmetically) by
   /// [shiftAmount].
-  ARShift(Logic in_, Logic shiftAmount, {String name = 'arshift'})
+  ARShift(Logic in_, dynamic shiftAmount, {String name = 'arshift'})
       : // Note: >>> vs >> is backwards for SystemVerilog and Dart
         super((a, shamt) => a >> shamt, '>>>', in_, shiftAmount,
             name: name, signed: true);
@@ -548,7 +548,7 @@ class ARShift extends _ShiftGate {
 /// A logical left-shift module.
 class LShift extends _ShiftGate {
   /// Calculates the value of [in_] shifted left by [shiftAmount].
-  LShift(Logic in_, Logic shiftAmount, {String name = 'lshift'})
+  LShift(Logic in_, dynamic shiftAmount, {String name = 'lshift'})
       : super((a, shamt) => a << shamt, '<<', in_, shiftAmount, name: name);
 }
 

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -12,21 +12,8 @@ import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
 class MathTestModule extends Module {
-  Logic get a => input('a');
-  Logic get b => input('b');
-
-  Logic get aPlusB => output('a_plus_b');
-  Logic get aMinusB => output('a_minus_b');
-  Logic get aTimesB => output('a_times_b');
-  Logic get aDividedByB => output('a_dividedby_b');
-  Logic get aModuloB => output('a_modulo_b');
-
-  Logic get aPlusConst => output('a_plus_const');
-  Logic get aMinusConst => output('a_minus_const');
-  Logic get aTimesConst => output('a_times_const');
-  Logic get aDividedByConst => output('a_dividedby_const');
-
   final int c;
+
   MathTestModule(Logic a, Logic b, {this.c = 5})
       : super(name: 'gatetestmodule') {
     if (a.width != b.width) {
@@ -40,22 +27,40 @@ class MathTestModule extends Module {
     final aTimesB = addOutput('a_times_b', width: a.width);
     final aDividedByB = addOutput('a_dividedby_b', width: a.width);
     final aModuloB = addOutput('a_modulo_b', width: a.width);
+    final aModuleConst = addOutput('a_modulo_const', width: a.width);
 
     final aPlusConst = addOutput('a_plus_const', width: a.width);
     final aMinusConst = addOutput('a_minus_const', width: a.width);
     final aTimesConst = addOutput('a_times_const', width: a.width);
     final aDividedByConst = addOutput('a_dividedby_const', width: a.width);
 
+    final aSlB = addOutput('a_sl_b', width: a.width);
+    final aSrlB = addOutput('a_srl_b', width: a.width);
+    final aSraB = addOutput('a_sra_b', width: a.width);
+
+    final aSlConst = addOutput('a_sl_const', width: a.width);
+    final aSrlConst = addOutput('a_srl_const', width: a.width);
+    final aSraConst = addOutput('a_sra_const', width: a.width);
+
     aPlusB <= a + b;
     aMinusB <= a - b;
     aTimesB <= a * b;
     aDividedByB <= a / b;
     aModuloB <= a % b;
+    aModuleConst <= a % c;
 
     aPlusConst <= a + c;
     aMinusConst <= a - c;
     aTimesConst <= a * c;
     aDividedByConst <= a / c;
+
+    aSlB <= a << b;
+    aSrlB <= a >>> b;
+    aSraB <= a >> b;
+
+    aSlConst <= a << c;
+    aSrlConst <= a >>> c;
+    aSraConst <= a >> c;
   }
 }
 
@@ -75,12 +80,27 @@ void main() {
       'a_minus_const': 8,
       'a_times_const': 8,
       'a_dividedby_const': 8,
+      'a_modulo_const': 8,
+      'a_sl_b': 8,
+      'a_srl_b': 8,
+      'a_sra_b': 8,
+      'a_sl_const': 8,
+      'a_srl_const': 8,
+      'a_sra_const': 8,
     };
 
-    test('addition', () async {
+    Future<void> runMathVectors(List<Vector> vectors) async {
       final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
       await gtm.build();
-      final vectors = [
+      await SimCompare.checkFunctionalVector(gtm, vectors);
+      final simResult = SimCompare.iverilogVector(
+          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
+          signalToWidthMap: signalToWidthMap);
+      expect(simResult, equals(true));
+    }
+
+    test('addition', () async {
+      await runMathVectors([
         Vector({'a': 0, 'b': 0}, {'a_plus_b': 0}),
         Vector({'a': 0, 'b': 1}, {'a_plus_b': 1}),
         Vector({'a': 1, 'b': 0}, {'a_plus_b': 1}),
@@ -89,80 +109,72 @@ void main() {
         Vector({'a': 6}, {'a_plus_const': 11}),
         // Vector({'a': -6, 'b': 7}, {'a_plus_b': 1}),
         // Vector({'a': -6, 'b': 2}, {'a_plus_b': -4}),
-      ];
-      await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(
-          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap);
-      expect(simResult, equals(true));
+      ]);
     });
 
     test('subtraction', () async {
-      final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
-      await gtm.build();
-      final vectors = [
+      await runMathVectors([
         Vector({'a': 0, 'b': 0}, {'a_minus_b': 0}),
         Vector({'a': 1, 'b': 0}, {'a_minus_b': 1}),
         Vector({'a': 0xff, 'b': 0xff}, {'a_minus_b': 0}),
         Vector({'a': 12, 'b': 5}, {'a_minus_b': 7}),
         Vector({'a': 6}, {'a_minus_const': 1}),
-      ];
-      await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(
-          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap);
-      expect(simResult, equals(true));
+      ]);
     });
 
     test('multiplication', () async {
-      final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
-      await gtm.build();
-      final vectors = [
+      await runMathVectors([
         Vector({'a': 0, 'b': 0}, {'a_times_b': 0}),
         Vector({'a': 1, 'b': 1}, {'a_times_b': 1}),
         Vector({'a': 3, 'b': 4}, {'a_times_b': 12}),
         Vector({'a': 6}, {'a_times_const': 30}),
-      ];
-      await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(
-          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap);
-      expect(simResult, equals(true));
+      ]);
     });
 
     test('division', () async {
-      final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
-      await gtm.build();
-      final vectors = [
+      await runMathVectors([
         Vector({'a': 0, 'b': 0}, {'a_dividedby_b': LogicValue.x}),
         Vector({'a': 1, 'b': 0}, {'a_dividedby_b': LogicValue.x}),
         Vector({'a': 4, 'b': 2}, {'a_dividedby_b': 2}),
         Vector({'a': 5, 'b': 2}, {'a_dividedby_b': 2}),
         Vector({'a': 9, 'b': 3}, {'a_dividedby_b': 3}),
         Vector({'a': 6}, {'a_dividedby_const': 1}),
-      ];
-      await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(
-          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap);
-      expect(simResult, equals(true));
+      ]);
     });
 
     test('modulo', () async {
-      final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
-      await gtm.build();
-      final vectors = [
+      await runMathVectors([
         Vector({'a': 0, 'b': 0}, {'a_modulo_b': LogicValue.x}),
         Vector({'a': 1, 'b': 0}, {'a_modulo_b': LogicValue.x}),
         Vector({'a': 4, 'b': 2}, {'a_modulo_b': 0}),
         Vector({'a': 5, 'b': 2}, {'a_modulo_b': 1}),
         Vector({'a': 9, 'b': 3}, {'a_modulo_b': 0}),
-      ];
-      await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(
-          gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
-          signalToWidthMap: signalToWidthMap);
-      expect(simResult, equals(true));
+        Vector({'a': 11}, {'a_modulo_const': 1})
+      ]);
+    });
+
+    test('shift left', () async {
+      await runMathVectors([
+        Vector({'a': 0xf, 'b': 0}, {'a_sl_b': 0xf}),
+        Vector({'a': 0xf, 'b': 2}, {'a_sl_b': 0xf << 2}),
+        Vector({'a': 0x2}, {'a_sl_const': 0x2 << 5}),
+      ]);
+    });
+
+    test('shift right logical', () async {
+      await runMathVectors([
+        Vector({'a': 0xf, 'b': 0}, {'a_srl_b': 0xf}),
+        Vector({'a': 0xff, 'b': 2}, {'a_srl_b': 0x3f}),
+        Vector({'a': bin('11000000')}, {'a_srl_const': bin('00000110')}),
+      ]);
+    });
+
+    test('shift right arithmetic', () async {
+      await runMathVectors([
+        Vector({'a': 0xf, 'b': 0}, {'a_sra_b': 0xf}),
+        Vector({'a': 0xfe, 'b': 2}, {'a_sra_b': 0xff}),
+        Vector({'a': bin('11000000')}, {'a_sra_const': bin('11111110')}),
+      ]);
     });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Most math operations supported a `dynamic` type to be operated on a `Logic`, but modulo and shift operations (`%`, `>>`, `<<`, `>>>`) only accepted other `Logic`s, which was inconvenient because it requires creating of a `Const` to use them.

This change allows `dynamic` on all these operations as well.

This also closes a testing hole around shift operations.

## Related Issue(s)

Close #170 via testing the fix that has been in there since #174

## Testing

Added tests for all new functionality, as well as missing tests around shift operations

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, this loosens the API but is completely backwards compatible

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
