### PR TITLE
Revert IndexError deprecation change to maintain backwards compatibility

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -448,10 +448,12 @@ abstract class LogicValue {
   LogicValue operator [](int index) {
     final modifiedIndex = (index < 0) ? width + index : index;
     if (modifiedIndex >= width || modifiedIndex < 0) {
-      throw IndexError.withLength(index, width,
-          indexable: this,
-          name: 'LogicValueIndexOutOfRange',
-          message: 'Index out of range: $modifiedIndex(=$index).');
+      // The suggestion in the deprecation for this constructor is not available
+      // before 2.19, so keep it in here for now.  Eventually, switch to the
+      // new one.
+      // ignore: deprecated_member_use
+      throw IndexError(index, this, 'LogicValueIndexOutOfRange',
+          'Index out of range: $modifiedIndex(=$index).', width);
     }
     return _getIndex(modifiedIndex);
   }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The deprecation suggestion for `IndexError` to use `IndexError.withLength` instead is not backwards-compatible before dart v2.19.  This change alone is not sufficient to justify raising the SDK requirements for ROHD to 2.19, so reverting back with an "ignore" for this lint violation.

## Related Issue(s)

N/A

## Testing

Existing tests and analysis

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
