### PR TITLE
Upgrade VcdParser to handle more VCD files

### DIFF
--- a/lib/src/utilities/vcd_parser.dart
+++ b/lib/src/utilities/vcd_parser.dart
@@ -1,3 +1,13 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// vcd_parser.dart
+/// Utility for parsing VCD files for tests
+///
+/// 2023 January 5
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
 import 'package:rohd/rohd.dart';
 
 /// State of VCD parsing
@@ -21,14 +31,15 @@ abstract class VcdParser {
 
     var state = _VCDParseState.findSig;
 
-    final sigNameRegexp = RegExp(r'\s*\$var\swire\s(\d+)\s(\S*)\s(\S*)\s\$end');
+    final sigNameRegexp = RegExp(
+        r'\s*\$var\s(wire|reg)\s(\d+)\s(\S*)\s(\S*)\s+(\[\d+\:\d+\])?\s*\$end');
     for (final line in lines) {
       if (state == _VCDParseState.findSig) {
         if (sigNameRegexp.hasMatch(line)) {
           final match = sigNameRegexp.firstMatch(line)!;
-          final w = int.parse(match.group(1)!);
-          final sName = match.group(2)!;
-          final lName = match.group(3)!;
+          final w = int.parse(match.group(2)!);
+          final sName = match.group(3)!;
+          final lName = match.group(4)!;
 
           if (lName == signalName) {
             sigName = sName;
@@ -54,6 +65,8 @@ abstract class VcdParser {
             // ex: bzzzzzzzz s2
             currentValue = LogicValue.ofString(line.split(' ')[0].substring(1));
           }
+
+          currentValue = currentValue.zeroExtend(width!);
         }
       }
     }

--- a/lib/src/utilities/vcd_parser.dart
+++ b/lib/src/utilities/vcd_parser.dart
@@ -11,7 +11,7 @@
 import 'package:rohd/rohd.dart';
 
 /// State of VCD parsing
-enum _VCDParseState { findSig, findDumpVars, findValue }
+enum _VcdParseState { findSig, findDumpVars, findValue }
 
 /// A parser for VCD files for testing purposes.
 abstract class VcdParser {
@@ -29,12 +29,12 @@ abstract class VcdParser {
     var currentTime = 0;
     LogicValue? currentValue;
 
-    var state = _VCDParseState.findSig;
+    var state = _VcdParseState.findSig;
 
     final sigNameRegexp = RegExp(
         r'\s*\$var\s(wire|reg)\s(\d+)\s(\S*)\s(\S*)\s+(\[\d+\:\d+\])?\s*\$end');
     for (final line in lines) {
-      if (state == _VCDParseState.findSig) {
+      if (state == _VcdParseState.findSig) {
         if (sigNameRegexp.hasMatch(line)) {
           final match = sigNameRegexp.firstMatch(line)!;
           final w = int.parse(match.group(2)!);
@@ -44,14 +44,14 @@ abstract class VcdParser {
           if (lName == signalName) {
             sigName = sName;
             width = w;
-            state = _VCDParseState.findDumpVars;
+            state = _VcdParseState.findDumpVars;
           }
         }
-      } else if (state == _VCDParseState.findDumpVars) {
+      } else if (state == _VcdParseState.findDumpVars) {
         if (line.contains(r'$dumpvars')) {
-          state = _VCDParseState.findValue;
+          state = _VcdParseState.findValue;
         }
-      } else if (state == _VCDParseState.findValue) {
+      } else if (state == _VcdParseState.findValue) {
         if (line.startsWith('#')) {
           currentTime = int.parse(line.substring(1));
           if (currentTime > timestamp) {

--- a/test/example_icarus_waves.vcd
+++ b/test/example_icarus_waves.vcd
@@ -1,0 +1,101 @@
+$date
+	Tue Feb  7 10:45:30 2023
+$end
+$version
+	Icarus Verilog
+$end
+$timescale
+	1ps
+$end
+$scope module cosim_wrapper $end
+$scope module external_module $end
+$var wire 1 ! clk $end
+$var wire 8 " push_data [7:0] $end
+$var wire 1 # push_valid $end
+$var reg 8 $ sampled [7:0] $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+bx $
+z#
+bz "
+0!
+$end
+#5000
+1!
+#5002
+b0 "
+1#
+#10000
+0!
+#15000
+b0 $
+1!
+#15002
+b1 "
+0#
+#20000
+0!
+#25000
+1!
+#25002
+b10 "
+1#
+#30000
+0!
+#35000
+b10 $
+1!
+#35002
+b11 "
+0#
+#40000
+0!
+#45000
+1!
+#45002
+b100 "
+1#
+#50000
+0!
+#55000
+b100 $
+1!
+#55002
+b101 "
+0#
+#60000
+0!
+#65000
+1!
+#65002
+b110 "
+1#
+#70000
+0!
+#75000
+b110 $
+1!
+#75002
+b111 "
+0#
+#80000
+0!
+#85000
+1!
+#85002
+b1000 "
+1#
+#90000
+0!
+#95000
+b1000 $
+1!
+#95002
+b1001 "
+0#
+#100000
+0!
+#100002

--- a/test/vcd_parser_test.dart
+++ b/test/vcd_parser_test.dart
@@ -1,0 +1,33 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// vcd_parser_test.dart
+/// Tests for the VcdParser
+///
+/// 2023 February 7
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:io';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/vcd_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('VCD parser can parse Icarus Verilog generated VCD file', () {
+    final vcdContents =
+        File('test/example_icarus_waves.vcd').readAsStringSync();
+    for (var countI = 1; countI < 10; countI++) {
+      expect(
+        VcdParser.confirmValue(
+          vcdContents,
+          'sampled',
+          (10 * countI + 5) * 1000,
+          LogicValue.ofInt(countI.isEven ? countI - 2 : countI - 1, 8),
+        ),
+        isTrue,
+      );
+    }
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

While ROHD generates relatively simple VCD files, other tools (like Icarus Verilog) take advantage of more features of VCD files.  This PR upgrades the `VcdParser` utility in ROHD so that it can check a wider variety of VCD files.  It's still pretty limited, but this helps.

## Related Issue(s)

N/A

## Testing

Added a new test on a VCD file generated by Icarus Verilog

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
