### PR TITLE
Fix typo on modulo test

### DIFF
--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -27,7 +27,7 @@ class MathTestModule extends Module {
     final aTimesB = addOutput('a_times_b', width: a.width);
     final aDividedByB = addOutput('a_dividedby_b', width: a.width);
     final aModuloB = addOutput('a_modulo_b', width: a.width);
-    final aModuleConst = addOutput('a_modulo_const', width: a.width);
+    final aModuloConst = addOutput('a_modulo_const', width: a.width);
 
     final aPlusConst = addOutput('a_plus_const', width: a.width);
     final aMinusConst = addOutput('a_minus_const', width: a.width);
@@ -47,7 +47,7 @@ class MathTestModule extends Module {
     aTimesB <= a * b;
     aDividedByB <= a / b;
     aModuloB <= a % b;
-    aModuleConst <= a % c;
+    aModuloConst <= a % c;
 
     aPlusConst <= a + c;
     aMinusConst <= a - c;


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Typo in #208, `aModuleConst` -> `aModuloConst`

## Related Issue(s)

None

## Testing

Fixed existing test, functionally the same

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No