### PR TITLE
Replace awkward map+reduce chain with smart literal

### DIFF
--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -122,11 +122,11 @@ class Pipeline {
 
     for (var stageIndex = 0; stageIndex < _numStages; stageIndex++) {
       Combinational([
-        ..._registeredLogics
-            .map((logic) => get(logic, stageIndex) < _i(logic, stageIndex)),
+        for (Logic l in _registeredLogics)
+          get(l, stageIndex) < _i(l, stageIndex),
         ...combMiddles[stageIndex],
-        ..._registeredLogics
-            .map((logic) => _o(logic, stageIndex) < get(logic, stageIndex)),
+        for (Logic l in _registeredLogics)
+          _o(l, stageIndex) < get(l, stageIndex),
       ], name: 'comb_stage$stageIndex');
     }
   }

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -162,10 +162,10 @@ abstract class SimCompare {
       }
     }
 
-    final allSignals = vectors
-        .map((e) => [...e.inputValues.keys, ...e.expectedOutputValues.keys])
-        .reduce((a, b) => [...a, ...b])
-        .toSet();
+    final allSignals = <String>{
+      for (final e in vectors) ...e.inputValues.keys,
+      for (final e in vectors) ...e.expectedOutputValues.keys,
+    };
     final localDeclarations =
         allSignals.map((e) => 'logic ${signalDeclaration(e)};').join('\n');
     final moduleConnections = allSignals.map((e) => '.$e($e)').join(', ');


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Saw some awkward code, wanted to cleanup

## Related Issue(s)

None

## Testing

Existing tests should valid correctness of this code.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Completely backwards compatible

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No need.