### PR TITLE
await Simulator.reset in test teardowns

### DIFF
--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -155,7 +155,9 @@ class BusTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
+  tearDown(() async {
+    await Simulator.reset();
+  });
 
   group('functional', () {
     test('NotGate bus', () async {

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021-2022 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// changed_test.dart
@@ -14,8 +14,9 @@ import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('single changed multiple injections', () async {
     final a = Logic()..put(0);
 

--- a/test/collapse_test.dart
+++ b/test/collapse_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// collapse_test.dart
@@ -37,8 +37,9 @@ class CollapseTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('collapse functional', () async {
     final mod = CollapseTestModule(Logic(), Logic());
     await mod.build();

--- a/test/comb_math_test.dart
+++ b/test/comb_math_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// comb_math_test.dart
@@ -104,8 +104,9 @@ class ReducedExample extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   // thank you to @chykon in issue #158 for providing this example!
   test('execute math conditionally', () async {
     final codepoint = Logic(width: 21);

--- a/test/comb_mod_test.dart
+++ b/test/comb_mod_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// comb_mod_test.dart
@@ -58,7 +58,9 @@ class DuplicateExample extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
+  tearDown(() async {
+    await Simulator.reset();
+  });
 
   test('module reuse should apply twice', () async {
     final mod = ReuseExample(Logic(width: 8));

--- a/test/comparison_test.dart
+++ b/test/comparison_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// comparison_test.dart
@@ -48,8 +48,9 @@ class ComparisonTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('compares', () async {
       final gtm = ComparisonTestModule(Logic(width: 8), Logic(width: 8));

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// conditionals_test.dart
@@ -327,8 +327,9 @@ class MultipleConditionalModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('functional', () {
     test('conditional loopy comb', () async {
       final mod = LoopyCombModule(Logic());

--- a/test/counter_test.dart
+++ b/test/counter_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// counter_test.dart
@@ -40,8 +40,9 @@ class Counter extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('counter', () async {
       final reset = Logic();

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// counter_wintf_test.dart
@@ -60,8 +60,9 @@ class Counter extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('counter', () async {
       final mod = Counter(CounterInterface(8));

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// example_test.dart
@@ -15,7 +15,9 @@ import '../example/fir_filter.dart' as fir_filter;
 import '../example/tree.dart' as tree;
 
 void main() {
-  tearDown(Simulator.reset);
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('counter example', () async {
     await counter.main(noPrint: true);
   });

--- a/test/flop_test.dart
+++ b/test/flop_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// flop_test.dart
@@ -25,8 +25,9 @@ class FlopTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('flop bit', () async {
       final ftm = FlopTestModule(Logic());

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// fsm_test.dart
@@ -104,8 +104,9 @@ class TrafficTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('simple fsm', () async {
       final pipem = TestModule(Logic(), Logic(), Logic());

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021-2022 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// gate_test.dart
@@ -103,8 +103,9 @@ class IndexGateTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('functional', () {
     test('NotGate single bit', () async {
       final a = Logic();

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// interface_test.dart
@@ -39,8 +39,9 @@ class UncleanPortInterface extends Interface<MyDirection> {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('uniquified interfaces', () {
     test('get uniquified ports', () async {
       final m = MyModule(MyModuleInterface(), MyModuleInterface());

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -66,8 +66,9 @@ class MathTestModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     Future<void> runMathVectors(List<Vector> vectors) async {
       final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));

--- a/test/multimodule3_test.dart
+++ b/test/multimodule3_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021-2022 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// multimodule3_test.dart
@@ -44,8 +44,9 @@ class TopModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('multimodules3', () async {
       final ftm = TopModule();

--- a/test/multimodule4_test.dart
+++ b/test/multimodule4_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021-2022 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// multimodule4_test.dart
@@ -38,8 +38,9 @@ class TopModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('multimodules4', () async {
     final ftm = TopModule(Logic());
     await ftm.build();

--- a/test/multimodule_test.dart
+++ b/test/multimodule_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// multimodule_test.dart
@@ -49,8 +49,9 @@ class BModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('multimodules', () async {
       final ftm = TopModule(Logic(width: 4), Logic());

--- a/test/name_test.dart
+++ b/test/name_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// definition_name_test.dart
@@ -82,8 +82,9 @@ enum NameType {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('signal and module naming conflicts', () {
     Future<void> runTest(RenameableModule mod) async {
       await mod.build();

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// pipeline_test.dart
@@ -51,8 +51,9 @@ class RVPipelineModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('simple pipeline', () async {
       final pipem = SimplePipelineModule(Logic(width: 8));

--- a/test/shuffle_test.dart
+++ b/test/shuffle_test.dart
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2022-2023 Intel Corporation
 ///
 /// shuffle_test.dart
 /// Tests related to shuffled bits
@@ -37,6 +37,10 @@ class Shuffler extends Module {
 }
 
 void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
   test('shuffle test', () async {
     final gtm = Shuffler(Logic(width: 8), Logic(width: 8));
     await gtm.build();

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// simulator_test.dart
@@ -14,8 +14,9 @@ import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('simulator supports registration of actions at time stamps', () async {
     var actionTaken = false;
     Simulator.registerAction(100, () => actionTaken = true);

--- a/test/swizzle_test.dart
+++ b/test/swizzle_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// swizzle_test.dart
@@ -21,8 +21,9 @@ class SwizzlyModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('LogicValue', () {
     test('simple swizzle', () {
       expect(

--- a/test/trace_bounce_test.dart
+++ b/test/trace_bounce_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2022 Intel Corporation
+/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// trace_bounce_test.dart
@@ -38,6 +38,10 @@ class SubModule extends Module {
 }
 
 void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
   test('out depends on out', () async {
     final mod = TopModule(Logic());
     await mod.build();

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021-2022 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// trace_test.dart
@@ -57,8 +57,9 @@ class DoubledGappedInputModule extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('flying output', () async {
     final mod = FlyingOutputModule(Logic());
     expect(() async {

--- a/test/translations_test.dart
+++ b/test/translations_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// translations_test.dart
@@ -97,8 +97,9 @@ class FlopArray extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('translation', () async {
       const numRdPorts = 2;

--- a/test/tree_test.dart
+++ b/test/tree_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// tree_test.dart
@@ -43,8 +43,9 @@ class TreeOfTwoInputModules extends Module {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   group('simcompare', () {
     test('tree', () async {
       final mod = TreeOfTwoInputModules(

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// wave_dumper_test.dart
@@ -41,8 +41,9 @@ void deleteTemporaryDump(String name) {
 }
 
 void main() {
-  tearDown(Simulator.reset);
-
+  tearDown(() async {
+    await Simulator.reset();
+  });
   test('attach dumper after put', () async {
     final a = Logic(name: 'a');
     final mod = SimpleModule(a);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Since `Simulator.reset` is async, we should await it.  This PR updates tests that weren't doing that.

## Related Issue(s)

N/A

## Testing

Existing tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
