### PR TITLE
Move VCD parser for tests into utilities

### DIFF
--- a/lib/src/utilities/vcd_parser.dart
+++ b/lib/src/utilities/vcd_parser.dart
@@ -1,0 +1,62 @@
+import 'package:rohd/rohd.dart';
+
+/// State of VCD parsing
+enum _VCDParseState { findSig, findDumpVars, findValue }
+
+/// A parser for VCD files for testing purposes.
+abstract class VcdParser {
+  /// Checks that the contents of a VCD file ([vcdContents]) have [value] on
+  /// [signalName] at time [timestamp].
+  ///
+  /// This function is basic and only works on flat, single modules, or at least
+  /// cases where only one signal is named [signalName] across all scopes.
+  static bool confirmValue(
+      String vcdContents, String signalName, int timestamp, LogicValue value) {
+    final lines = vcdContents.split('\n');
+
+    String? sigName;
+    int? width;
+    var currentTime = 0;
+    LogicValue? currentValue;
+
+    var state = _VCDParseState.findSig;
+
+    final sigNameRegexp = RegExp(r'\s*\$var\swire\s(\d+)\s(\S*)\s(\S*)\s\$end');
+    for (final line in lines) {
+      if (state == _VCDParseState.findSig) {
+        if (sigNameRegexp.hasMatch(line)) {
+          final match = sigNameRegexp.firstMatch(line)!;
+          final w = int.parse(match.group(1)!);
+          final sName = match.group(2)!;
+          final lName = match.group(3)!;
+
+          if (lName == signalName) {
+            sigName = sName;
+            width = w;
+            state = _VCDParseState.findDumpVars;
+          }
+        }
+      } else if (state == _VCDParseState.findDumpVars) {
+        if (line.contains(r'$dumpvars')) {
+          state = _VCDParseState.findValue;
+        }
+      } else if (state == _VCDParseState.findValue) {
+        if (line.startsWith('#')) {
+          currentTime = int.parse(line.substring(1));
+          if (currentTime > timestamp) {
+            return currentValue == value;
+          }
+        } else if (line.endsWith(sigName!)) {
+          if (width == 1) {
+            // ex: zs1
+            currentValue = LogicValue.ofString(line[0]);
+          } else {
+            // ex: bzzzzzzzz s2
+            currentValue = LogicValue.ofString(line.split(' ')[0].substring(1));
+          }
+        }
+      }
+    }
+    return currentValue == value;
+  }
+}

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/vcd_parser.dart';
 import 'package:test/test.dart';
 
 class SimpleModule extends Module {
@@ -39,64 +40,6 @@ void deleteTemporaryDump(String name) {
   File(tmpDumpFile).deleteSync();
 }
 
-/// State of VCD parsing for [confirmValue].
-enum VCDParseState { findSig, findDumpVars, findValue }
-
-/// Checks that the contents of a VCD file ([vcdContents]) have [value] on
-/// [signalName] at time [timestamp].
-///
-/// This function is basic and only works on flat, single modules, or at least
-/// cases where only one signal is named [signalName] across all scopes.
-bool confirmValue(
-    String vcdContents, String signalName, int timestamp, LogicValue value) {
-  final lines = vcdContents.split('\n');
-
-  String? sigName;
-  int? width;
-  var currentTime = 0;
-  LogicValue? currentValue;
-
-  var state = VCDParseState.findSig;
-
-  final sigNameRegexp = RegExp(r'\s*\$var\swire\s(\d+)\s(\S*)\s(\S*)\s\$end');
-  for (final line in lines) {
-    if (state == VCDParseState.findSig) {
-      if (sigNameRegexp.hasMatch(line)) {
-        final match = sigNameRegexp.firstMatch(line)!;
-        final w = int.parse(match.group(1)!);
-        final sName = match.group(2)!;
-        final lName = match.group(3)!;
-
-        if (lName == signalName) {
-          sigName = sName;
-          width = w;
-          state = VCDParseState.findDumpVars;
-        }
-      }
-    } else if (state == VCDParseState.findDumpVars) {
-      if (line.contains(r'$dumpvars')) {
-        state = VCDParseState.findValue;
-      }
-    } else if (state == VCDParseState.findValue) {
-      if (line.startsWith('#')) {
-        currentTime = int.parse(line.substring(1));
-        if (currentTime > timestamp) {
-          return currentValue == value;
-        }
-      } else if (line.endsWith(sigName!)) {
-        if (width == 1) {
-          // ex: zs1
-          currentValue = LogicValue.ofString(line[0]);
-        } else {
-          // ex: bzzzzzzzz s2
-          currentValue = LogicValue.ofString(line.split(' ')[0].substring(1));
-        }
-      }
-    }
-  }
-  return currentValue == value;
-}
-
 void main() {
   tearDown(Simulator.reset);
 
@@ -115,11 +58,14 @@ void main() {
 
     final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
 
-    expect(confirmValue(vcdContents, 'a', 0, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 0, LogicValue.ofString('1')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 5, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 5, LogicValue.ofString('1')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
         equals(true));
 
     deleteTemporaryDump(dumpName);
@@ -141,13 +87,17 @@ void main() {
 
     final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
 
-    expect(confirmValue(vcdContents, 'a', 0, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 0, LogicValue.ofString('1')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 1, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 1, LogicValue.ofString('1')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 20, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 20, LogicValue.ofString('1')),
         equals(true));
 
     deleteTemporaryDump(dumpName);
@@ -179,13 +129,17 @@ void main() {
 
     final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
 
-    expect(confirmValue(vcdContents, 'a', 0, LogicValue.ofString('0')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 0, LogicValue.ofString('0')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 5, LogicValue.ofString('1')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 5, LogicValue.ofString('1')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 35, LogicValue.ofString('0')),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 35, LogicValue.ofString('0')),
         equals(true));
 
     deleteTemporaryDump(dumpName);
@@ -206,9 +160,11 @@ void main() {
 
     final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
 
-    expect(confirmValue(vcdContents, 'a', 0, LogicValue.ofInt(0x5a, 8)),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 0, LogicValue.ofInt(0x5a, 8)),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 10, LogicValue.ofInt(0xa5, 8)),
+    expect(
+        VcdParser.confirmValue(vcdContents, 'a', 10, LogicValue.ofInt(0xa5, 8)),
         equals(true));
 
     deleteTemporaryDump(dumpName);
@@ -229,9 +185,13 @@ void main() {
 
     final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
 
-    expect(confirmValue(vcdContents, 'a', 0, LogicValue.ofString('01xzzx10')),
+    expect(
+        VcdParser.confirmValue(
+            vcdContents, 'a', 0, LogicValue.ofString('01xzzx10')),
         equals(true));
-    expect(confirmValue(vcdContents, 'a', 10, LogicValue.ofString('0x0x1z1z')),
+    expect(
+        VcdParser.confirmValue(
+            vcdContents, 'a', 10, LogicValue.ofString('0x0x1z1z')),
         equals(true));
 
     deleteTemporaryDump(dumpName);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The VCD parser is a useful utility for testing, so it's nice to have it as a separate utility rather than just a part of the test.

## Related Issue(s)

N/A

## Testing

Existing tests pass

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No, but doc comments updated even though non-public API