### PR TITLE
[Issue-12] simpler constructor of simple control blocks

### DIFF
--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -917,7 +917,7 @@ ${padding}end ''');
 /// Represents a block of code to be conditionally executed, like `if`/`else`.
 class If extends Conditional {
   /// [Conditional]s to be executed if [condition] is true.
-  late final List<Conditional> then;
+  final List<Conditional> then;
 
   /// [Conditional]s to be executed if [condition] is not true.
   final List<Conditional> orElse;
@@ -928,12 +928,13 @@ class If extends Conditional {
   /// If [condition] is 1, then [then] executes, otherwise [orElse] is executed.
   If(this.condition, {this.then = const [], this.orElse = const []});
 
-  /// If [condition] is 1, then [sig] is excutes.
+  /// If [condition] is 1, then [then] is excutes,
+  /// otherwise [orElse] is executed.
   ///
-  /// Use this constructor when you only have a single condition.
-  If.s(this.condition, Conditional sig, [this.orElse = const []]) {
-    then = [sig];
-  }
+  /// Use this constructor when you only have a single [then] condition.
+  /// An optional [orElse] condition can be passed.
+  If.s(Logic condition, Conditional then, [Conditional? orElse])
+      : this(condition, then: [then], orElse: orElse == null ? [] : [orElse]);
 
   @override
   List<Logic> getReceivers() {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -796,6 +796,11 @@ class ElseIf {
 
   /// If [condition] is 1, then [then] will be executed.
   ElseIf(this.condition, this.then);
+
+  /// If [condition] is 1, then [then] will be executed.
+  ///
+  /// Use this constructor when you only have a single [then] condition.
+  ElseIf.s(Logic condition, Conditional then) : this(condition, [then]);
 }
 
 /// A conditional block to execute only if `condition` is satisified.

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -917,7 +917,7 @@ ${padding}end ''');
 /// Represents a block of code to be conditionally executed, like `if`/`else`.
 class If extends Conditional {
   /// [Conditional]s to be executed if [condition] is true.
-  final List<Conditional> then;
+  late final List<Conditional> then;
 
   /// [Conditional]s to be executed if [condition] is not true.
   final List<Conditional> orElse;
@@ -927,6 +927,13 @@ class If extends Conditional {
 
   /// If [condition] is 1, then [then] executes, otherwise [orElse] is executed.
   If(this.condition, {this.then = const [], this.orElse = const []});
+
+  /// If [condition] is 1, then [sig] is excutes.
+  ///
+  /// Use this constructor when you only have a single condition.
+  If.s(this.condition, Conditional sig, [this.orElse = const []]) {
+    then = [sig];
+  }
 
   @override
   List<Logic> getReceivers() {

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -80,6 +80,19 @@ class IfBlockModule extends Module {
   }
 }
 
+class SingleIfBlockModule extends Module {
+  SingleIfBlockModule(Logic a) : super(name: 'singleifblockmodule') {
+    a = addInput('a', a);
+    final c = addOutput('c');
+
+    Combinational([
+      IfBlock([
+        Iff.s(a, c < 1),
+      ])
+    ]);
+  }
+}
+
 class ElseIfBlockModule extends Module {
   ElseIfBlockModule(Logic a, Logic b) : super(name: 'ifblockmodule') {
     a = addInput('a', a);
@@ -91,6 +104,21 @@ class ElseIfBlockModule extends Module {
       IfBlock([
         ElseIf(a & ~b, [c < 1, d < 0]),
         ElseIf(b & ~a, [c < 1, d < 0]),
+        Else([c < 0, d < 1])
+      ])
+    ]);
+  }
+}
+
+class SingleElseIfBlockModule extends Module {
+  SingleElseIfBlockModule(Logic a) : super(name: 'singleifblockmodule') {
+    a = addInput('a', a);
+    final c = addOutput('c');
+    final d = addOutput('d');
+
+    Combinational([
+      IfBlock([
+        ElseIf.s(a, c < 1),
         Else([c < 0, d < 1])
       ])
     ]);
@@ -235,6 +263,18 @@ void main() {
       expect(simResult, equals(true));
     });
 
+    test('single iffblock comb', () async {
+      final mod = SingleIfBlockModule(Logic());
+      await mod.build();
+      final vectors = [
+        Vector({'a': 1}, {'c': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      final simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors);
+      expect(simResult, equals(true));
+    });
+
     test('elseifblock comb', () async {
       final mod = ElseIfBlockModule(Logic(), Logic());
       await mod.build();
@@ -243,6 +283,19 @@ void main() {
         Vector({'a': 0, 'b': 1}, {'c': 1, 'd': 0}),
         Vector({'a': 1, 'b': 0}, {'c': 1, 'd': 0}),
         Vector({'a': 1, 'b': 1}, {'c': 0, 'd': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      final simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors);
+      expect(simResult, equals(true));
+    });
+
+    test('single elseifblock comb', () async {
+      final mod = SingleElseIfBlockModule(Logic());
+      await mod.build();
+      final vectors = [
+        Vector({'a': 1}, {'c': 1}),
+        Vector({'a': 0}, {'c': 0, 'd': 1}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
       final simResult = SimCompare.iverilogVector(

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -160,21 +160,18 @@ class SequentialModule extends Module {
 }
 
 class SingleIfModule extends Module {
-  SingleIfModule(Logic a, Logic b, Logic d) : super(name: 'combmodule') {
+  SingleIfModule(Logic a, Logic b) : super(name: 'combmodule') {
     a = addInput('a', a);
     b = addInput('b', b);
-    // final y = addOutput('y');
-    // final z = addOutput('z');
-    // final x = addOutput('x');
 
-    // d = addInput('d', d, width: d.width);
-    final q = addOutput('q', width: d.width);
+    final q = addOutput('q');
+    final x = addOutput('x');
 
-    Combinational([
-      If(a, then: [
-        q < 1,
-      ])
-    ]);
+    Combinational(
+      [
+        If.s(a, q < 1, [x < 1]),
+      ],
+    );
   }
 }
 
@@ -274,16 +271,16 @@ void main() {
 
     test(
         'should return true on simcompare when '
-        'there is only one conditional in single costructor.', () async {
-      final mod = SingleIfModule(Logic(), Logic(), Logic(width: 10));
+        'execute if.s() for single if...else conditional.', () async {
+      final mod = SingleIfModule(Logic(), Logic());
       await mod.build();
       final vectors = [
         Vector({'a': 1}, {'q': 1}),
+        Vector({'a': 0}, {'x': 1}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
       final simResult = SimCompare.iverilogVector(
-          mod.generateSynth(), mod.runtimeType.toString(), vectors,
-          signalToWidthMap: {'d': 10, 'q': 10});
+          mod.generateSynth(), mod.runtimeType.toString(), vectors);
       expect(simResult, equals(true));
     });
   });

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -252,5 +252,10 @@ void main() {
           signalToWidthMap: {'d': 8, 'q': 8});
       expect(simResult, equals(true));
     });
+
+    test(
+        'should return true on single constructor usage when '
+        'there is only one conditionals',
+        () async {});
   });
 }

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -160,7 +160,21 @@ class SequentialModule extends Module {
 }
 
 class SingleIfModule extends Module {
-  SingleIfModule(Logic a, Logic b) : super(name: 'combmodule') {
+  SingleIfModule(Logic a) : super(name: 'combmodule') {
+    a = addInput('a', a);
+
+    final q = addOutput('q');
+
+    Combinational(
+      [
+        If.s(a, q < 1),
+      ],
+    );
+  }
+}
+
+class SingleIfOrElseModule extends Module {
+  SingleIfOrElseModule(Logic a, Logic b) : super(name: 'combmodule') {
     a = addInput('a', a);
     b = addInput('b', b);
 
@@ -169,7 +183,7 @@ class SingleIfModule extends Module {
 
     Combinational(
       [
-        If.s(a, q < 1, [x < 1]),
+        If.s(a, q < 1, x < 1),
       ],
     );
   }
@@ -271,8 +285,24 @@ void main() {
 
     test(
         'should return true on simcompare when '
-        'execute if.s() for single if...else conditional.', () async {
-      final mod = SingleIfModule(Logic(), Logic());
+        'execute if.s() for single if...else conditional without orElse.',
+        () async {
+      final mod = SingleIfModule(Logic());
+      await mod.build();
+      final vectors = [
+        Vector({'a': 1}, {'q': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      final simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors);
+      expect(simResult, equals(true));
+    });
+
+    test(
+        'should return true on simcompare when '
+        'execute if.s() for single if...else conditional with orElse.',
+        () async {
+      final mod = SingleIfOrElseModule(Logic(), Logic());
       await mod.build();
       final vectors = [
         Vector({'a': 1}, {'q': 1}),

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -159,6 +159,25 @@ class SequentialModule extends Module {
   }
 }
 
+class SingleIfModule extends Module {
+  SingleIfModule(Logic a, Logic b, Logic d) : super(name: 'combmodule') {
+    a = addInput('a', a);
+    b = addInput('b', b);
+    // final y = addOutput('y');
+    // final z = addOutput('z');
+    // final x = addOutput('x');
+
+    // d = addInput('d', d, width: d.width);
+    final q = addOutput('q', width: d.width);
+
+    Combinational([
+      If(a, then: [
+        q < 1,
+      ])
+    ]);
+  }
+}
+
 void main() {
   tearDown(Simulator.reset);
 
@@ -254,8 +273,18 @@ void main() {
     });
 
     test(
-        'should return true on single constructor usage when '
-        'there is only one conditionals',
-        () async {});
+        'should return true on simcompare when '
+        'there is only one conditional in single costructor.', () async {
+      final mod = SingleIfModule(Logic(), Logic(), Logic(width: 10));
+      await mod.build();
+      final vectors = [
+        Vector({'a': 1}, {'q': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      final simResult = SimCompare.iverilogVector(
+          mod.generateSynth(), mod.runtimeType.toString(), vectors,
+          signalToWidthMap: {'d': 10, 'q': 10});
+      expect(simResult, equals(true));
+    });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The default implementation for If, Iff, etc. take lists of Conditionals as inputs, which can be excessively verbose in cases where there is only one Conditional. Adding a special constructor (e.g. something like Iff.s) which takes a single Conditional could make simple code look cleaner.

## Related Issue(s)

Issue #12 

## Testing

Added a new unit test that should return ``true`` if single conditional constructor is used.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Nope.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Yes. 
