### PR TITLE
Fix combinational sensitivity excessive pessimism, fix #233

### DIFF
--- a/lib/src/exceptions/conditionals/signal_redriven_exception.dart
+++ b/lib/src/exceptions/conditionals/signal_redriven_exception.dart
@@ -9,20 +9,16 @@
 /// Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/rohd_exception.dart';
 
 /// An exception that thrown when a [Logic] signal is
 /// operated multiple times.
-class SignalRedrivenException implements Exception {
-  late final String _message;
-
+class SignalRedrivenException extends RohdException {
   /// Displays [signals] that are driven multiple times
   /// with default error [message].
   ///
   /// Creates a [SignalRedrivenException] with an optional error [message].
   SignalRedrivenException(String signals,
       [String message = 'Sequential drove the same signal(s) multiple times: '])
-      : _message = message + signals;
-
-  @override
-  String toString() => _message;
+      : super(message + signals);
 }

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -2,5 +2,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 
 export './conditionals/conditional_exceptions.dart';
+export './module/module_exceptions.dart';
 export './name/name_exceptions.dart';
 export './sim_compare/sim_compare_exceptions.dart';

--- a/lib/src/exceptions/module/module_exceptions.dart
+++ b/lib/src/exceptions/module/module_exceptions.dart
@@ -1,0 +1,4 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+
+export 'module_not_built_exception.dart';

--- a/lib/src/exceptions/module/module_not_built_exception.dart
+++ b/lib/src/exceptions/module/module_not_built_exception.dart
@@ -1,0 +1,21 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// module_not_build_exception.dart
+/// Definition for exception when module is not built
+///
+/// 2022 December 30
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/rohd_exception.dart';
+
+/// An [Exception] thrown when a [Module] was used in a way that required it
+/// to be built first, but it was not yet built.
+class ModuleNotBuiltException extends RohdException {
+  /// Constructs a new [Exception] for when a [Module] should have been built
+  /// before some action was taken.
+  ModuleNotBuiltException(
+      [super.message = 'Module has not yet built!  Must call build() first.']);
+}

--- a/lib/src/exceptions/name/invalid_reserved_name_exception.dart
+++ b/lib/src/exceptions/name/invalid_reserved_name_exception.dart
@@ -8,19 +8,15 @@
 /// Author: Yao Jing Quek <yao.jing.quek@intel.com>
 ///
 
-/// An exception that thrown when a reserved name is invalid.
-class InvalidReservedNameException implements Exception {
-  late final String _message;
+import 'package:rohd/src/exceptions/rohd_exception.dart';
 
+/// An exception that thrown when a reserved name is invalid.
+class InvalidReservedNameException extends RohdException {
   /// Display error [message] on invalid reserved name.
   ///
   /// Creates a [InvalidReservedNameException] with an optional error [message].
   InvalidReservedNameException(
-      [String message = 'Reserved Name need to follow proper naming '
+      [super.message = 'Reserved Name need to follow proper naming '
           'convention if reserved'
-          ' name set to true'])
-      : _message = message;
-
-  @override
-  String toString() => _message;
+          ' name set to true']);
 }

--- a/lib/src/exceptions/name/null_reserved_name_exception.dart
+++ b/lib/src/exceptions/name/null_reserved_name_exception.dart
@@ -8,18 +8,14 @@
 /// Author: Yao Jing Quek <yao.jing.quek@intel.com>
 ///
 
-/// An exception that thrown when a reserved name is `null`.
-class NullReservedNameException implements Exception {
-  late final String _message;
+import 'package:rohd/src/exceptions/rohd_exception.dart';
 
+/// An exception that thrown when a reserved name is `null`.
+class NullReservedNameException extends RohdException {
   /// Display error [message] on `null` reserved name.
   ///
   /// Creates a [NullReservedNameException] with an optional error [message].
   NullReservedNameException(
-      [String message = 'Reserved Name cannot be null '
-          'if reserved name set to true'])
-      : _message = message;
-
-  @override
-  String toString() => _message;
+      [super.message = 'Reserved Name cannot be null '
+          'if reserved name set to true']);
 }

--- a/lib/src/exceptions/rohd_exception.dart
+++ b/lib/src/exceptions/rohd_exception.dart
@@ -1,0 +1,21 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// rohd_exception.dart
+/// Base class for all ROHD exceptions
+///
+/// 2022 December 30
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+/// A base type of exception that ROHD-specific exceptions inherit from.
+abstract class RohdException implements Exception {
+  /// A description of what this exception means.
+  final String message;
+
+  /// Creates a new exception with description [message].
+  RohdException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/exceptions/sim_compare/non_supported_type_exception.dart
+++ b/lib/src/exceptions/sim_compare/non_supported_type_exception.dart
@@ -9,21 +9,17 @@
 /// Author: Yao Jing Quek <yao.jing.quek@intel.com>
 ///
 
+import 'package:rohd/src/exceptions/rohd_exception.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 
 /// An exception that thrown when `runtimeType` of expected vector
 /// output from [SimCompare] is invalid or unsupported.
-class NonSupportedTypeException implements Exception {
-  late final String _message;
-
+class NonSupportedTypeException extends RohdException {
   /// Displays [vector] which have invalid or unsupported `runtimeType`
   /// with default error [message].
   ///
   /// Creates a [NonSupportedTypeException] with an optional error [message].
   NonSupportedTypeException(String vector,
       [String message = 'The runtimetype of expected vector is unsupported: '])
-      : _message = message + vector.runtimeType.toString();
-
-  @override
-  String toString() => _message;
+      : super(message + vector.runtimeType.toString());
 }

--- a/lib/src/modules/bus.dart
+++ b/lib/src/modules/bus.dart
@@ -14,7 +14,7 @@ import 'package:rohd/rohd.dart';
 ///
 /// The returned signal is inclusive of both the [startIndex] and [endIndex].
 /// The output [subset] will have width equal to `|endIndex - startIndex| + 1`.
-class BusSubset extends Module with InlineSystemVerilog {
+class BusSubset extends Module with InlineSystemVerilog, FullyCombinational {
   /// Name for the input port of this module.
   late final String _original;
 
@@ -127,7 +127,7 @@ class BusSubset extends Module with InlineSystemVerilog {
 ///
 /// You can use convenience functions [swizzle()] or [rswizzle()] to more easily
 /// use this [Module].
-class Swizzle extends Module with InlineSystemVerilog {
+class Swizzle extends Module with InlineSystemVerilog, FullyCombinational {
   final String _out = Module.unpreferredName('swizzled');
 
   /// The output port containing concatenated signals.

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -117,11 +117,11 @@ class Combinational extends _Always with FullyCombinational {
   }
 
   @override
-  void postPeerBuild() {
+  Future<void> build() async {
+    await super.build();
+
     // any glitch on an input to an output's sensitivity should
     // trigger re-execution
-    // call this in here so that all peer-level modules
-    // are already built
     _listenToSensitivities();
   }
 
@@ -166,7 +166,7 @@ class Combinational extends _Always with FullyCombinational {
 
       // we're at the input to another module, grab all the outputs of it which
       // are combinationally connected and continue searching
-      dstConnections.addAll(src.parentModule!.combinationalPaths![src]!);
+      dstConnections.addAll(src.parentModule!.combinationalPaths[src]!);
     }
 
     if (dstConnections.isEmpty) {
@@ -204,7 +204,7 @@ class Combinational extends _Always with FullyCombinational {
               // default, add all inputs that may affect outputs affected
               // by this input
               for (final dstDependentOutput
-                  in dst.parentModule!.combinationalPaths![dst]!) {
+                  in dst.parentModule!.combinationalPaths[dst]!) {
                 collection.addAll(dst.parentModule!
                     .reverseCombinationalPaths[dstDependentOutput]!);
               }

--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -10,8 +10,23 @@
 
 import 'package:rohd/rohd.dart';
 
+/// A [Module] which has only combinational logic within it and defines
+/// custom functionality.
+///
+/// This type of [Module] implies that any input port may combinationally
+/// affect any output.
+mixin FullyCombinational on Module {
+  @override
+  Map<Logic, List<Logic>> getCombinationalPaths() {
+    // combinational gates are all combinational paths
+    final allOutputs = outputs.values.toList();
+    return Map.fromEntries(
+        inputs.values.map((inputPort) => MapEntry(inputPort, allOutputs)));
+  }
+}
+
 /// A gate [Module] that performs bit-wise inversion.
-class NotGate extends Module with InlineSystemVerilog {
+class NotGate extends Module with InlineSystemVerilog, FullyCombinational {
   /// Name for the input of this inverter.
   late final String _inName;
 
@@ -61,7 +76,8 @@ class NotGate extends Module with InlineSystemVerilog {
 /// A generic unary gate [Module].
 ///
 /// It always takes one input, and the output width is always 1.
-class _OneInputUnaryGate extends Module with InlineSystemVerilog {
+class _OneInputUnaryGate extends Module
+    with InlineSystemVerilog, FullyCombinational {
   /// Name for the input port of this module.
   late final String _inName;
 
@@ -125,7 +141,8 @@ class _OneInputUnaryGate extends Module with InlineSystemVerilog {
 ///
 /// It always takes two inputs and has one output.  All ports have the
 /// same width.
-abstract class _TwoInputBitwiseGate extends Module with InlineSystemVerilog {
+abstract class _TwoInputBitwiseGate extends Module
+    with InlineSystemVerilog, FullyCombinational {
   /// Name for a first input port of this module.
   late final String _in0Name;
 
@@ -221,7 +238,8 @@ abstract class _TwoInputBitwiseGate extends Module with InlineSystemVerilog {
 /// A generic two-input comparison gate [Module].
 ///
 /// It always takes two inputs of the same width and has one 1-bit output.
-abstract class _TwoInputComparisonGate extends Module with InlineSystemVerilog {
+abstract class _TwoInputComparisonGate extends Module
+    with InlineSystemVerilog, FullyCombinational {
   /// Name for a first input port of this module.
   late final String _in0Name;
 
@@ -311,7 +329,7 @@ abstract class _TwoInputComparisonGate extends Module with InlineSystemVerilog {
 ///
 /// It always takes two inputs and has one output of equal width to the primary
 /// of the input.
-class _ShiftGate extends Module with InlineSystemVerilog {
+class _ShiftGate extends Module with InlineSystemVerilog, FullyCombinational {
   /// Name for the main input port of this module.
   late final String _inName;
 
@@ -564,7 +582,7 @@ Logic mux(Logic control, Logic d1, Logic d0) => Mux(control, d1, d0).out;
 ///
 /// If [_control] has value `1`, then [out] gets [_d1].
 /// If [_control] has value `0`, then [out] gets [_d0].
-class Mux extends Module with InlineSystemVerilog {
+class Mux extends Module with InlineSystemVerilog, FullyCombinational {
   /// Name for the control signal of this mux.
   late final String _controlName;
 
@@ -659,7 +677,7 @@ class Mux extends Module with InlineSystemVerilog {
 /// A two-input bit index gate [Module].
 ///
 /// It always takes two inputs and has one output of width 1.
-class IndexGate extends Module with InlineSystemVerilog {
+class IndexGate extends Module with InlineSystemVerilog, FullyCombinational {
   late final String _originalName;
   late final String _indexName;
   late final String _selectionName;
@@ -737,7 +755,8 @@ class IndexGate extends Module with InlineSystemVerilog {
 ///
 /// It takes two inputs (bit and width) and outputs a [Logic] representing
 /// the input bit repeated over the input width
-class ReplicationOp extends Module with InlineSystemVerilog {
+class ReplicationOp extends Module
+    with InlineSystemVerilog, FullyCombinational {
   // input component name
   final String _inputName;
   // output component name

--- a/test/comb_sensitivity_search_test.dart
+++ b/test/comb_sensitivity_search_test.dart
@@ -1,0 +1,45 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// comb_sensitivity_search_test.dart
+/// Unit tests related to Combinational sensitivity searching.
+///
+/// 2023 January 5
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class CombySubModule extends Module {
+  Logic get b => output('b');
+  CombySubModule(Logic a) : super(name: 'combySubModule') {
+    a = addInput('a', a);
+    addOutput('b');
+
+    Combinational([b < a]);
+  }
+}
+
+class ContainerModule extends Module {
+  ContainerModule(Logic a) : super(name: 'containerModule') {
+    a = addInput('a', a);
+    final b = addOutput('b');
+    final bb = addOutput('bb');
+
+    final combySubMod = CombySubModule(a);
+
+    // attach `b` output first so that the CombySubModule gets found by
+    // the output search before the inverter for `bb`
+    b <= combySubMod.b;
+
+    bb <= ~combySubMod.b;
+  }
+}
+
+void main() {
+  test('build runs properly for comb sensitivity search', () async {
+    final mod = ContainerModule(Logic());
+    await mod.build();
+  });
+}

--- a/test/comb_sensitivity_test.dart
+++ b/test/comb_sensitivity_test.dart
@@ -1,0 +1,67 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// comb_sensitivity_test.dart
+/// Unit tests related to Combinational sensitivities.
+///
+/// 2022 December 22
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class SeqWrapper extends Module {
+  Logic get fromFlop => output('fromFlop');
+  SeqWrapper(Logic toFlop, Logic toNothing) {
+    toFlop = addInput('toFlop', toFlop);
+    toNothing = addInput('toNothing', toNothing);
+
+    addOutput('fromFlop');
+
+    fromFlop <=
+        FlipFlop(
+          SimpleClockGenerator(10).clk,
+          toFlop,
+        ).q;
+  }
+}
+
+class TopMod extends Module {
+  Logic get muxToFlop => output('muxToFlop');
+  TopMod(Logic theSource) {
+    theSource = addInput('theSource', theSource);
+
+    final control = Logic(name: 'control');
+    final toNothing = Logic(name: 'toNothing');
+
+    final toFlop = mux(
+      control,
+      Const(0),
+      theSource,
+    );
+
+    final seqWrapper = SeqWrapper(toFlop, toNothing);
+
+    Combinational([
+      control < theSource,
+      toNothing < seqWrapper.fromFlop,
+    ]);
+
+    addOutput('muxToFlop') <= toFlop;
+  }
+}
+
+void main() async {
+  test('false sensitivity does not cause false comb cycle', () async {
+    final theSource = Logic(name: 'theSource')..put(0);
+
+    final mod = TopMod(theSource);
+
+    await mod.build();
+
+    theSource.put(1);
+
+    expect(mod.muxToFlop.value.isValid, isTrue);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Issue #233 finds that searches for `Combinational` sensitivity lists, it is excessively pessimistic in that sometimes there aren't really any combinational paths, but it assumes that there may be.  This can cause an issue where a false combinational loop is detected, causing incorrect X-generation.

This PR fixes the bug by calculating more detailed combinational paths for `Module`s at `build` time.  This information can be leveraged by `Combinational` to understand more accurately where combinational paths may exist.  Results are cached to avoid repeated calculations when multiple `Combinational`s search through similar paths of potential sensitivities.  All `Module`s with custom functionality must explicitly define any combinational paths from all inputs to applicable outputs or else `Combinational` will be unable to properly determine an accurate sensitivity list.  A new `FullyCombinational` mixin is included in this PR to automatically add all input/output combinations as potential combinational paths, since that's a common case for many small custom gates.

Additionally,
- Added `RohdException` base type for all ROHD exceptions, making it easier to handle ROHD-related exceptions
- Added new `ModuleNotBuiltException`, used in multiple places in `Module`

## Related Issue(s)

Fix #233 

## Testing

- Added a new test that had reproduced the original issue without this fix.
- Existing tests cover scenarios where non-trivial sensitivities exist.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Other custom functionality modules defined outside of the ROHD framework which had previously benefited from assumption of the behavior of `FullyCombinational` will now be treated as the complete opposite (no combinational paths).  This could mean `Combinational`s would now be missing sensitivities that previously existed.  If those sensitivities were true, then existing simulations in ROHD might now have incorrect behavior.  This is likely rare, and since this is really a bug fix it doesn't quite feel like it's breaking backwards-compatibility.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Doc comments updated/included
