### PR TITLE
Add check for Markdown links in CI

### DIFF
--- a/.github/configs/mlc_config.json
+++ b/.github/configs/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html$"
+    }
+  ]
+}

--- a/.github/configs/mlc_config.json
+++ b/.github/configs/mlc_config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html$"
+      "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html"
     }
   ]
 }

--- a/.github/configs/mlc_config.json
+++ b/.github/configs/mlc_config.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html"
+      "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html$"
     }
   ]
 }

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Check Markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: yes
+
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
         with:
           use-quiet-mode: yes
           config-file: .github/configs/mlc_config.json

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -21,6 +21,7 @@ jobs:
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: yes
+          config-file: .github/configs/mlc_config.json
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Description & Motivation

### Motivation

Since the ROHD project uses `Markdown` for writing documentation and tutorials, it would be nice to make things easier to work with. One of them is link checking. As evidence of the urgency of the problem, you can refer here:

1. https://github.com/intel/rohd/pull/221#discussion_r1097825483
2. https://github.com/intel/rohd/pull/266#discussion_r1104862385

The proposed changes will completely solve the problem from the first point and mitigate the problem from the second point.

### Description

The changes themselves are:

* Add a new step to `CI`, during which a link health check will be performed.
* Add a configuration file, in particular allowing to overcome false positives.

The risks of adding a new [action](https://github.com/gaurav-nelson/github-action-markdown-link-check) are minimal as it is executed in a job without permissions (`permissions: {}`).

The configuration file comes with the address already added to the ignore list because there were [false positives](https://github.com/chykon/rohd/actions/runs/4196972120/jobs/7278680046). An attempt to go to the address from a personal device without a proxy also failed, but the site is accessible when using a proxy. Probably DDoS protection applied.

### Problems

Limited anchor link checking: available in [beta](https://github.com/gaurav-nelson/github-action-markdown-link-check/releases/tag/1.0.14) and only for headers located in the document itself (there is an open issue: <https://github.com/tcort/markdown-link-check/issues/212>).

Some alternative solutions have been explored, but all have a problem with handling anchor links pointing to other documents.

## Related Issue(s)

No.

## Testing

Several launches were made on our own branch:

1. (https://github.com/chykon/rohd/actions/runs/4196972120/jobs/7278680046) First run with a false positive. FAILURE.
2. (https://github.com/chykon/rohd/actions/runs/4197452723/jobs/7279783587) Second run with added ignore rule. SUCCESS.
3. (https://github.com/chykon/rohd/actions/runs/4197728761/jobs/7280432455) Third run with test files `test_a.md` and `test_b.md` demonstrating the ability to test anchor links. FAILURE.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.