### PR TITLE
Added test for changed triggers on injection from changed

### DIFF
--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -176,4 +176,51 @@ void main() {
     a <= Const(0);
     expect(b.value, equals(LogicValue.one));
   });
+
+  test('injection on edge happens on same edge', () async {
+    final clk = SimpleClockGenerator(200).clk;
+
+    // faster clk just to add more events to the Simulator
+    SimpleClockGenerator(17).clk;
+
+    final posedgeChangingSignal = Logic()..put(0);
+    final negedgeChangingSignal = Logic()..put(0);
+
+    void posedgeExpect() {
+      if (Simulator.time > 50) {
+        expect((Simulator.time + 100) % 200, equals(0));
+      }
+    }
+
+    void negedgeExpect() {
+      if (Simulator.time > 50) {
+        expect(Simulator.time % 200, equals(0));
+      }
+    }
+
+    clk.posedge.listen((event) {
+      posedgeExpect();
+      posedgeChangingSignal.inject(~posedgeChangingSignal.value);
+    });
+    clk.negedge.listen((event) {
+      negedgeChangingSignal.inject(~negedgeChangingSignal.value);
+    });
+
+    posedgeChangingSignal.glitch.listen((args) {
+      posedgeExpect();
+    });
+    negedgeChangingSignal.glitch.listen((args) {
+      negedgeExpect();
+    });
+
+    posedgeChangingSignal.changed.listen((args) {
+      posedgeExpect();
+    });
+    negedgeChangingSignal.changed.listen((args) {
+      negedgeExpect();
+    });
+
+    Simulator.setMaxSimTime(5000);
+    await Simulator.run();
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

During some debug, there was some concern on whether ROHD was properly injecting at the right simulation time when triggered on another signal's edge.  This test confirms that ROHD is working properly.  No bug found, but it's good to check in this test to help protect the functionality.

## Related Issue(s)

N/A

## Testing

Only new test added, no functionality changed

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
