### PR TITLE
Add test for shuffling bits

### DIFF
--- a/lib/src/modules/passthrough.dart
+++ b/lib/src/modules/passthrough.dart
@@ -21,13 +21,13 @@ class Passthrough extends Module {
   /// Constructs a simple pass-through module that performs no operations
   /// between [a] and [out].
   Passthrough(Logic a, [String name = 'passthrough']) : super(name: name) {
-    addInput('in', a);
-    addOutput('out');
+    addInput('in', a, width: a.width);
+    addOutput('out', width: a.width);
     _setup();
   }
 
   void _setup() {
-    final inner = Logic(name: 'inner');
+    final inner = Logic(name: 'inner', width: in_.width);
     inner <= in_;
     out <= inner;
   }

--- a/test/shuffle_test.dart
+++ b/test/shuffle_test.dart
@@ -1,0 +1,53 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// Copyright (C) 2022 Intel Corporation
+///
+/// shuffle_test.dart
+/// Tests related to shuffled bits
+///
+/// 2022 December 21
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/modules/passthrough.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class Shuffler extends Module {
+  final int payloadWidth;
+  Shuffler(Logic payloadIn1, Logic payloadIn2)
+      : payloadWidth = payloadIn1.width + payloadIn2.width {
+    payloadIn1 = addInput('payloadIn1', payloadIn1, width: payloadIn1.width);
+    payloadIn2 = addInput('payloadIn2', payloadIn2, width: payloadIn2.width);
+    final payloadOut = addOutput('payloadOut', width: payloadWidth);
+
+    final innerPayload1 = Logic(name: 'innerPayload1', width: payloadIn1.width)
+      ..gets(Passthrough(payloadIn1).out);
+    final innerPayload2 = Logic(name: 'innerPayload2', width: payloadIn2.width)
+      ..gets(Passthrough(payloadIn2).out);
+
+    payloadOut <=
+        List.generate(
+          payloadWidth,
+          (index) => index.isEven
+              ? innerPayload1[index ~/ 2]
+              : innerPayload2[index ~/ 2],
+        ).reversed.toList().rswizzle();
+  }
+}
+
+void main() {
+  test('shuffle test', () async {
+    final gtm = Shuffler(Logic(width: 8), Logic(width: 8));
+    await gtm.build();
+    final vectors = [
+      Vector({'payloadIn1': 0xff, 'payloadIn2': 0}, {'payloadOut': 0xaaaa}),
+    ];
+    await SimCompare.checkFunctionalVector(gtm, vectors);
+    final simResult = SimCompare.iverilogVector(
+        gtm.generateSynth(), gtm.runtimeType.toString(), vectors,
+        signalToWidthMap: {'payloadIn1': 8, 'payloadIn2': 8, 'payloadOut': 16},
+        dontDeleteTmpFiles: true);
+    expect(simResult, equals(true));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

When investigating a potential bug, wrote this test which is pretty good to help protect this type of logic.

## Related Issue(s)

N/A

## Testing

Just added a new test, no bug found.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, but updates `Passthrough` (not publicly exposed in lib)

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
