### PR TITLE
Add Markdown linting to CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v9
+        with:
+          globs: '**/*.md'
 
       - name: Check Markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.14

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Lint Markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v9
+
       - name: Check Markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
         with:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "default": true,
+    "MD041": false
+  },
+
+  "ignores": [
+    "doc/api/"
+  ]
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,7 @@
 {
   "config": {
     "default": true,
+    "MD013": false,
     "MD041": false
   },
 


### PR DESCRIPTION
## Description & Motivation

**RELATED TO <https://github.com/intel/rohd/pull/279>**

The motivation for the proposed changes is to make it easier to write collaboratively Markdown.

It is proposed to add a [new step](https://github.com/DavidAnson/markdownlint-cli2-action) to CI to allow parsing Markdown files for formatting issues or deprecated features that may not be handled correctly by some parsers.

Additionally, it is proposed (https://github.com/intel/rohd/pull/279) to add an extension that will allow you to correct errors when working with Markdown in an interactive form and in real time.

---

**ISSUES**

[Run](https://github.com/chykon/rohd/actions/runs/4217962760/jobs/7322121795) revealed a large number of errors. Most can be fixed automatically (eg `MD034/no-bare-urls`), but some require tweaking (eg string length). For now, it is recommended to install the extension from <https://github.com/intel/rohd/pull/279> and apply document formatting (`RMB -> Format Document`).

Perhaps some rules need to be redefined. For example, a string length of 80 characters seems too short for Markdown documents. Tell me which rules need to be overridden and I will prepare the appropriate configuration for CI/extension.

## Related Issue(s)

No.

## Testing

You can examine the run results here:
<https://github.com/chykon/rohd/actions/runs/4217962760/jobs/7322121795>.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

To be able to merge, you will need to correct the formatting of most Markdown files (which is a significant part of the documentation).
