### PR TITLE
Add recommended extensions for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ doc/api/
 # Other stuff
 tmp_test/
 *.vcd
-.vscode/
+.vscode/*
 
 # Exceptions
+!.vscode/extensions.json
 !test/example_icarus_waves.vcd

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "Dart-Code.dart-code"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
+// See https://go.microsoft.com/fwlink/?LinkId=827846
+// for the documentation about the `extensions.json` format.
+
 {
   "recommendations": [
     "Dart-Code.dart-code"


### PR DESCRIPTION
## Description & Motivation

It is suggested to add information about [recommended extensions](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions) to the project. This is similar to <https://github.com/intel/rohd/blob/da23c8bb3a222c26322c6474f2466093f60eb8b6/.devcontainer/devcontainer.json#L18-L20> in the `devcontainer.json` file, but is only a recommendation and works even without using containers:

![Снимок экрана от 2023-02-20 11-15-05](https://user-images.githubusercontent.com/82272369/220053024-b1e416d7-3d42-4ff7-8f29-7847b7d03473.png)

The motivation for the change is to make it easier for new members to contribute.

## Related Issue(s)

No.

## Testing

Removed the `Dart` extension, restarted the IDE, opened the cloned ROHD repository, got a suggestion to install the `Dart` extension.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

This can be mentioned, for example, in `README.md`, but these changes are not included in this PR.