### PR TITLE
Slightly fix the example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc/api/
 
 # Other stuff
 tmp_test/
+*.sv
 *.vcd
 .vscode/
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,12 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-// For greater clarity in the example, one of the rules of code analysis
-// will be suppressed. Sometimes it can be useful, but you should always
-// evaluate the consequences of deviations from the set of static analysis
-// rules used in the project. Additional information is available at
-// https://dart.dev/guides/language/analysis-options
-//
+// Though we usually avoid them, for this example,
+// allow `print` messages (disable lint):
 // ignore_for_file: avoid_print
 
 // Import the ROHD package.

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,8 +8,13 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-// Import the standard library for I/O.
-import 'dart:io';
+// For greater clarity in the example, one of the rules of code analysis
+// will be suppressed. Sometimes it can be useful, but you should always
+// evaluate the consequences of deviations from the set of static analysis
+// rules used in the project. Additional information is available at
+// https://dart.dev/guides/language/analysis-options
+//
+// ignore_for_file: avoid_print
 
 // Import the ROHD package.
 import 'package:rohd/rohd.dart';
@@ -78,7 +83,7 @@ Future<void> main({bool noPrint = false}) async {
   // to other tools.
   final systemVerilogCode = counter.generateSynth();
   if (!noPrint) {
-    stdout.writeln(systemVerilogCode);
+    print(systemVerilogCode);
   }
 
   // Now let's try simulating!
@@ -101,7 +106,7 @@ Future<void> main({bool noPrint = false}) async {
   // Print a message when we're done with the simulation!
   Simulator.registerAction(100, () {
     if (!noPrint) {
-      stdout.writeln('Simulation completed!');
+      print('Simulation completed!');
     }
   });
 
@@ -113,7 +118,7 @@ Future<void> main({bool noPrint = false}) async {
 
   // We can take a look at the waves now.
   if (!noPrint) {
-    stdout.writeln('To view waves, check out waves.vcd with a waveform viewer'
+    print('To view waves, check out waves.vcd with a waveform viewer'
         ' (e.g. `gtkwave waves.vcd`).');
   }
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,7 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-// ignore_for_file: avoid_print
+// Import the standard library for I/O.
+import 'dart:io';
 
 // Import the ROHD package.
 import 'package:rohd/rohd.dart';
@@ -77,7 +78,7 @@ Future<void> main({bool noPrint = false}) async {
   // to other tools.
   final systemVerilogCode = counter.generateSynth();
   if (!noPrint) {
-    print(systemVerilogCode);
+    stdout.writeln(systemVerilogCode);
   }
 
   // Now let's try simulating!
@@ -100,7 +101,7 @@ Future<void> main({bool noPrint = false}) async {
   // Print a message when we're done with the simulation!
   Simulator.registerAction(100, () {
     if (!noPrint) {
-      print('Simulation completed!');
+      stdout.writeln('Simulation completed!');
     }
   });
 
@@ -112,7 +113,7 @@ Future<void> main({bool noPrint = false}) async {
 
   // We can take a look at the waves now.
   if (!noPrint) {
-    print('To view waves, check out waves.vcd with a waveform viewer'
+    stdout.writeln('To view waves, check out waves.vcd with a waveform viewer'
         ' (e.g. `gtkwave waves.vcd`).');
   }
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// example.dart
@@ -10,17 +10,18 @@
 
 // ignore_for_file: avoid_print
 
-// Import the ROHD package
+// Import the ROHD package.
 import 'package:rohd/rohd.dart';
 
-// Define a class Counter that extends ROHD's abstract Module class
+// Define a class Counter that extends ROHD's abstract Module class.
 class Counter extends Module {
   // For convenience, map interesting outputs to short variable names for
-  // consumers of this module
+  // consumers of this module.
   Logic get val => output('val');
 
-  // This counter supports any width, determined at run-time
+  // This counter supports any width, determined at run-time.
   final int width;
+
   Counter(Logic en, Logic reset, Logic clk,
       {this.width = 8, super.name = 'counter'}) {
     // Register inputs and outputs of the module in the constructor.
@@ -32,20 +33,20 @@ class Counter extends Module {
 
     final val = addOutput('val', width: width);
 
-    // A local signal named 'nextVal'
+    // A local signal named 'nextVal'.
     final nextVal = Logic(name: 'nextVal', width: width);
 
     // Assignment statement of nextVal to be val+1
-    // (<= is the assignment operator)
+    // ('<=' is the assignment operator).
     nextVal <= val + 1;
 
     // `Sequential` is like SystemVerilog's always_ff, in this case trigger on
-    // the positive edge of clk
+    // the positive edge of clk.
     Sequential(clk, [
       // `If` is a conditional if statement, like `if` in SystemVerilog
-      // always blocks
+      // always blocks.
       If(reset, then: [
-        // the '<' operator is a conditional assignment
+        // The '<' operator is a conditional assignment.
         val < 0
       ], orElse: [
         If(en, then: [val < nextVal])
@@ -61,7 +62,7 @@ Future<void> main({bool noPrint = false}) async {
   final en = Logic(name: 'en');
   final reset = Logic(name: 'reset');
 
-  // Generate a simple clock.  This will run along by itself as
+  // Generate a simple clock. This will run along by itself as
   // the Simulator goes.
   final clk = SimpleClockGenerator(10).clk;
 

--- a/example/fir_filter.dart
+++ b/example/fir_filter.dart
@@ -8,12 +8,8 @@
 /// Author: wswongat
 ///
 
-// For greater clarity in the example, one of the rules of code analysis
-// will be suppressed. Sometimes it can be useful, but you should always
-// evaluate the consequences of deviations from the set of static analysis
-// rules used in the project. Additional information is available at
-// https://dart.dev/guides/language/analysis-options
-//
+// Though we usually avoid them, for this example,
+// allow `print` messages (disable lint):
 // ignore_for_file: avoid_print
 
 import 'dart:io';

--- a/example/fir_filter.dart
+++ b/example/fir_filter.dart
@@ -1,76 +1,73 @@
+/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
+///
 /// fir_filter.dart
-/// A basic example of a FIR filter
+/// A basic example of a FIR filter.
 ///
 /// 2022 February 02
 /// Author: wswongat
 ///
-
-// ignore_for_file: avoid_print
 
 import 'dart:io';
 import 'package:rohd/rohd.dart';
 
 class FirFilter extends Module {
   // For convenience, map interesting outputs to short variable names for
-  // consumers of this module
+  // consumers of this module.
   Logic get out => output('out');
 
-  // This Fir Filter supports any width and depth, defined at runtime
+  // This Fir Filter supports any width and depth, defined at runtime.
   final int bitWidth;
   final int depth;
+
   FirFilter(Logic en, Logic resetB, Logic clk, Logic inputVal, List<int> coef,
       {this.bitWidth = 16, super.name = 'FirFilter'})
       : depth = coef.length {
-    // Register inputs and outputs of the module in the constructor
-    // Module logic must consume registered inputs and output to
-    // registered outputs
+    // Depth check.
     if (depth < 1) {
-      // Depth Check
       throw Exception('Depth parameter should more than 1');
     }
-    // Add input/output port
+
+    // Register inputs and outputs of the module in the constructor.
+    // Module logic must consume registered inputs and output to
+    // registered outputs.
+
+    // Register inputs.
     en = addInput('en', en);
     inputVal = addInput('inputVal', inputVal, width: bitWidth);
     resetB = addInput('resetB', resetB);
     clk = addInput('clk', clk);
-    // Generate input train
+
+    // Register output.
+    final out = addOutput('out', width: bitWidth);
+
+    // Generate input train.
     final z = List<Logic>.generate(
         depth, (index) => Logic(width: bitWidth, name: 'z$index'));
 
-    // Generate output
-    final out = addOutput('out', width: bitWidth);
-
-    // Initialize conditionalAssign list
+    // The ConditionalAssign list below is represent the FIR filter:
+    // sum[n] = z[n]*coef[n] + z[n-1]*coef[n-1] + ... + z[n-depth]*coef[n-depth]
     final inputTrain = [z[0] < inputVal];
     var sum = z[0] * coef[0];
     for (var i = 0; i < z.length - 1; i++) {
       inputTrain.add(z[i + 1] < z[i]);
       sum = sum + z[i + 1] * coef[i + 1];
     }
-    // The List above is represent the FIR filter
-    // sum[n] =
-    //    _z[n]*coef[n] + _z[n-1]*coef[n-1] + .... + _z[n-depth]*coef[n-depth]
 
     // `Sequential` is like SystemVerilog's always_ff,
-    // in this case trigger on the positive edge of clk
+    // in this case trigger on the positive edge of clk.
     Sequential(clk, [
       // `If` is a conditional if statement, like `if` in SystemVerilog
-      // always blocks
+      // always blocks.
       If(resetB,
           then: [
-            // `If` is a conditional if statement, like `if` in SystemVerilog
-            //  always blocks
             If(en, then: inputTrain + [out < sum], orElse: [
-              // the '<' operator is a conditional assignment
+              // The '<' operator is a conditional assignment.
               out < 0
             ])
           ],
-          orElse: [
-                // the '<' operator is a conditional assignment
-                out < 0
-                // Set all _z to zero
-              ] +
+          orElse: [out < 0] +
+              // Set all 'z' to zero.
               List<ConditionalAssign>.generate(depth, (index) => z[index] < 0))
     ]);
   }
@@ -78,38 +75,51 @@ class FirFilter extends Module {
 
 Future<void> main({bool noPrint = false}) async {
   const sumWidth = 8;
+
+  // Define some local signals.
   final en = Logic(name: 'en');
   final resetB = Logic(name: 'resetB');
   final inputVal = Logic(name: 'inputVal', width: sumWidth);
 
+  // Generate a simple clock. This will run along by itself as
+  // the Simulator goes.
   final clk = SimpleClockGenerator(5).clk;
-  // 4-cycle delay coefficients
+
+  // 4-cycle delay coefficients.
   final firFilter =
       FirFilter(en, resetB, clk, inputVal, [0, 0, 0, 1], bitWidth: sumWidth);
 
+  // Build a FIR filter.
   await firFilter.build();
 
-  // Generate systemverilog code to file
+  // Generate SystemVerilog code.
   final systemVerilogCode = firFilter.generateSynth();
   if (!noPrint) {
-    // Print systemverilog code to console
-    print(systemVerilogCode);
-    // Save systemverilog code to file
+    // Print SystemVerilog code to console.
+    stdout.writeln(systemVerilogCode);
+    // Save SystemVerilog code to file.
     File('rtl.sv').writeAsStringSync(systemVerilogCode);
   }
 
+  // Now let's try simulating!
+
+  // Let's set the initial setting.
   en.put(0);
   resetB.put(0);
   inputVal.put(1);
 
-  // Attach a waveform dumper
+  // Attach a waveform dumper.
   if (!noPrint) {
     WaveDumper(firFilter);
   }
 
+  // Raise enable at time 5.
   Simulator.registerAction(5, () => en.put(1));
+
+  // Raise resetB at time 10.
   Simulator.registerAction(10, () => resetB.put(1));
 
+  // Plan the input sequence.
   for (var i = 1; i < 10; i++) {
     Simulator.registerAction(5 + i * 4, () => inputVal.put(i));
   }
@@ -117,19 +127,19 @@ Future<void> main({bool noPrint = false}) async {
   // Print a message when we're done with the simulation!
   Simulator.registerAction(100, () {
     if (!noPrint) {
-      print('Simulation completed!');
+      stdout.writeln('Simulation completed!');
     }
   });
 
-  // Set a maximum time for the simulation so it doesn't keep running forever
+  // Set a maximum time for the simulation so it doesn't keep running forever.
   Simulator.setMaxSimTime(100);
 
-  // Kick off the simulation
+  // Kick off the simulation.
   await Simulator.run();
 
-  // We can take a look at the waves now
+  // We can take a look at the waves now.
   if (!noPrint) {
-    print('To view waves, check out waves.vcd with a'
+    stdout.writeln('To view waves, check out waves.vcd with a'
         ' waveform viewer (e.g. `gtkwave waves.vcd`).');
   }
 }

--- a/example/fir_filter.dart
+++ b/example/fir_filter.dart
@@ -8,6 +8,14 @@
 /// Author: wswongat
 ///
 
+// For greater clarity in the example, one of the rules of code analysis
+// will be suppressed. Sometimes it can be useful, but you should always
+// evaluate the consequences of deviations from the set of static analysis
+// rules used in the project. Additional information is available at
+// https://dart.dev/guides/language/analysis-options
+//
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 import 'package:rohd/rohd.dart';
 
@@ -96,7 +104,7 @@ Future<void> main({bool noPrint = false}) async {
   final systemVerilogCode = firFilter.generateSynth();
   if (!noPrint) {
     // Print SystemVerilog code to console.
-    stdout.writeln(systemVerilogCode);
+    print(systemVerilogCode);
     // Save SystemVerilog code to file.
     File('rtl.sv').writeAsStringSync(systemVerilogCode);
   }
@@ -127,7 +135,7 @@ Future<void> main({bool noPrint = false}) async {
   // Print a message when we're done with the simulation!
   Simulator.registerAction(100, () {
     if (!noPrint) {
-      stdout.writeln('Simulation completed!');
+      print('Simulation completed!');
     }
   });
 
@@ -139,7 +147,7 @@ Future<void> main({bool noPrint = false}) async {
 
   // We can take a look at the waves now.
   if (!noPrint) {
-    stdout.writeln('To view waves, check out waves.vcd with a'
+    print('To view waves, check out waves.vcd with a'
         ' waveform viewer (e.g. `gtkwave waves.vcd`).');
   }
 }

--- a/example/fir_filter.dart
+++ b/example/fir_filter.dart
@@ -1,4 +1,3 @@
-/// Copyright (C) 2022-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// fir_filter.dart

--- a/example/tree.dart
+++ b/example/tree.dart
@@ -8,7 +8,14 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-import 'dart:io';
+// For greater clarity in the example, one of the rules of code analysis
+// will be suppressed. Sometimes it can be useful, but you should always
+// evaluate the consequences of deviations from the set of static analysis
+// rules used in the project. Additional information is available at
+// https://dart.dev/guides/language/analysis-options
+//
+// ignore_for_file: avoid_print
+
 import 'package:rohd/rohd.dart';
 
 /// The below example demonstrates some aspects of the power of ROHD where
@@ -85,6 +92,6 @@ Future<void> main({bool noPrint = false}) async {
   await tree.build();
   final generatedSystemVerilog = tree.generateSynth();
   if (!noPrint) {
-    stdout.writeln(generatedSystemVerilog);
+    print(generatedSystemVerilog);
   }
 }

--- a/example/tree.dart
+++ b/example/tree.dart
@@ -1,4 +1,4 @@
-/// Copyright (C) 2021 Intel Corporation
+/// Copyright (C) 2021-2023 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 ///
 /// tree.dart
@@ -8,13 +8,12 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-// ignore_for_file: avoid_print
-
+import 'dart:io';
 import 'package:rohd/rohd.dart';
 
 /// The below example demonstrates some aspects of the power of ROHD where
 /// writing equivalent design code in SystemVerilog can be challenging or
-/// impossible.  The example is a port from an example used by Chisel.
+/// impossible. The example is a port from an example used by Chisel.
 ///
 /// The ROHD module `TreeOfTwoInputModules` is a succinct representation a
 /// logarithmic-height tree of arbitrary two-input/one-output modules.
@@ -30,7 +29,7 @@ import 'package:rohd/rohd.dart';
 ///       can be stored in variables). It expects a function which takes two
 ///       `Logic` inputs and provides one `Logic` output.
 /// - This module recursively instantiates itself, but with different numbers of
-///   inputs each time.  The same module implementation can have a variable
+///   inputs each time. The same module implementation can have a variable
 ///   number of inputs and different logic without any explicit
 ///   parameterization.
 
@@ -71,11 +70,12 @@ Future<void> main({bool noPrint = false}) async {
       (a, b) => mux(a > b, a, b));
 
   /// This instantiation code generates a list of sixteen 8-bit logic signals.
-  /// The operation to be performed (`_op`) is to create a `Mux` which returns
-  ///  `a` if `a` is greater than `b`, otherwise `b`.  Therefore, this
+  /// The operation to be performed (`_op`) is to create a `Mux` (in this case,
+  /// the `mux` helper function is used to create) which returns
+  /// `a` if `a` is greater than `b`, otherwise `b`. Therefore, this
   /// instantiation creates a logarithmic-height tree of modules which outputs
-  /// the largest 8-bit value.  Note that `Mux` also needs no parameters, as it
-  /// can automatically determine the appropriate size of `y` based on the
+  /// the largest 8-bit value. Note that `Mux` also needs no parameters, as it
+  /// can automatically determine the appropriate size of `out` based on the
   /// inputs.
   ///
   /// A SystemVerilog implementation of this requires numerous module
@@ -85,6 +85,6 @@ Future<void> main({bool noPrint = false}) async {
   await tree.build();
   final generatedSystemVerilog = tree.generateSynth();
   if (!noPrint) {
-    print(generatedSystemVerilog);
+    stdout.writeln(generatedSystemVerilog);
   }
 }

--- a/example/tree.dart
+++ b/example/tree.dart
@@ -8,12 +8,8 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-// For greater clarity in the example, one of the rules of code analysis
-// will be suppressed. Sometimes it can be useful, but you should always
-// evaluate the consequences of deviations from the set of static analysis
-// rules used in the project. Additional information is available at
-// https://dart.dev/guides/language/analysis-options
-//
+// Though we usually avoid them, for this example,
+// allow `print` messages (disable lint):
 // ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';


### PR DESCRIPTION
## Description & Motivation

Examples should be given special attention, as the quality of the examples can both attract and repel new users from the project.

This set of changes proposes:

* Remove `ignore_for_file: avoid_print` from examples, import `dart:io` and use `stdout.writeln('string')` instead of `print('string')`. Subjectively, ignoring the rules of the linter in the examples does not look very nice.
* Ignore `*.sv` files, because the `fir_filter.dart` example creates a `rtl.sv` file (maybe in the future there will be more examples that save the generated SystemVerilog to a file).
* Slightly tweak comments to match [Effective Dart](https://dart.dev/guides/language/effective-dart/documentation#comments) (dots, capital letters, etc).
* In the `fir_filter.dart` file, the declaration code and comments have been slightly rearranged to make the example more consistent.
* Other minor changes.

## Related Issue(s)

No.

## Testing

The only more or less significant change in the code is the use of the `stdout.writeln('string')` function instead of `print('string')`. You can check the functionality by running the examples.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Unfortunately, since the `dart:io` library is now used, it becomes impossible to compile examples in JS to run in browsers, but this should not be a problem since ROHD itself also uses the `dart:io` library.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

`README.md` contains the code from `example.dart`, but since `README.md` is under revision, it is better to make changes in the new version of `README.md`.