### PR TITLE
Fix bug related to late connection signal prop with wires

### DIFF
--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -489,9 +489,14 @@ class Logic {
   /// Updates the current active [_Wire] for this [Logic] and also
   /// notifies all downstream [Logic]s of the new source [_Wire].
   void _updateWire(_Wire newWire) {
+    // first, propagate the new value (if it's different) downstream
+    _wire.put(newWire.value);
+
+    // then, replace the wire
     newWire._adopt(_wire);
     _wire = newWire;
 
+    // tell all downstream signals to update to the new wire as well
     for (final dstConnection in dstConnections) {
       dstConnection._updateWire(newWire);
     }

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -169,4 +169,11 @@ void main() {
 
     expect(a.value, equals(LogicValue.one));
   });
+
+  test('late connection propagates without put', () async {
+    final a = Logic(name: 'a');
+    final b = ~a;
+    a <= Const(0);
+    expect(b.value, equals(LogicValue.one));
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A bug was introduced in #199 where connecting two `Logic`s together wouldn't propagate signals downstream at connection time if the values were different.  This PR fixes the issue by propagating the change downstream to listeners upon connection.

## Related Issue(s)

N/A

## Testing

Added a simple new test that failed without the fix, based on original bug report

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
