### PR TITLE
Added test to check sanitized names

### DIFF
--- a/test/logic_name_test.dart
+++ b/test/logic_name_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   test('Test signals for sanitized names', () async {
-    expect(Sanitizer.isSanitary(Const(LogicValue.ofString('1x0101')).name),
+    expect(Sanitizer.isSanitary(Const(LogicValue.ofString('1x0101z')).name),
         isTrue);
   });
 

--- a/test/logic_name_test.dart
+++ b/test/logic_name_test.dart
@@ -9,6 +9,7 @@
 ///
 
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:test/test.dart';
 
 class LogicTestModule extends Module {
@@ -23,6 +24,11 @@ void main() {
       'THEN expected to see proper name being generated', () async {
     final bus = Logic(name: 'validName');
     expect(bus.name, equals('validName'));
+  });
+
+  test('Test signals for sanitized names', () async {
+    expect(
+        Sanitizer.isSanitary(Const(LogicValue.ofString('1x0101')).name), isTrue);
   });
 
   test('GIVEN logic name is invalid THEN expected to see sanitized name',

--- a/test/logic_name_test.dart
+++ b/test/logic_name_test.dart
@@ -27,8 +27,8 @@ void main() {
   });
 
   test('Test signals for sanitized names', () async {
-    expect(
-        Sanitizer.isSanitary(Const(LogicValue.ofString('1x0101')).name), isTrue);
+    expect(Sanitizer.isSanitary(Const(LogicValue.ofString('1x0101')).name),
+        isTrue);
   });
 
   test('GIVEN logic name is invalid THEN expected to see sanitized name',


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Added function to validate sanitizer

## Related Issue(s)

https://github.com/intel/rohd/issues/152

## Testing

Call sanitizer to check on signal given

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
