### PR TITLE
Add `markdownlint` extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
     },
     "vscode": {
       "extensions": [
-        "Dart-Code.dart-code"
+        "Dart-Code.dart-code",
+        "DavidAnson.vscode-markdownlint"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ doc/api/
 # Other stuff
 tmp_test/
 *.vcd
-.vscode/
+.vscode/*
 
 # Exceptions
+!.vscode/extensions.json
 !test/example_icarus_waves.vcd

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "Dart-Code.dart-code"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 {
   "recommendations": [
     "Dart-Code.dart-code",
-    "ms-vscode-remote.remote-containers"
+    "ms-vscode-remote.remote-containers",
+    "DavidAnson.vscode-markdownlint"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 
 {
   "recommendations": [
-    "Dart-Code.dart-code"
+    "Dart-Code.dart-code",
+    "ms-vscode-remote.remote-containers"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
+// See https://go.microsoft.com/fwlink/?LinkId=827846
+// for the documentation about the `extensions.json` format.
+
 {
   "recommendations": [
     "Dart-Code.dart-code"


### PR DESCRIPTION
## Description & Motivation

**DEPENDS ON <https://github.com/intel/rohd/pull/277>**
**RELATED TO <https://github.com/intel/rohd/pull/280>**

It is suggested to add the [extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) for VSCode to the list of those installed in the container (`./devcontainer/devcontainer.json`) and the list of recommended ones (`.vscode/extensions.json`). The extension should make it easier to follow the established rules when working with Markdown.

## Related Issue(s)

No.

## Testing

Clone branch, open in VSCode, get suggestions for installing extensions.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

This can be mentioned, for example, in `README.md`, but these changes are not included in this PR.
