### PR TITLE
`WaveDumper` optimization

### DIFF
--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -11,9 +11,11 @@
 import 'byte_enable_benchmark.dart';
 import 'logic_value_of_benchmark.dart';
 import 'pipeline_benchmark.dart';
+import 'wave_dump_benchmark.dart';
 
 void main() async {
   await PipelineBenchmark().report();
   LogicValueOfBenchmark().report();
   ByteEnableBenchmark().report();
+  await WaveDumpBenchmark().report();
 }

--- a/benchmark/wave_dump_benchmark.dart
+++ b/benchmark/wave_dump_benchmark.dart
@@ -1,0 +1,65 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// wave_dump_benchmark.dart
+/// Benchmarking for wave dumping
+///
+/// 2023 January 5
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:io';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:rohd/rohd.dart';
+
+class _ModuleToDump extends Module {
+  _ModuleToDump(Logic d) {
+    d = addInput('d', d);
+
+    final q = addOutput('q');
+
+    final clk = SimpleClockGenerator(10).clk;
+
+    for (var i = 0; i < 100; i++) {
+      addOutput('i$i') <= FlipFlop(clk, ~output('i$i')).q;
+    }
+
+    q <= FlipFlop(clk, d).q;
+  }
+}
+
+class WaveDumpBenchmark extends AsyncBenchmarkBase {
+  late _ModuleToDump _mod;
+
+  static const _vcdTemporaryPath = 'tmp_test/wave_dump_benchmark.vcd';
+
+  WaveDumpBenchmark() : super('WaveDump');
+
+  @override
+  Future<void> setup() async {
+    Simulator.setMaxSimTime(1000);
+
+    _mod = _ModuleToDump(Logic());
+    await _mod.build();
+  }
+
+  @override
+  Future<void> teardown() async {
+    File(_vcdTemporaryPath).deleteSync();
+    await Simulator.reset();
+  }
+
+  @override
+  Future<void> run() async {
+    WaveDumper(_mod, outputPath: _vcdTemporaryPath);
+
+    await Simulator.run();
+
+    await Simulator.reset();
+  }
+}
+
+Future<void> main() async {
+  await WaveDumpBenchmark().report();
+}

--- a/test/benchmark_test.dart
+++ b/test/benchmark_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 import '../benchmark/byte_enable_benchmark.dart';
 import '../benchmark/logic_value_of_benchmark.dart';
 import '../benchmark/pipeline_benchmark.dart';
+import '../benchmark/wave_dump_benchmark.dart';
 
 void main() {
   test('pipeline benchmark', () async {
@@ -25,5 +26,9 @@ void main() {
 
   test('byte enable benchmark', () {
     ByteEnableBenchmark().measure();
+  });
+
+  test('waveform benchmark', () async {
+    await WaveDumpBenchmark().measure();
   });
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -60,10 +60,11 @@ void main() async {
 
     createTemporaryDump(mod, dumpName);
 
+    await Simulator.run();
+
     final vcdContents = await File(temporaryDumpPath(dumpName)).readAsString();
     expect(vcdContents, contains(version));
 
-    await Simulator.run();
     deleteTemporaryDump(dumpName);
   });
 }

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -196,4 +196,27 @@ void main() {
 
     deleteTemporaryDump(dumpName);
   });
+
+  test('dump after max sim time works', () async {
+    final a = SimpleClockGenerator(10).clk;
+    final mod = SimpleModule(a);
+    await mod.build();
+
+    const dumpName = 'maxSimTime';
+
+    createTemporaryDump(mod, dumpName);
+
+    Simulator.setMaxSimTime(100);
+
+    await Simulator.run();
+
+    final vcdContents = File(temporaryDumpPath(dumpName)).readAsStringSync();
+
+    expect(
+      VcdParser.confirmValue(vcdContents, 'a', 99, LogicValue.one),
+      equals(true),
+    );
+
+    deleteTemporaryDump(dumpName);
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Dumping waves is too slow for large designs on long simulations!  A lot of time was spent in File IO.  This PR makes many fewer file operations by buffering it in a `StringBuffer` and only sending to the file once it reaches a large amount of data.

Also added a benchmark for the `WaveDumper`.

## Related Issue(s)

N/A

## Testing

New benchmark and existing tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, but VCD contents will update less frequently now

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
