### PR TITLE
[Issue-234] Port should validate that names are sanitary

### DIFF
--- a/lib/src/interface.dart
+++ b/lib/src/interface.dart
@@ -11,11 +11,18 @@
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/sanitizer.dart';
 
 /// An extension of [Logic] useful for [Interface] definitions.
 class Port extends Logic {
   /// Constructs a [Logic] intended to be used for ports in an [Interface].
-  Port(String name, [int width = 1]) : super(name: name, width: width);
+  Port(String name, [int width = 1]) : super(name: name, width: width) {
+    if (!Sanitizer.isSanitary(name)) {
+      throw Exception(
+          'Invalid name "$name", must be legal SystemVerilog and not collide'
+          ' with any keywords.');
+    }
+  }
 }
 
 /// Represents a logical interface to a [Module].

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -32,6 +32,12 @@ class MyModule extends Module {
   }
 }
 
+class UncleanPortInterface extends Interface<MyDirection> {
+  UncleanPortInterface() {
+    setPorts([Port('end')], [MyDirection.dir1]);
+  }
+}
+
 void main() {
   tearDown(Simulator.reset);
 
@@ -42,5 +48,11 @@ void main() {
       expect(m.i1.getPorts({MyDirection.dir1}).length, 1);
       expect(m.i2.getPorts({MyDirection.dir2}).length, 1);
     });
+  });
+
+  test('should return exception when port name is not sanitary.', () async {
+    expect(() async {
+      UncleanPortInterface();
+    }, throwsException);
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

When creating a Port, the expectation is that the name will not change. Since Port extends from Logic, and Logic was updated to prevent names from being unsanitary by renaming them using the Sanitizer, it is now possible that the name will be sanitized silently, leading to bugs down the line.

Usually, it's not a good idea to name a port an unsanitary name ever, but sometimes it makes sense to want to name it something unsanitary if you know it will always be uniquified such that it will not actually be unsanitary on an interface.

## Related Issue(s)

Fix #234 

## Testing

<!-- Please describe how you tested your changes -->

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

<!--Answer here-->

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

<!--Answer here-->
