### PR TITLE
Optimize LogicValue operations to avoid Strings where possible

### DIFF
--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -8,8 +8,10 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
+import 'logic_value_of_benchmark.dart';
 import 'pipeline_benchmark.dart';
 
 void main() async {
   await PipelineBenchmark().report();
+  await LogicValueOfBenchmark().report();
 }

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -8,10 +8,12 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
+import 'byte_enable_benchmark.dart';
 import 'logic_value_of_benchmark.dart';
 import 'pipeline_benchmark.dart';
 
 void main() async {
   await PipelineBenchmark().report();
-  await LogicValueOfBenchmark().report();
+  LogicValueOfBenchmark().report();
+  ByteEnableBenchmark().report();
 }

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -1,4 +1,0 @@
-/// Copyright (C) 2022 Intel Corporation
-/// SPDX-License-Identifier: BSD-3-Clause
-
-export 'pipeline_benchmark.dart';

--- a/benchmark/byte_enable_benchmark.dart
+++ b/benchmark/byte_enable_benchmark.dart
@@ -1,17 +1,17 @@
 /// Copyright (C) 2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
-/// pipeline_benchmark.dart
-/// Benchmarking for pipeline simulation performance
+/// byte_enable_benchmark.dart
+/// Benchmarking for simple byte enable hardware
 ///
-/// 2022 September 28
+/// 2022 December 2
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:rohd/rohd.dart';
 
