### PR TITLE
`await` registered actions in `Simulator`

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -170,6 +170,8 @@ class Simulator {
   }
 
   /// Registers an abritrary [action] to be executed at [timestamp] time.
+  ///
+  /// The [action], if it returns a [Future], will be `await`ed.
   static void registerAction(int timestamp, dynamic Function() action) {
     if (timestamp <= _currentTimestamp) {
       throw Exception('Cannot add timestamp "$timestamp" in the past.'

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -73,8 +73,8 @@ class Simulator {
       _pendingTimestamps.isNotEmpty || _injectedActions.isNotEmpty;
 
   /// Sorted storage for pending functions to execute at appropriate times.
-  static final SplayTreeMap<int, List<void Function()>> _pendingTimestamps =
-      SplayTreeMap<int, List<void Function()>>();
+  static final SplayTreeMap<int, List<dynamic Function()>> _pendingTimestamps =
+      SplayTreeMap<int, List<dynamic Function()>>();
 
   /// Functions to be executed as soon as possible by the [Simulator].
   ///
@@ -170,7 +170,7 @@ class Simulator {
   }
 
   /// Registers an abritrary [action] to be executed at [timestamp] time.
-  static void registerAction(int timestamp, void Function() action) {
+  static void registerAction(int timestamp, dynamic Function() action) {
     if (timestamp <= _currentTimestamp) {
       throw Exception('Cannot add timestamp "$timestamp" in the past.'
           '  Current time is ${Simulator.time}');
@@ -225,9 +225,9 @@ class Simulator {
 
     _currentTimestamp = nextTimeStamp;
 
-    await tickExecute(() {
+    await tickExecute(() async {
       for (final func in _pendingTimestamps[nextTimeStamp]!) {
-        func();
+        await func();
       }
     });
     _pendingTimestamps.remove(_currentTimestamp);
@@ -242,7 +242,7 @@ class Simulator {
   }
 
   /// Performs the actual execution of a collection of actions for a [tick()].
-  static Future<void> tickExecute(void Function() toExecute) async {
+  static Future<void> tickExecute(dynamic Function() toExecute) async {
     _phase = SimulatorPhase.beforeTick;
 
     // useful for flop sampling
@@ -252,7 +252,7 @@ class Simulator {
 
     // useful for things that need to trigger every tick without other input
     _startTickController.add(null);
-    toExecute();
+    await toExecute();
 
     _phase = SimulatorPhase.clkStable;
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

End of simulation and injected actions are `await`ed in the `Simulator` already, but when you register an action with `Simulator.registerAction` the function is not `await`ed.  This PR makes it more consistent by `await`ing actions registered that way as well.

The implementation revealed that additional error handling was needed in some scenarios for `Sequential`s, as well.

## Related Issue(s)

N/A

## Testing

Added new tests which cover this behavior and adjusted tests which needed it.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

It is somewhat of a different behavior than was previously there, but the inconsistency makes this change closer to a bug fix than a new feature or API change.  It may break code that relied on `Simulator.registerAction` not `await`ing in the `Simulator`.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Updated documentation for `registerAction`
