### PR TITLE
[Issue-225] Add Else.s() constructor to for single then execution

### DIFF
--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -831,6 +831,12 @@ class Else extends Iff {
   /// If none of the proceding [Iff] or [ElseIf] are executed, then
   /// [then] will be executed.
   Else(List<Conditional> then) : super(Const(1), then);
+
+  /// If none of the proceding [Iff] or [ElseIf] are executed, then
+  /// [then] will be executed.
+  ///
+  /// Use this constructor when you only have a single [then] condition.
+  Else.s(Conditional then) : super(Const(1), [then]);
 }
 
 /// Represents a chain of blocks of code to be conditionally executed, like

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -836,7 +836,7 @@ class Else extends Iff {
   /// [then] will be executed.
   ///
   /// Use this constructor when you only have a single [then] condition.
-  Else.s(Conditional then) : super(Const(1), [then]);
+  Else.s(Conditional then) : this([then]);
 }
 
 /// Represents a chain of blocks of code to be conditionally executed, like

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -219,6 +219,23 @@ class SingleIfOrElseModule extends Module {
   }
 }
 
+class SingleElseModule extends Module {
+  SingleElseModule(Logic a, Logic b) : super(name: 'combmodule') {
+    a = addInput('a', a);
+    b = addInput('b', b);
+
+    final q = addOutput('q');
+    final x = addOutput('x');
+
+    Combinational([
+      IfBlock([
+        Iff.s(a, q < 1),
+        Else.s(x < 1),
+      ])
+    ]);
+  }
+}
+
 class SignalRedrivenSequentialModule extends Module {
   SignalRedrivenSequentialModule(Logic a, Logic b, Logic d)
       : super(name: 'ffmodule') {
@@ -394,6 +411,21 @@ void main() {
       'should return true on simcompare when '
       'execute if.s() for single if...else conditional with orElse.', () async {
     final mod = SingleIfOrElseModule(Logic(), Logic());
+    await mod.build();
+    final vectors = [
+      Vector({'a': 1}, {'q': 1}),
+      Vector({'a': 0}, {'x': 1}),
+    ];
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    final simResult = SimCompare.iverilogVector(
+        mod.generateSynth(), mod.runtimeType.toString(), vectors);
+    expect(simResult, equals(true));
+  });
+
+  test(
+      'should return true on simcompare when '
+      'execute Else.s() for single else conditional', () async {
+    final mod = SingleElseModule(Logic(), Logic());
     await mod.build();
     final vectors = [
       Vector({'a': 1}, {'q': 1}),


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

https://github.com/intel/rohd/pull/210 implements If.s, Iff.s, and ElseIf.s, but not Else.s.

## Related Issue(s)

Fix #225 

## Testing

Add new unit test for single conditionals else then.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No.