### PR TITLE
Improve exceptions for `Logic.put`

### DIFF
--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -1,7 +1,8 @@
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
-
 export './conditionals/conditional_exceptions.dart';
+export './logic/logic_exceptions.dart';
 export './module/module_exceptions.dart';
 export './name/name_exceptions.dart';
 export './sim_compare/sim_compare_exceptions.dart';
+export 'rohd_exception.dart';

--- a/lib/src/exceptions/logic/logic_exceptions.dart
+++ b/lib/src/exceptions/logic/logic_exceptions.dart
@@ -1,0 +1,4 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+
+export 'put_exception.dart';

--- a/lib/src/exceptions/logic/put_exception.dart
+++ b/lib/src/exceptions/logic/put_exception.dart
@@ -1,0 +1,20 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// put_exception.dart
+/// An exception that thrown when a signal failes to `put`.
+///
+/// 2023 January 5
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/rohd_exception.dart';
+
+/// An exception that thrown when a [Logic] signal fails to `put`.
+class PutException extends RohdException {
+  /// Creates an exception for when a `put` fails on a `Logic` with [context] as
+  /// to where the
+  PutException(String context, String message)
+      : super('Failed to put value on signal ($context): $message');
+}

--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// bus_test.dart
@@ -7,7 +7,9 @@
 /// 2021 May 7
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
+
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/logic/logic_exceptions.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
@@ -248,6 +250,16 @@ void main() {
       a.put(0xaa);
       b.put(0x55);
       expect(out.value.toInt(), equals(0x55aa));
+    });
+
+    group('put exceptions', () {
+      test('width mismatch', () {
+        expect(
+          () => Logic(name: 'byteSignal', width: 8)
+              .put(LogicValue.ofString('1010')),
+          throwsA(const TypeMatcher<PutException>()),
+        );
+      });
     });
   });
 

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -1,12 +1,13 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// math_test.dart
-/// Unit tests for bus-related operations
+/// Unit tests for math-related operations
 ///
 /// 2021 May 21
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The exceptions raised by `Logic.put` don't communicate what signal was having an issue, just what the issue was.  This PR adds the name of the signal and makes all `put` exceptions of type `PutException`.

## Related Issue(s)

N/A

## Testing

Added one new test that `PutException` is thrown when there's a width mismatch.  There could be more testing added across other exceptions as part of coverage closure.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