-class ByteEnableBenchmark extends AsyncBenchmarkBase {
+class ByteEnableBenchmark extends BenchmarkBase {
   late Logic result;
   late Logic select;
   late Logic original;
@@ -26,7 +26,7 @@ class ByteEnableBenchmark extends AsyncBenchmarkBase {
   ByteEnableBenchmark() : super('ByteEnable');
 
   @override
-  Future<void> setup() async {
+  void setup() {
     select = Logic(name: 'select', width: numBytes);
     original = Logic(name: 'original', width: numBytes * 8);
     original.put(LogicValue.ofString('0x1z10xz' * numBytes));
@@ -41,14 +41,14 @@ class ByteEnableBenchmark extends AsyncBenchmarkBase {
   }
 
   @override
-  Future<void> teardown() async {}
+  void teardown() {}
 
   @override
-  Future<void> run() async {
+  void run() {
     vectors.forEach(select.put);
   }
 }
 
-Future<void> main() async {
-  await ByteEnableBenchmark().report();
+void main() {
+  ByteEnableBenchmark().report();
 }

--- a/benchmark/byte_enable_benchmark.dart
+++ b/benchmark/byte_enable_benchmark.dart
@@ -1,0 +1,54 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// pipeline_benchmark.dart
+/// Benchmarking for pipeline simulation performance
+///
+/// 2022 September 28
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:rohd/rohd.dart';
+
+class ByteEnableBenchmark extends AsyncBenchmarkBase {
+  late Logic result;
+  late Logic select;
+  late Logic original;
+
+  static const int numBytes = 128;
+
+  final List<LogicValue> vectors = List.generate(
+      numBytes,
+      (index) => LogicValue.ofString(
+          (index.toRadixString(2) * numBytes).substring(0, numBytes)));
+
+  ByteEnableBenchmark() : super('ByteEnable');
+
+  @override
+  Future<void> setup() async {
+    select = Logic(name: 'select', width: numBytes);
+    original = Logic(name: 'original', width: numBytes * 8);
+    original.put(LogicValue.ofString('0x1z10xz' * numBytes));
+    select.put(0);
+    result = List.generate(
+        numBytes,
+        (index) => mux(
+              select[index],
+              original.getRange(index * 8, (index + 1) * 8),
+              Const(0, width: 8),
+            )).swizzle();
+  }
+
+  @override
+  Future<void> teardown() async {}
+
+  @override
+  Future<void> run() async {
+    vectors.forEach(select.put);
+  }
+}
+
+Future<void> main() async {
+  await ByteEnableBenchmark().report();
+}

--- a/benchmark/logic_value_of_benchmark.dart
+++ b/benchmark/logic_value_of_benchmark.dart
@@ -1,0 +1,36 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// logic_value_of_benchmark.dart
+/// Benchmarking for concatenation of values together into one.
+///
+/// 2022 December 1
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:rohd/rohd.dart';
+
+class LogicValueOfBenchmark extends AsyncBenchmarkBase {
+  late List<LogicValue> toOf;
+
+  LogicValueOfBenchmark() : super('LogicValueOf');
+
+  @override
+  Future<void> setup() async {
+    toOf = List.generate(
+        1000, (index) => index.isEven ? LogicValue.one : LogicValue.zero);
+  }
+
+  @override
+  Future<void> teardown() async {}
+
+  @override
+  Future<void> run() async {
+    LogicValue.of(toOf);
+  }
+}
+
+Future<void> main() async {
+  await LogicValueOfBenchmark().report();
+}

--- a/benchmark/logic_value_of_benchmark.dart
+++ b/benchmark/logic_value_of_benchmark.dart
@@ -13,13 +13,13 @@ import 'dart:math';
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:rohd/rohd.dart';
 
-class LogicValueOfBenchmark extends AsyncBenchmarkBase {
+class LogicValueOfBenchmark extends BenchmarkBase {
   late List<LogicValue> toOf;
 
   LogicValueOfBenchmark() : super('LogicValueOf');
 
   @override
-  Future<void> setup() async {
+  void setup() {
     final rand = Random(1234);
     toOf = List.generate(
         1000,
@@ -33,14 +33,14 @@ class LogicValueOfBenchmark extends AsyncBenchmarkBase {
   }
 
   @override
-  Future<void> teardown() async {}
+  void teardown() {}
 
   @override
-  Future<void> run() async {
+  void run() {
     LogicValue.of(toOf);
   }
 }
 
-Future<void> main() async {
-  await LogicValueOfBenchmark().report();
+void main() async {
+  LogicValueOfBenchmark().report();
 }

--- a/benchmark/logic_value_of_benchmark.dart
+++ b/benchmark/logic_value_of_benchmark.dart
@@ -8,6 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
+import 'dart:math';
+
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:rohd/rohd.dart';
 
@@ -18,8 +20,16 @@ class LogicValueOfBenchmark extends AsyncBenchmarkBase {
 
   @override
   Future<void> setup() async {
+    final rand = Random(1234);
     toOf = List.generate(
-        1000, (index) => index.isEven ? LogicValue.one : LogicValue.zero);
+        1000,
+        (index) => LogicValue.ofString(([
+              '0' * rand.nextInt(10),
+              '1' * rand.nextInt(10),
+              'x' * rand.nextInt(10),
+              'z' * rand.nextInt(10),
+            ]..shuffle(rand))
+                .join()));
   }
 
   @override

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -147,8 +147,7 @@ class Swizzle extends Module with InlineSystemVerilog {
 
   /// Executes the functional behavior of this gate.
   void _execute() {
-    final updatedVal =
-        _swizzleInputs.reversed.map((e) => e.value).toList().swizzle();
+    final updatedVal = LogicValue.of(_swizzleInputs.map((e) => e.value));
     out.put(updatedVal);
   }
 

--- a/lib/src/values/filled_logic_value.dart
+++ b/lib/src/values/filled_logic_value.dart
@@ -244,4 +244,28 @@ class _FilledLogicValue extends LogicValue {
   LogicValue _shiftArithmeticRight(int shamt) => LogicValue.ofString(
       ((_value == _LogicValueEnum.one ? '1' : '0') * shamt) +
           (this[0]._bitString() * (width - shamt)));
+
+  @override
+  BigInt get _bigIntInvalid =>
+      (_value == _LogicValueEnum.z || _value == _LogicValueEnum.x)
+          ? _BigLogicValue._maskOfWidth(width)
+          : BigInt.zero;
+
+  @override
+  BigInt get _bigIntValue =>
+      (_value == _LogicValueEnum.one || _value == _LogicValueEnum.z)
+          ? _BigLogicValue._maskOfWidth(width)
+          : BigInt.zero;
+
+  @override
+  int get _intInvalid =>
+      (_value == _LogicValueEnum.z || _value == _LogicValueEnum.x)
+          ? _SmallLogicValue._maskOfWidth(width)
+          : 0;
+
+  @override
+  int get _intValue =>
+      (_value == _LogicValueEnum.one || _value == _LogicValueEnum.z)
+          ? _SmallLogicValue._maskOfWidth(width)
+          : 0;
 }

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -137,10 +137,16 @@ abstract class LogicValue {
     // shift small chunks in together before shifting BigInt's, since
     // shifting BigInt's is expensive
     for (final lv in it) {
-      smallBuffer = lv._concatenate(smallBuffer);
-      if (smallBuffer.width > _INT_BITS && smallBuffer is! _FilledLogicValue) {
-        fullResult = smallBuffer._concatenate(fullResult);
-        smallBuffer = LogicValue.empty;
+      if (lv.width + smallBuffer.width <= _INT_BITS) {
+        smallBuffer = lv._concatenate(smallBuffer);
+      } else {
+        final upperBound = (_INT_BITS - smallBuffer.width) +
+            _INT_BITS * max(lv.width ~/ _INT_BITS - 1, 0) as int;
+        fullResult = lv
+            .getRange(0, upperBound)
+            ._concatenate(smallBuffer)
+            ._concatenate(fullResult);
+        smallBuffer = lv.getRange(upperBound, lv.width);
       }
     }
 

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -138,14 +138,19 @@ abstract class LogicValue {
   /// The new value will have `this`'s current value shifted left by
   /// the width of [other].
   LogicValue _concatenate(LogicValue other) {
+    if (other.width == 0) {
+      return this;
+    } else if (width == 0) {
+      return other;
+    }
+
     final newWidth = width + other.width;
+
     if (this is _FilledLogicValue &&
         other is _FilledLogicValue &&
-        ((other.width == 0 || width == 0) || (other[0] == this[0]))) {
+        other[0] == this[0]) {
       // can keep it filled
-      final filledValue =
-          other.width == 0 ? (this as _FilledLogicValue)._value : other._value;
-      return _FilledLogicValue(filledValue, newWidth);
+      return _FilledLogicValue(other._value, newWidth);
     } else if (newWidth > LogicValue._INT_BITS) {
       // BigInt's only
       return _BigLogicValue(_bigIntValue << other.width | other._bigIntValue,

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -129,7 +129,6 @@ abstract class LogicValue {
   /// var lv = LogicValue.of(it);
   /// print(lv); // This prints `6'b01xzx0`
   /// ```
-  ///
   static LogicValue of(Iterable<LogicValue> it) {
     var smallBuffer = LogicValue.empty;
     var fullResult = LogicValue.empty;
@@ -150,6 +149,7 @@ abstract class LogicValue {
             ._concatenate(fullResult);
         smallBuffer = lv.getRange(upperBound, lv.width);
       }
+
       assert(smallBuffer.width <= _INT_BITS,
           'Keep smallBuffer small to meet invariants and efficiency');
     }

--- a/lib/src/values/small_logic_value.dart
+++ b/lib/src/values/small_logic_value.dart
@@ -180,4 +180,18 @@ class _SmallLogicValue extends LogicValue {
               _mask,
           _invalid >> shamt,
           width);
+
+  @override
+  BigInt get _bigIntInvalid =>
+      BigInt.from(_invalid) & _BigLogicValue._maskOfWidth(width);
+
+  @override
+  BigInt get _bigIntValue =>
+      BigInt.from(_value) & _BigLogicValue._maskOfWidth(width);
+
+  @override
+  int get _intInvalid => _invalid;
+
+  @override
+  int get _intValue => _value;
 }

--- a/lib/src/values/values.dart
+++ b/lib/src/values/values.dart
@@ -3,7 +3,6 @@
 
 library values;
 
-import 'dart:math';
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 

--- a/lib/src/values/values.dart
+++ b/lib/src/values/values.dart
@@ -3,8 +3,8 @@
 
 library values;
 
+import 'dart:math';
 import 'package:meta/meta.dart';
-// ignore: unused_import
 import 'package:rohd/rohd.dart';
 
 part 'logic_value.dart';

--- a/test/benchmark_test.dart
+++ b/test/benchmark_test.dart
@@ -19,11 +19,11 @@ void main() {
     await PipelineBenchmark().measure();
   });
 
-  test('logic value of benchmark', () async {
-    await LogicValueOfBenchmark().measure();
+  test('logic value of benchmark', () {
+    LogicValueOfBenchmark().measure();
   });
 
-  test('byte enable benchmark', () async {
-    await ByteEnableBenchmark().measure();
+  test('byte enable benchmark', () {
+    ByteEnableBenchmark().measure();
   });
 }

--- a/test/benchmark_test.dart
+++ b/test/benchmark_test.dart
@@ -9,10 +9,16 @@
 ///
 
 import 'package:test/test.dart';
-import '../benchmark/benchmarks.dart';
+
+import '../benchmark/logic_value_of_benchmark.dart';
+import '../benchmark/pipeline_benchmark.dart';
 
 void main() {
   test('pipeline benchmark', () async {
     await PipelineBenchmark().measure();
+  });
+
+  test('logic value of benchmark', () async {
+    await LogicValueOfBenchmark().measure();
   });
 }

--- a/test/benchmark_test.dart
+++ b/test/benchmark_test.dart
@@ -10,6 +10,7 @@
 
 import 'package:test/test.dart';
 
+import '../benchmark/byte_enable_benchmark.dart';
 import '../benchmark/logic_value_of_benchmark.dart';
 import '../benchmark/pipeline_benchmark.dart';
 
@@ -20,5 +21,9 @@ void main() {
 
   test('logic value of benchmark', () async {
     await LogicValueOfBenchmark().measure();
+  });
+
+  test('byte enable benchmark', () async {
+    await ByteEnableBenchmark().measure();
   });
 }

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -267,6 +267,13 @@ void main() {
           equals(LogicValue.of([LogicValue.zero, LogicValue.zero])));
     });
   });
+
+  test('LogicValue.of example', () {
+    final it = [LogicValue.zero, LogicValue.x, LogicValue.ofString('01xz')];
+    final lv = LogicValue.of(it);
+    expect(lv.toString(), equals("6'b01xzx0"));
+  });
+
   group('unary operations (including "to")', () {
     test('toMethods', () {
       expect(

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -37,7 +37,7 @@ void main() {
           equals(LogicValue.ofString('zx01')));
     });
   });
-  group('LogicValue', () {
+  group('LogicValue of multi-bit', () {
     test('simple swizzle', () {
       expect([LogicValue.ofString('10'), LogicValue.ofString('xz')].swizzle(),
           equals(LogicValue.ofString('10xz')));
@@ -46,6 +46,67 @@ void main() {
     test('simple rswizzle', () {
       expect([LogicValue.ofString('10'), LogicValue.ofString('xz')].rswizzle(),
           equals(LogicValue.ofString('xz10')));
+    });
+
+    test('64-bit swizzle', () {
+      expect(
+          List.generate(
+              32,
+              (index) => index.isEven
+                  ? LogicValue.ofString('10')
+                  : LogicValue.ofString('xz')).swizzle(),
+          equals(LogicValue.ofString('10xz' * 16)));
+    });
+    test('>64-bit swizzle single concat', () {
+      final str1 = '10xz' * 16;
+      final str2 = 'xz10' * 10;
+      expect([LogicValue.ofString(str2), LogicValue.ofString(str1)].swizzle(),
+          equals(LogicValue.ofString(str2 + str1)));
+    });
+    test('>64-bit swizzle', () {
+      expect(
+          List.generate(
+              40,
+              (index) => index.isEven
+                  ? LogicValue.ofString('10')
+                  : LogicValue.ofString('xz')).swizzle(),
+          equals(LogicValue.ofString('10xz' * 20)));
+    });
+
+    group('filled', () {
+      test('simple swizzle', () {
+        expect(
+            [LogicValue.ofString('1' * 4), LogicValue.ofString('1' * 4)]
+                .swizzle(),
+            equals(LogicValue.ofString('1' * 8)));
+      });
+      test('0-width both swizzle', () {
+        expect([LogicValue.ofString(''), LogicValue.ofString('')].swizzle(),
+            equals(LogicValue.ofString('')));
+      });
+      test('0-width lhs swizzle', () {
+        expect([LogicValue.ofString(''), LogicValue.ofString('111')].swizzle(),
+            equals(LogicValue.ofString('111')));
+      });
+      test('0-width rhs swizzle', () {
+        expect([LogicValue.ofString('111'), LogicValue.ofString('')].swizzle(),
+            equals(LogicValue.ofString('111')));
+      });
+    });
+
+    group('non-filled', () {
+      test('0-width both swizzle', () {
+        expect([LogicValue.ofString(''), LogicValue.ofString('')].swizzle(),
+            equals(LogicValue.ofString('')));
+      });
+      test('0-width lhs swizzle', () {
+        expect([LogicValue.ofString(''), LogicValue.ofString('1zx0')].swizzle(),
+            equals(LogicValue.ofString('1zx0')));
+      });
+      test('0-width rhs swizzle', () {
+        expect([LogicValue.ofString('1zx0'), LogicValue.ofString('')].swizzle(),
+            equals(LogicValue.ofString('1zx0')));
+      });
     });
   });
 

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -73,6 +73,30 @@ void main() {
           equals(LogicValue.ofString('10xz' * 20)));
     });
 
+    group('variety of sizes', () {
+      test('smaller', () {
+        final bits = ['0', '1', 'x', 'z'];
+        final swizzleStrings = List.generate(
+            100,
+            (index) =>
+                bits[index % bits.length] * (index % 17) +
+                bits[(index + 1) % bits.length] * (index % 2));
+        expect(LogicValue.of(swizzleStrings.map(LogicValue.ofString)),
+            equals(LogicValue.ofString(swizzleStrings.reversed.join())));
+      });
+
+      test('larger', () {
+        final bits = ['0', '1', 'x', 'z'];
+        final swizzleStrings = List.generate(
+            1000,
+            (index) =>
+                bits[index % bits.length] * (index % 71) +
+                bits[(index + 1) % bits.length] * (index % 2));
+        expect(LogicValue.of(swizzleStrings.map(LogicValue.ofString)),
+            equals(LogicValue.ofString(swizzleStrings.reversed.join())));
+      });
+    });
+
     group('filled', () {
       test('simple swizzle', () {
         expect(

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -80,6 +80,10 @@ void main() {
                 .swizzle(),
             equals(LogicValue.ofString('1' * 8)));
       });
+      test('big swizzle', () {
+        expect(List.generate(100, (index) => LogicValue.one).swizzle(),
+            equals(LogicValue.ofString('1' * 100)));
+      });
       test('0-width both swizzle', () {
         expect([LogicValue.ofString(''), LogicValue.ofString('')].swizzle(),
             equals(LogicValue.ofString('')));


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

String manipulation is not ideal for performance but was used in a number of places for `LogicValue` operations.  This PR removes some of those places where possible.

See conversation that initiated some of these changes here: https://github.com/intel/rohd/pull/213#discussion_r1037443152

This PR specifically fixes:
- Conversion to unsigned `int` from `BigInt` to not use `String`
- `LogicValue.of` to not use `String` (which also optimizes all of the `swizzle` operations on `LogicValue`)

## Related Issue(s)

Fixed #202 (since it was convenient for implementation)

Improved upon fixes in #213

## Testing

Added new tests to cover potential corner cases

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
