### PR TITLE
Format Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,84 +1,91 @@
 ## 0.4.2
+
 - Added a GitHub Codespace to the repository as a quick way to experiment with ROHD without any environment setup.
-- Added `Conditional` operations similar to `++x` (`incr`), `--x` (`decr`), `x *= ` (`mulAssign`), and `x /=` (`divAssign`) to `Logic` (https://github.com/intel/rohd/issues/141).
-- Fixed a bug where generated SystemVerilog could perform index accesses on single-bit signals (https://github.com/intel/rohd/issues/204).
-- Expanded capability to construct single-`Conditional` more succinctly via `Else.s` (https://github.com/intel/rohd/issues/225).
-- Fixed a bug where sensitivities for `Combinational`s were excessively pessimistic (https://github.com/intel/rohd/issues/233).
-- Improved exceptions raised by `Logic.put` to include context on which signal was affected to help with debug (https://github.com/intel/rohd/pull/243).
-- Optimized `WaveDumper` to only periodically write data to the VCD file to improve performance (https://github.com/intel/rohd/pull/242).
-- Made `endIndex` in `getRange` an optional positional argument with a default value of `width`, enabling a more convenient method for collecting all bits from some index until the end (https://github.com/intel/rohd/issues/228).
-- Added an exception in cases where names of interface ports are invalid/unsanitary (https://github.com/intel/rohd/issues/234).
-- Upgraded the `Simulator` so that it would `await` asynchronous registered actions (https://github.com/intel/rohd/pull/252).
-- Deprecated `Logic.hasValidValue` and `Logic.isFloating` in favor of similar operations on `Logic.value` (https://github.com/intel/rohd/issues/198).
-- Added `Logic.isIn`, which generates logic computing whether the signal is equal to any values in a (optionally mixed) list of constants or other signals (https://github.com/intel/rohd/issues/7).
+- Added `Conditional` operations similar to `++x` (`incr`), `--x` (`decr`), `x *=` (`mulAssign`), and `x /=` (`divAssign`) to `Logic` (<https://github.com/intel/rohd/issues/141>).
+- Fixed a bug where generated SystemVerilog could perform index accesses on single-bit signals (<https://github.com/intel/rohd/issues/204>).
+- Expanded capability to construct single-`Conditional` more succinctly via `Else.s` (<https://github.com/intel/rohd/issues/225>).
+- Fixed a bug where sensitivities for `Combinational`s were excessively pessimistic (<https://github.com/intel/rohd/issues/233>).
+- Improved exceptions raised by `Logic.put` to include context on which signal was affected to help with debug (<https://github.com/intel/rohd/pull/243>).
+- Optimized `WaveDumper` to only periodically write data to the VCD file to improve performance (<https://github.com/intel/rohd/pull/242>).
+- Made `endIndex` in `getRange` an optional positional argument with a default value of `width`, enabling a more convenient method for collecting all bits from some index until the end (<https://github.com/intel/rohd/issues/228>).
+- Added an exception in cases where names of interface ports are invalid/unsanitary (<https://github.com/intel/rohd/issues/234>).
+- Upgraded the `Simulator` so that it would `await` asynchronous registered actions (<https://github.com/intel/rohd/pull/252>).
+- Deprecated `Logic.hasValidValue` and `Logic.isFloating` in favor of similar operations on `Logic.value` (<https://github.com/intel/rohd/issues/198>).
+- Added `Logic.isIn`, which generates logic computing whether the signal is equal to any values in a (optionally mixed) list of constants or other signals (<https://github.com/intel/rohd/issues/7>).
 
 ## 0.4.1
-- Fixed a bug where `Module`s could have invalid names in generated SystemVerilog (https://github.com/intel/rohd/issues/138).
+
+- Fixed a bug where `Module`s could have invalid names in generated SystemVerilog (<https://github.com/intel/rohd/issues/138>).
 - Fixed a bug where `Logic`s could have invalid names in generated SystemVerilog.
-- Added a feature allowing access of an index of a `Logic` via another `Logic` (https://github.com/intel/rohd/issues/153).
-- Fixed a bug where multiple sequential driver issues might not be caught during ROHD simulation (https://github.com/intel/rohd/issues/114).
+- Added a feature allowing access of an index of a `Logic` via another `Logic` (<https://github.com/intel/rohd/issues/153>).
+- Fixed a bug where multiple sequential driver issues might not be caught during ROHD simulation (<https://github.com/intel/rohd/issues/114>).
 - Improved `Exception`s in ROHD with better error messages and more granular exception types to make handling easier.
-- Improved generated SystemVerilog for sign extension and added capability for replication (https://github.com/intel/rohd/issues/157).
-- Fixed a bug where signal names and module instance names could collide in generated SystemVerilog (https://github.com/intel/rohd/issues/205).
+- Improved generated SystemVerilog for sign extension and added capability for replication (<https://github.com/intel/rohd/issues/157>).
+- Fixed a bug where signal names and module instance names could collide in generated SystemVerilog (<https://github.com/intel/rohd/issues/205>).
 - Fixed a bug where in some cases modules might not be properly detected as sub-modules, leading to erroneous omission in generated outputs.
-- Added capability to perform modulo and shift operations on `Logic` via a constant values (https://github.com/intel/rohd/pull/208).
-- Completed a fix for a bug where shifting a `Logic` by a constant would throw an exception (https://github.com/intel/rohd/issues/170).
-- Modified the mechanism by which signal propagation occurs between `Logic`s so that connected `Logic`s share an underlying value-holding entity (https://github.com/intel/rohd/pull/199).  One significant implication is that modifying a value of a `Logic` (e.g. via `put` or `inject`) will now affect the value of both downstream *and* upstream connected `Logic`s instead of only downstream.  This change also can significantly improve simulation performance in connection-heavy designs.  Additionally, this change helps mitigate an issue where very long combinational chains of logic can hit the stack size limit (https://github.com/intel/rohd/issues/194).
-- Fixed a bug where large unsigned values on `LogicValue`s would convert to incorrect `int` values (https://github.com/intel/rohd/issues/212).
+- Added capability to perform modulo and shift operations on `Logic` via a constant values (<https://github.com/intel/rohd/pull/208>).
+- Completed a fix for a bug where shifting a `Logic` by a constant would throw an exception (<https://github.com/intel/rohd/issues/170>).
+- Modified the mechanism by which signal propagation occurs between `Logic`s so that connected `Logic`s share an underlying value-holding entity (<https://github.com/intel/rohd/pull/199>).  One significant implication is that modifying a value of a `Logic` (e.g. via `put` or `inject`) will now affect the value of both downstream *and* upstream connected `Logic`s instead of only downstream.  This change also can significantly improve simulation performance in connection-heavy designs.  Additionally, this change helps mitigate an issue where very long combinational chains of logic can hit the stack size limit (<https://github.com/intel/rohd/issues/194>).
+- Fixed a bug where large unsigned values on `LogicValue`s would convert to incorrect `int` values (<https://github.com/intel/rohd/issues/212>).
 - Added an extension on `BigInt` to perform unsigned conversion to an `int`.
-- Added a capability to construct some `Conditional` types (e.g. `If`) which have only a single `Conditional` more succinctly (https://github.com/intel/rohd/issues/12).
-- Optimized some operations in `LogicValue` for performance (https://github.com/intel/rohd/pull/215).
-- Added a shortcut to create a 0-width `LogicValue` called `LogicValue.empty` (https://github.com/intel/rohd/issues/202).
-- Fixed a bug where equal `LogicValue`s could have unequal hash codes (https://github.com/intel/rohd/issues/206).  The fix also improved internal representation consistency for `LogicValue`s, which could provide a significant performance improvement when wide values are used often.
+- Added a capability to construct some `Conditional` types (e.g. `If`) which have only a single `Conditional` more succinctly (<https://github.com/intel/rohd/issues/12>).
+- Optimized some operations in `LogicValue` for performance (<https://github.com/intel/rohd/pull/215>).
+- Added a shortcut to create a 0-width `LogicValue` called `LogicValue.empty` (<https://github.com/intel/rohd/issues/202>).
+- Fixed a bug where equal `LogicValue`s could have unequal hash codes (<https://github.com/intel/rohd/issues/206>).  The fix also improved internal representation consistency for `LogicValue`s, which could provide a significant performance improvement when wide values are used often.
 
 ## 0.4.0
-- Fixed a bug where generated SystemVerilog could apply bit slicing to an expression (https://github.com/intel/rohd/issues/163).
-- Fixed a bug where constant collapsing in SystemVerilog could erroneously remove constant assignments (https://github.com/intel/rohd/issues/159).
-- Fixed a bug where `Combinational` could have an incomplete sensitivity list causing incorrect simulation behavior (https://github.com/intel/rohd/issues/158).
-- Significantly improved simulation performance of `Combinational` (https://github.com/intel/rohd/issues/106).
+
+- Fixed a bug where generated SystemVerilog could apply bit slicing to an expression (<https://github.com/intel/rohd/issues/163>).
+- Fixed a bug where constant collapsing in SystemVerilog could erroneously remove constant assignments (<https://github.com/intel/rohd/issues/159>).
+- Fixed a bug where `Combinational` could have an incomplete sensitivity list causing incorrect simulation behavior (<https://github.com/intel/rohd/issues/158>).
+- Significantly improved simulation performance of `Combinational` (<https://github.com/intel/rohd/issues/106>).
 - Upgraded and made lints more strict within ROHD, leading to some quality and documentation improvements.
-- Added a feature allowing negative indexing to access relative to the end of a `Logic` or `LogicValue` (https://github.com/intel/rohd/issues/99).
+- Added a feature allowing negative indexing to access relative to the end of a `Logic` or `LogicValue` (<https://github.com/intel/rohd/issues/99>).
 - Breaking: Increased minimum Dart SDK version to 2.18.0.
-- Fixed a bug when parsing unsigned large binary integers (https://github.com/intel/rohd/issues/183).
-- Exposed `SynthesisResult`s from the `SynthBuilder`, making it easier to generate SystemVerilog modules into independent files (https://github.com/intel/rohd/issues/172).
-- Breaking: Renamed `topModuleName` to `definitionName` in `ExternalSystemVerilogModule` (https://github.com/intel/rohd/issues/169).
-- Added the `mux` function as a shortcut for building a `Mux` and returning the output of it (https://github.com/intel/rohd/issues/13).
-- Deprecation: Improved naming of ports on basic gates, old port names remain accessible but deprecated for now (https://github.com/intel/rohd/issues/135).
-- Fixed list of reserved SystemVerilog keywords for sanitization (https://github.com/intel/rohd/issues/168).
+- Fixed a bug when parsing unsigned large binary integers (<https://github.com/intel/rohd/issues/183>).
+- Exposed `SynthesisResult`s from the `SynthBuilder`, making it easier to generate SystemVerilog modules into independent files (<https://github.com/intel/rohd/issues/172>).
+- Breaking: Renamed `topModuleName` to `definitionName` in `ExternalSystemVerilogModule` (<https://github.com/intel/rohd/issues/169>).
+- Added the `mux` function as a shortcut for building a `Mux` and returning the output of it (<https://github.com/intel/rohd/issues/13>).
+- Deprecation: Improved naming of ports on basic gates, old port names remain accessible but deprecated for now (<https://github.com/intel/rohd/issues/135>).
+- Fixed list of reserved SystemVerilog keywords for sanitization (<https://github.com/intel/rohd/issues/168>).
 
 ## 0.3.2
+
 - Added the `StateMachine` abstraction for finite state machines.
 - Added support for the modulo `%` operator.
 - Added ability to register actions to be executed at the end of the simulation.
-- Modified the `WaveDumper` to write to the `.vcd` file asynchronously to improve simulation performance while waveform dumping is enabled (https://github.com/intel/rohd/issues/3)
+- Modified the `WaveDumper` to write to the `.vcd` file asynchronously to improve simulation performance while waveform dumping is enabled (<https://github.com/intel/rohd/issues/3>)
 
 ## 0.3.1
-- Fixed a bug (introduced in v0.3.0) where `WaveDumper` doesn't properly dump multi-bit values to VCD (https://github.com/intel/rohd/issues/129).
+
+- Fixed a bug (introduced in v0.3.0) where `WaveDumper` doesn't properly dump multi-bit values to VCD (<https://github.com/intel/rohd/issues/129>).
 
 ## 0.3.0
+
 - Breaking: Merged `LogicValue` and `LogicValues` into one type called `LogicValue`.
 - Deprecation: Aligned `LogicValue` to `Logic` by renaming `length` to `width`.
 - Breaking: `Logic.put` no longer accepts `List<LogicValue>`, swizzle it together instead.
 - Deprecated `Logic.valueInt` and `Logic.valueBigInt`; instead use equivalent functions on `Logic.value`.
 - Deprecated `bit` on both `LogicValue` and `Logic`; instead just check `width`.
 - Added ability in `LogicValue.toString` to decide whether or not to include the width annotation through `includeWidth` argument.
-- Fixed a bug related to zero-width construction of `LogicValue`s (https://github.com/intel/rohd/issues/90).
-- Fixed a bug where generated constants in SystemVerilog had no width, which can cause issues in some cases (e.g. swizzles) (https://github.com/intel/rohd/issues/89)
-- Added capability to convert binary strings to ints with underscore separators using `bin` (https://github.com/intel/rohd/issues/56).
+- Fixed a bug related to zero-width construction of `LogicValue`s (<https://github.com/intel/rohd/issues/90>).
+- Fixed a bug where generated constants in SystemVerilog had no width, which can cause issues in some cases (e.g. swizzles) (<https://github.com/intel/rohd/issues/89>)
+- Added capability to convert binary strings to ints with underscore separators using `bin` (<https://github.com/intel/rohd/issues/56>).
 - Added `getRange` and `reversed` on `Logic` and `slice` on `LogicValue` to improve consistency.
 - Using `slice` in reverse-index order now reverses the order.
-- Added the ability to extend signals (e.g. `zeroExtend` and `signExtend`) on both `Logic` and `LogicValue` (https://github.com/intel/rohd/issues/101).
+- Added the ability to extend signals (e.g. `zeroExtend` and `signExtend`) on both `Logic` and `LogicValue` (<https://github.com/intel/rohd/issues/101>).
 - Improved flexibility of `IfBlock`.
-- Added `withSet` on `LogicValue` and `Logic` to make it easier to assign subsets of signals and values (https://github.com/intel/rohd/issues/101).
-- Fixed a bug where 0-bit signals would sometimes improperly generate 0-bit constants in generated SystemVerilog (https://github.com/intel/rohd/issues/122).
+- Added `withSet` on `LogicValue` and `Logic` to make it easier to assign subsets of signals and values (<https://github.com/intel/rohd/issues/101>).
+- Fixed a bug where 0-bit signals would sometimes improperly generate 0-bit constants in generated SystemVerilog (<https://github.com/intel/rohd/issues/122>).
 - Added capability to reserve instance names, as well as provide and reserve definition names, for `Module`s and their corresponding generated outputs.
 
 ## 0.2.0
+
 - Updated implementation to avoid `Iterable.forEach` to make debug easier.
-- Added `ofBool` to `LogicValue` and `LogicValues` (https://github.com/intel/rohd/issues/34).
+- Added `ofBool` to `LogicValue` and `LogicValues` (<https://github.com/intel/rohd/issues/34>).
 - Breaking: updated `Interface` API so that `getPorts` returns a `Map` from port names to `Logic` signals instead of just a list, which makes it easier to work with when names are uniquified.
 - Breaking: removed `setPort` from `Interface`.  Use `setPorts` instead.
-- Deprecated `swizzle` and `rswizzle` global functions and replaced them with extensions on `List`s of certain types including `Logic`, `LogicValue`, and `LogicValues` (https://github.com/intel/rohd/issues/70). 
+- Deprecated `swizzle` and `rswizzle` global functions and replaced them with extensions on `List`s of certain types including `Logic`, `LogicValue`, and `LogicValues` (<https://github.com/intel/rohd/issues/70>).
 - Breaking: renamed `ExternalModule` to `ExternalSystemVerilogModule` since it is specifically for SystemVerilog.
 - Breaking: made `topModuleName` a required named parameter in `ExternalSystemVerilogModule` to reduce confusion.
 - Added `simulationHasEnded` bool to `Simulator`.
@@ -86,18 +93,20 @@
 - Fixed bug where `Simulator` warns about maximum simulation time when not appropriate.
 - Fixed a bug where `ExternalSystemVerilogModule` could enter infinite recursion.
 - Some improvements to `SimCompare` to properly check values at the end of a tick and support a wider variety of values in `Vector`s.
-- Fixed a bug related to `Sequential` signal sampling where under certain scenarios, signals would pass through instead of being flopped (https://github.com/intel/rohd/issues/79).
-- Deprecated a number of `from` functions and replaced them with `of` to more closely follow Dart conventions (https://github.com/intel/rohd/issues/72).
+- Fixed a bug related to `Sequential` signal sampling where under certain scenarios, signals would pass through instead of being flopped (<https://github.com/intel/rohd/issues/79>).
+- Deprecated a number of `from` functions and replaced them with `of` to more closely follow Dart conventions (<https://github.com/intel/rohd/issues/72>).
 
 ## 0.1.2
+
 - Optimized construction of `LogicValues` to improve performance
 - Renamed `FF` to `Sequential` (marked `FF` as deprecated) (breaking: removed `clk` signal)
-- Added `Sequential.multi` for multi-edge-triggered blocks (https://github.com/intel/rohd/issues/42)
-- Improved exception and error messages (https://github.com/intel/rohd/issues/64)
+- Added `Sequential.multi` for multi-edge-triggered blocks (<https://github.com/intel/rohd/issues/42>)
+- Improved exception and error messages (<https://github.com/intel/rohd/issues/64>)
 
 ## 0.1.1
-- Fix `Interface.connectIO` bug when no tags specified (https://github.com/intel/rohd/issues/38)
-- Fix uniquified `Interface.getPorts` bug (https://github.com/intel/rohd/issues/59)
+
+- Fix `Interface.connectIO` bug when no tags specified (<https://github.com/intel/rohd/issues/38>)
+- Fix uniquified `Interface.getPorts` bug (<https://github.com/intel/rohd/issues/59>)
 
 ## 0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,63 +10,78 @@ Anyone interested in participating in ROHD is more than welcome to help!
 ROHD adopts the Contributor Covenant v2.1 for the code of conduct.  It can be accessed [here](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md).
 
 ## Getting Help
+
 ### Chat on Discord
+
 Discord is a free online instant messaging app which you can use directly in your web browser or install to your device.  Feel free to join to look around at the conversations and have a real-time discussion with the ROHD community.  This a great place to ask questions, get help, engage with the rest of the community, and discuss new ideas.
 
-Join the Discord server here: https://discord.com/invite/jubxF84yGw
+Join the Discord server here: <https://discord.com/invite/jubxF84yGw>
 
 ### Issues
+
 If something doesn't seem right, you're stuck, there's a critical feature/enhancement missing, you find a bug, etc. then filing an issue on the GitHub repository is a great option.  Please try to provide as much detail as possible.  Complete, stand-alone reproduction instructions are extremely helpful for bugs!
 
-You can file an issue here: https://github.com/intel/rohd/issues/new
+You can file an issue here: <https://github.com/intel/rohd/issues/new>
 
 ### Discussions
+
 GitHub Discussions is a place where you can find announcements, ask questions, share ideas, show new things you're working on, or just discuss in general with the community!  If you have a question or need some help, this is a great place to go.
 
-You can access the discussions area here: https://github.com/intel/rohd/discussions
+You can access the discussions area here: <https://github.com/intel/rohd/discussions>
 
 ### StackOverflow
+
 StackOverflow.com is a great tool to ask questions and get answers from the community.  Use the `rohd` tag when asking your question so that others in the community who subscribe to that tag can find and answer your question more quickly!
 
 ### Meetings in the ROHD Forum
+
 The [ROHD Forum](https://github.com/intel/rohd/wiki/ROHD-Forum) is a periodic virtual meeting for developers and users of ROHD that anyone can join.  Feel free to join the call!
 
 ## Getting Started
 
 ### Requirements
-You must have [Dart](https://dart.dev/) installed on your system to use ROHD.  You can find detailed instructions for how to install Dart here:
-https://dart.dev/get-dart
 
-To run the complete ROHD test suite for development, you need to install [Icarus Verilog](http://iverilog.icarus.com/).  It is used to compare SystemVerilog functionality with the ROHD simulator functionality.  Installation instructions are available here: https://iverilog.fandom.com/wiki/Installation_Guide
+You must have [Dart](https://dart.dev/) installed on your system to use ROHD.  You can find detailed instructions for how to install Dart here:
+<https://dart.dev/get-dart>
+
+To run the complete ROHD test suite for development, you need to install [Icarus Verilog](http://iverilog.icarus.com/).  It is used to compare SystemVerilog functionality with the ROHD simulator functionality.  Installation instructions are available here: <https://iverilog.fandom.com/wiki/Installation_Guide>
 
 ### Setup Recommendations
 
 #### On your own system
-[Visual Studio Code (vscode)](https://code.visualstudio.com/) is a great IDE for development.  You can find installation instructions for vscode here: https://code.visualstudio.com/Download
 
-If you're developing on a remote host, vscode has a Remote SSH extension that can help: https://code.visualstudio.com/blogs/2019/07/25/remote-ssh
+[Visual Studio Code (vscode)](https://code.visualstudio.com/) is a great IDE for development.  You can find installation instructions for vscode here: <https://code.visualstudio.com/Download>
 
-If you're on Microsoft Windows, you may want to consider developing with Ubuntu WSL for a Linux environment: https://docs.microsoft.com/en-us/windows/wsl/install-win10
+If you're developing on a remote host, vscode has a Remote SSH extension that can help: <https://code.visualstudio.com/blogs/2019/07/25/remote-ssh>
+
+If you're on Microsoft Windows, you may want to consider developing with Ubuntu WSL for a Linux environment: <https://docs.microsoft.com/en-us/windows/wsl/install-win10>
 
 #### In a GitHub Codespace
+
 [GitHub Codespaces](https://github.com/features/codespaces) are a great feature provided by GitHub allowing you to get into a development environment based on a pre-configured container very quickly!  You can use them for a limited number of hours per month for free.  ROHD has set up GitHub Codespaces so that you can immediately start running examples and developing.
 
 The below button will allow you to create a GitHub Codespace with ROHD already cloned and ready to roll:
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=409325108)
 
 ### Cloning and Running the Tests
+
 Once requirements are installed, you can clone and run the test suite.
+
 ```
 git clone https://github.com/intel/rohd.git
 cd rohd
 dart pub get
 dart test
 ```
+
 ## How to Contribute
+
 ### Reporting Bugs
+
 Please report any bugs you find as a GitHub issue. Please try to provide as much detail as possible. Complete, stand-alone reproduction instructions are extremely helpful for bugs!
 
 Some helpful information you can include:
+
 * Output of `dart --version`
 * Your dependencies from pubspec.yaml
 * The version of ROHD you're using
@@ -74,18 +89,23 @@ Some helpful information you can include:
 * Reproduction code and steps
 
 ### Suggesting Enhancements
+
 If you have an idea for a feature or enhancement that would make ROHD better, feel free to submit a GitHub issue!  Discussion on the ticket about pros & cons, strategy, etc. is encouraged.
 
 ### Discussing Issues
+
 If you have an opinion or helpful information on any open issue, feel free to comment!  Even if you don't have the time to implement a change, providing valuable input is great too!
 
 ### Fix or implement an Issue
+
 Take a look around the issues on the repo and see if there's any you'd like to take ownership of.  For your first contributions, look for issues tagged with `good first issue`, which are intended to be easier to get started with.  Feel free to ask for help or guidance!
 
 ### Pull Requests
+
 If you have a change that you have implemented and would like to contribute, you can open a pull request.  Please try to make sure you have implemented tests covering the changes, if applicable.  Smaller, simpler pull requests are easier to review.
 
 Be sure to run the test suite (`dart test`) before asking for your code to be merged.  You may also locally generate API documentation (`dartdoc`) to make sure it looks right and doesn't have any errors.  You should use the dart formatter on all code (`dart format .`), and may prefer to have it automatically format on every file save.  If you're using Visual Studio Code, you could add this to `settings.json`:
+
 ```json
 "[dart]": {
     "editor.defaultFormatter": "Dart-Code.dart-code",
@@ -98,6 +118,7 @@ Be sure to run the test suite (`dart test`) before asking for your code to be me
 Maintainers of the project and other community members will provide feedback and help iterate as necessary until the contribution is ready to be merged.
 
 Please include the SPDX tag near the top of any new files you create:
+
 ```dart
 /// SPDX-License-Identifier: BSD-3-Clause
 ```
@@ -105,16 +126,19 @@ Please include the SPDX tag near the top of any new files you create:
 You may find that reading the [Architecture](doc/Architecture.md) document will be helpful to becoming familiar with the design of the ROHD framework.
 
 ### Creating a New Package
+
 Not every new contribution has to go directly into the ROHD framework!  If you have an idea for a reusable piece of hardware, tooling, verification collateral, or anything else that helps the ROHD ecosystem but is somewhat standalone, you can make your own package that depends on ROHD.  Building an ecosystem of reusable components is important to the success of ROHD.  Reach out if you want some help or guidance deciding if or how you should create a new package.
 
 ## Style
+
 ROHD follows the official Dart recommended style guides and lints.  The analyzer will help ensure that your code is written consistently with the rest of ROHD.
 
 Here are some links to help guide you on style as recommended by Dart:
-* Effective Dart: https://dart.dev/guides/language/effective-dart
-* Style: https://dart.dev/guides/language/effective-dart/style
-* Documentation: https://dart.dev/guides/language/effective-dart/documentation
-* Usage: https://dart.dev/guides/language/effective-dart/usage
-* Design: https://dart.dev/guides/language/effective-dart/design
+
+* Effective Dart: <https://dart.dev/guides/language/effective-dart>
+* Style: <https://dart.dev/guides/language/effective-dart/style>
+* Documentation: <https://dart.dev/guides/language/effective-dart/documentation>
+* Usage: <https://dart.dev/guides/language/effective-dart/usage>
+* Design: <https://dart.dev/guides/language/effective-dart/design>
 
 We recommend following these same guidelines for any of your own packages you may create for the ecosystem, as well.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The below button will allow you to create a GitHub Codespace with ROHD already c
 
 Once requirements are installed, you can clone and run the test suite.
 
-```
+```shell
 git clone https://github.com/intel/rohd.git
 cd rohd
 dart pub get

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![License](https://img.shields.io/badge/License-BSD--3-blue)](https://github.com/intel/rohd/blob/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md)
 
-
-
 Rapid Open Hardware Development (ROHD) Framework
 ================================================
 
 ## Describing Hardware in Dart with ROHD
+
 ROHD (pronounced like "road") is a framework for describing and verifying hardware in the Dart programming language.  ROHD enables you to build and traverse a graph of connectivity between module objects using unrestricted software.
 
 Features of ROHD include:
+
 - Full power of the modern **Dart language** for hardware design and verification
 - Makes **validation collateral** simpler to develop and debug.  The [ROHD Verification Framework](https://github.com/intel/rohd-vf) helps build well-structured testbenches.
 - Develop **layers of abstraction** within a hardware design, making it more flexible and powerful
@@ -48,7 +48,7 @@ Because it is designed with asynchronous requests in mind (i.e. sending a reques
 
 Dart can compile to native machine code, but also includes its own high-performance VM and a JIT compiler.  During development, you can use a feature called "hot reload" to change code while the program is actively executing.
 
-Dart has an excellent package manager called "pub" (https://pub.dev).  It is possible to host a private Dart Pub server for packages that shouldn't be shared broadly (e.g. Top-Secret IP).
+Dart has an excellent package manager called "pub" (<https://pub.dev>).  It is possible to host a private Dart Pub server for packages that shouldn't be shared broadly (e.g. Top-Secret IP).
 
 ### The Challenge of Justifying Trying a New Language
 
@@ -60,32 +60,35 @@ If you're thinking "SystemVerilog is just fine, I don't need something new", it 
 
 ### More Information on Dart
 
-Try out Dart instantly from your browser here (it supports ROHD too!): https://dartpad.dev/?null_safety=true
+Try out Dart instantly from your browser here (it supports ROHD too!): <https://dartpad.dev/?null_safety=true>
 
-See some Dart language samples here: https://dart.dev/samples
+See some Dart language samples here: <https://dart.dev/samples>
 
-For more information on Dart and tutorials, see https://dart.dev/ and https://dart.dev/overview
+For more information on Dart and tutorials, see <https://dart.dev/> and <https://dart.dev/overview>
 
 ## Development Recommendations
+
 - The [ROHD Verification Framework](https://github.com/intel/rohd-vf) is a UVM-like framework for building testbenches for hardware modelled in ROHD.
 - The [ROHD Cosimulation](https://github.com/intel/rohd-cosim) package allows you to cosimulate the ROHD simulator with a variety of SystemVerilog simulators.
 - Visual Studio Code (vscode) is a great, free IDE with excellent support for Dart.  It works well on all platforms, including native Windows or Windows Subsystem for Linux (WSL) which allows you to run a native Linux kernel (e.g. Ubuntu) within Windows.  You can also use vscode to develop on a remote machine with the Remote SSH extension.
-    - vscode: https://code.visualstudio.com/
-    - WSL: https://docs.microsoft.com/en-us/windows/wsl/install-win10
-    - Remote SSH: https://code.visualstudio.com/blogs/2019/07/25/remote-ssh
-    - Dart extension for vscode: https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code
+  - vscode: <https://code.visualstudio.com/>
+  - WSL: <https://docs.microsoft.com/en-us/windows/wsl/install-win10>
+  - Remote SSH: <https://code.visualstudio.com/blogs/2019/07/25/remote-ssh>
+  - Dart extension for vscode: <https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code>
 
 ## Getting started
-Once you have Dart installed, if you don't already have a project, you can create one using `dart create`: https://dart.dev/tools/dart-tool
 
-Then add ROHD as a dependency to your pubspec.yaml file.  ROHD is [registered](https://pub.dev/packages/rohd) on pub.dev.  The easiest way to add ROHD as a dependency is following the instructions here https://pub.dev/packages/rohd/install.
+Once you have Dart installed, if you don't already have a project, you can create one using `dart create`: <https://dart.dev/tools/dart-tool>
+
+Then add ROHD as a dependency to your pubspec.yaml file.  ROHD is [registered](https://pub.dev/packages/rohd) on pub.dev.  The easiest way to add ROHD as a dependency is following the instructions here <https://pub.dev/packages/rohd/install>.
 
 Now you can import it in your project using:
+
 ```dart
 import 'package:rohd/rohd.dart';
 ```
 
-There are complete API docs available at https://intel.github.io/rohd/rohd/rohd-library.html.
+There are complete API docs available at <https://intel.github.io/rohd/rohd/rohd-library.html>.
 
 If you need some help, you can join the [Discord server](https://discord.com/invite/jubxF84yGw) or visit our [Discussions](https://github.com/intel/rohd/discussions) page.  These are friendly places where you can ask questions, share ideas, or just discuss openly!  You could also head to [StackOverflow.com](https://stackoverflow.com/) (use the tag `rohd`) to ask questions or look for answers.
 
@@ -94,16 +97,20 @@ You also may be interested to join the [ROHD Forum](https://github.com/intel/roh
 Be sure to note the minimum Dart version required for ROHD specified in pubspec.yaml (at least 2.14.0).  If you're using the version of Dart that came with Flutter, it might be older than that.
 
 ## Package Managers for Hardware
+
 In the Dart ecosystem, you can use a package manager to define all package dependencies.  A package manager allows you to define constrainted subsets of versions of all your *direct* dependencies, and then the tool will solve for a coherent set of all (direct and indirect) dependencies required to build your project.  There's no need to manually figure out tool versions, build flags and options, environment setup, etc. because it is all guaranteed to work.  Integration of other packages (whether a tool or a hardware IP) become as simple as an `import` statment.  Compare that to SystemVerilog IP integration!
 
-Read more about package managers here: https://en.wikipedia.org/wiki/Package_manager  
-Take a look at Dart's package manager, pub.dev, here: https://pub.dev
+Read more about package managers here: <https://en.wikipedia.org/wiki/Package_manager>
+Take a look at Dart's package manager, pub.dev, here: <https://pub.dev>
 
 ## ROHD Syntax and Examples
+
 The below subsections offer some examples of implementations and syntax in ROHD.
 
 ### A full example of a counter module
+
 To get a quick feel for what ROHD looks like, below is an example of what a simple counter module looks like in ROHD.
+
 ```dart
 // Import the ROHD package
 import 'package:rohd/rohd.dart';
@@ -127,7 +134,7 @@ class Counter extends Module {
 
     // A local signal named 'nextVal'
     var nextVal = Logic(name: 'nextVal', width: width);
-    
+
     // Assignment statement of nextVal to be val+1 (<= is the assignment operator)
     nextVal <= val + 1;
 
@@ -155,6 +162,7 @@ See a more advanced example of a logarithmic-depth tree of arbitrary functionali
 You can find an executable version of the tree example in [example/tree.dart](https://github.com/intel/rohd/blob/main/example/tree.dart).
 
 ### Logical signals
+
 The fundamental signal building block in ROHD is called [`Logic`](https://intel.github.io/rohd/rohd/Logic-class.html).
 
 ```dart
@@ -166,6 +174,7 @@ var bus = Logic(name: 'b', width: 8)
 ```
 
 #### The value of a signal
+
 You can access the current value of a signal using `value`.  You cannot access this as part of synthesizable ROHD code.  ROHD supports X and Z values and propogation.  If the signal is valid (no X or Z in it), you can also convert it to an int with `value.toInt()` (ROHD will throw an exception otherwise).  If the signal has more bits than a dart `int` (64 bits, usually), you need to use `value.toBigInt()` to get a `BigInt` (again, ROHD will throw an exception otherwise).
 
 The value of a `Logic` is of type [`LogicValue`](https://intel.github.io/rohd/rohd/LogicValue-class.html), with pre-defined constant bit values `x`, `z`, `one`, and `zero`.  `LogicValue` has a number of built-in logical operations (like &, |, ^, +, -, etc.).
@@ -192,6 +201,7 @@ LogicValue.ofInt(15, 4);                              // 0xf
 You can create `LogicValue`s using a variety of constructors including `ofInt`, `ofBigInt`, `filled` (like '0, '1, 'x, etc. in SystemVerilog), and `of` (which takes any `Iterable<LogicValue>`).
 
 #### Listening to and waiting for changes
+
 You can trigger on changes of `Logic`s with some built in events.  ROHD uses dart synchronous [streams](https://dart.dev/tutorials/language/streams) for events.
 
 There are three testbench-consumable streams built-in to ROHD `Logic`s: `changed`, `posedge`, and `negedge`.  You can use `listen` to trigger something every time the edge transitions.  Note that this is *not* synthesizable by ROHD and should not be confused with a synthesizable `always(@)` type of statement.  Event arguments passed to listeners are of type `LogicValueChanged`, which has information about the `previousValue` and `newValue`.
@@ -207,6 +217,7 @@ mySignal.posedge.listen((args) {
 You can also use helper getters `nextChanged`, `nextPosedge`, and `nextNegedge` which return `Future<LogicValueChanged>`.  You can think of these as similar to something like `@(posedge mySignal);` in SystemVerilog testbench code.  Again, these are not something that should be included in synthesizable ROHD hardware.
 
 ### Constants
+
 Constants can often be inferred by ROHD automatically, but can also be explicitly defined using [`Const`](https://intel.github.io/rohd/rohd/Const-class.html), which extends `Logic`.
 
 ```dart
@@ -215,6 +226,7 @@ var x = Const(5, width:16);
 ```
 
 There is a convenience function for converting binary to an integer:
+
 ```dart
 // this is equvialent to and shorter than int.parse('010101', radix:2)
 // you can put underscores to help with readability, they are ignored
@@ -222,7 +234,9 @@ bin('01_0101')
 ```
 
 ### Assignment
+
 To assign one signal to the value of another signal, use the `<=` operator.  This is a hardware synthesizable assignment connecting two wires together.
+
 ```dart
 var a = Logic(), b = Logic();
 // assign a to always have the same value as b
@@ -230,7 +244,9 @@ a <= b;
 ```
 
 ### Simple logical, mathematical, and comparison operations
+
 Logical operations on signals are very similar to those in SystemVerilog.
+
 ```dart
 a_bar     <=  ~a;      // not
 a_and_b   <=  a & b;   // and
@@ -253,6 +269,7 @@ answer    <=  mux(selectA, a, b) // answer = selectA ? a : b
 ```
 
 ### Shift Operations
+
 Dart has [implemented the triple shift](https://github.com/dart-lang/language/blob/master/accepted/2.14/triple-shift-operator/feature-specification.md) operator (>>>) in the opposite way as is [implemented in SystemVerilog](https://www.nandland.com/verilog/examples/example-shift-operator-verilog.html).  That is to say in Dart, >>> means *logical* shift right (fill with 0's), and >> means *arithmetic* shift right (maintaining sign).  ROHD keeps consistency with Dart's implementation to avoid introducing confusion within Dart code you write (whether ROHD or plain Dart).
 
 ```dart
@@ -262,7 +279,9 @@ a >>> b   // logical shift right
 ```
 
 ### Bus ranges and swizzling
+
 Multi-bit busses can be accessed by single bits and ranges or composed from multiple other signals.  Slicing, swizzling, etc. are also accessible on `LogicValue`s.
+
 ```dart
 var a = Logic(width:8),
     b = Logic(width:3),
@@ -287,12 +306,14 @@ e <= [b, c, d].rswizzle();
 ```
 
 ROHD does not support assignment to a subset of a bus.  That is, you *cannot* do something like `e[3] <= d`.  Instead, you can use the `withSet` function to get a copy with that subset of the bus assigned to something else.  This applies for both `Logic` and `LogicValue`.  For example:
+
 ```dart
 // reassign the variable `e` to a new `Logic` where bit 3 is set to `d`
 e = e.withSet(3, d);
 ```
 
 ### Modules
+
 [`Module`](https://intel.github.io/rohd/rohd/Module-class.html)s are similar to modules in SystemVerilog.  They have inputs and outputs and logic that connects them.  There are a handful of rules that *must* be followed when implementing a module.
 
 1. All logic within a `Module` must consume only inputs (from the `input` or `addInput` methods) to the Module either directly or indirectly.
@@ -309,14 +330,14 @@ Note that the `build()` method returns a `Future<void>`, not just `void`.  This 
 
 It is not necessary to put all logic directly within a class that extends Module.  You can put synthesizable logic in other functions and classes, as long as the logic eventually connects to an input or output of a module if you hope to convert it to SystemVerilog.  Except where there is a desire for the waveforms and SystemVerilog generated to have module hierarchy, it is not necessary to use submodules within modules instead of plain classes or functions.
 
-
 The `Module` base class has an optional String argument 'name' which is an instance name.
 
 `Module`s have the below basic structure:
+
 ```dart
 // class must extend Module to be a Module
 class MyModule extends Module {
-    
+
     // constructor
     MyModule(Logic in1, {String name='mymodule'}) : super(name: name) {
         // add inputs in the constructor, passing in the Logic it is connected to
@@ -336,18 +357,19 @@ class MyModule extends Module {
 
 All gates or functionality apart from assign statements in ROHD are implemented using Modules.
 
-
 #### Inputs, outputs, widths, and getters
+
 The default width of an input and output is 1.  You can control the width of ports using the `width` argument of `addInput()` and `addOutput()`.  You may choose to set them to a static number, based on some other variable, or even dynamically based on the width of input parameters.  These functions also return the input/output signal.
 
 It can be convenient to use dart getters for signal names so that accessing inputs and outputs of a module doesn't require calling `input()` and `output()` every time.  It also makes it easier to consume your module.
 
 Below are some examples of inputs and outputs in a Module.
+
 ```dart
 class MyModule extends Module {
 
     MyModule(Logic a, Logic b, Logic c, {int xWidth=5}) {
-        
+
         // 'a' should always be width 4, throw an exception if its wrong
         if(a.width != 4) throw Exception('Width of a must be 4!');
         addInput('a', a, width: 4);
@@ -371,7 +393,7 @@ class MyModule extends Module {
     Logic get a {
       return input('a');
     }
-    
+
     // Dart shorthand makes getters less verbose, but the functionality is the same as above
     Logic get b => input('b');
     Logic get x => output('x');
@@ -383,11 +405,13 @@ class MyModule extends Module {
 ```
 
 ### Sequentials
+
 ROHD has a basic [`FlipFlop`](https://intel.github.io/rohd/rohd/FlipFlop-class.html) module that can be used as a flip flop.  For more complex sequential logic, use the `Sequential` block described in the Conditionals section.
 
 Dart doesn't have a notion of certain signals being "clocks" vs. "not clocks".  You can use any signal as a clock input to sequential logic, and have as many clocks of as many frequencies as you want.
 
 ### Conditionals
+
 ROHD supports a variety of [`Conditional`](https://intel.github.io/rohd/rohd/Conditional-class.html) type statements that always must fall within a type of `_Always` block, similar to SystemVerilog.  There are two types of `_Always` blocks: [`Sequential`](https://intel.github.io/rohd/rohd/Sequential-class.html) and [`Combinational`](https://intel.github.io/rohd/rohd/Combinational-class.html), which map to SystemVerilog's `always_ff` and `always_comb`, respectively.  `Combinational` takes a list of `Conditional` statements.  Different kinds of `Conditional` statement, such as `If`, may be composed of more `Conditional` statements.  You can create `Conditional` composition chains as deep as you like.
 
 Conditional statements are executed imperatively and in order, just like the contents of `always` blocks in SystemVerilog.  `_Always` blocks in ROHD map 1-to-1 with SystemVerilog `always` statements when converted.
@@ -395,7 +419,9 @@ Conditional statements are executed imperatively and in order, just like the con
 Assignments within an `_Always` should be executed conditionally, so use the `<` operator which creates a [`ConditionalAssign`](https://intel.github.io/rohd/rohd/ConditionalAssign-class.html) object instead of `<=`.  The right hand side a `ConditionalAssign` can be anything that can be `put` onto a `Logic`, which includes `int`s.  If you're looking to fill the width of something, use `Const` with the `fill = true`.
 
 #### `If`
+
 Below is an example of an [`If`](https://intel.github.io/rohd/rohd/If-class.html) statement in ROHD:
+
 ```dart
 Combinational([
   If(a, then: [
@@ -415,7 +441,9 @@ Combinational([
 ```
 
 #### `IfBlock`
+
 The [`IfBlock`](https://intel.github.io/rohd/rohd/IfBlock-class.html) makes syntax for long chains of if / else if / else chains nicer.  For example:
+
 ```dart
 Sequential(clk, [
   IfBlock([
@@ -438,7 +466,9 @@ Sequential(clk, [
 ```
 
 #### `Case` and `CaseZ`
+
 ROHD supports [`Case`](https://intel.github.io/rohd/rohd/Case-class.html) and [`CaseZ`](https://intel.github.io/rohd/rohd/CaseZ-class.html) statements, including priority and unique flavors, which are implemented in the same way as SystemVerilog.  For example:
+
 ```dart
 Combinational([
   Case([b,a].swizzle(), [
@@ -467,12 +497,13 @@ Combinational([
   )
 ]);
 ```
+
 Note that ROHD supports the 'z' syntax, not the '?' syntax (these are equivalent in SystemVerilog).
 
-There is no support for an equivalent of `casex` from SystemVerilog, since it can easily cause unsynthesizeable code to be generated (see: https://www.verilogpro.com/verilog-case-casez-casex/).
-
+There is no support for an equivalent of `casex` from SystemVerilog, since it can easily cause unsynthesizeable code to be generated (see: <https://www.verilogpro.com/verilog-case-casez-casex/>).
 
 ### Interfaces
+
 Interfaces make it easier to define port connections of a module in a reusable way.  An example of the counter re-implemented using interfaces is shown below.
 
 [`Interface`](https://intel.github.io/rohd/rohd/Interface-class.html) takes a generic parameter for direction type.  This enables you to group signals so make adding them as inputs/outputs easier for different modules sharing this interface.
@@ -487,7 +518,7 @@ The `connectIO` function under the hood calls `addInput` and `addOutput` directl
 // Define a set of legal directions for this interface, and pass as parameter to Interface
 enum CounterDirection {IN, OUT}
 class CounterInterface extends Interface<CounterDirection> {
-  
+
   // include the getters in the interface so any user can access them
   Logic get en => port('en');
   Logic get reset => port('reset');
@@ -509,23 +540,23 @@ class CounterInterface extends Interface<CounterDirection> {
 }
 
 class Counter extends Module {
-  
+
   late final CounterInterface intf;
   Counter(CounterInterface intf) {
     // define a new interface, and connect it to the interface passed in
     this.intf = CounterInterface(intf.width)
-      ..connectIO(this, intf, 
+      ..connectIO(this, intf,
         // map inputs and outputs to appropriate directions
-        inputTags: {CounterDirection.IN}, 
+        inputTags: {CounterDirection.IN},
         outputTags: {CounterDirection.OUT}
       );
-    
+
     _buildLogic();
   }
 
   void _buildLogic() {
     var nextVal = Logic(name: 'nextVal', width: intf.width);
-    
+
     // access signals directly from the interface
     nextVal <= intf.val + 1;
 
@@ -612,6 +643,7 @@ class NotGate extends Module with InlineSystemVerilog {
 ```
 
 ### Pipelines
+
 ROHD has a built-in syntax for handling pipelines in a simple & refactorable way.  The below example shows a three-stage pipeline which adds 1 three times.  Note that [`Pipeline`](https://intel.github.io/rohd/rohd/Pipeline-class.html) consumes a clock and a list of stages, which are each a `List<Conditional> Function(PipelineStageInfo p)`, where `PipelineStageInfo` has information on the value of a given signal in that stage.  The `List<Conditional>` the same type of procedural code that can be placed in `Combinational`.
 
 ```dart
@@ -650,11 +682,13 @@ var pipeline = Pipeline(clk,
 );
 var b = pipeline.get(a);
 ```
+
 You can also optionally add stalls and reset values for signals in the pipeline.  Any signal not accessed via the `PipelineStageInfo` object is just accessed as normal, so other logic can optionally sit outside of the pipeline object.
 
 ROHD also includes a version of `Pipeline` that supports a ready/valid protocol called [`ReadyValidPipeline`](https://intel.github.io/rohd/rohd/ReadyValidPipeline-class.html).  The syntax looks the same, but has some additional parameters for readys and valids.
 
 ### Finite State Machines
+
 ROHD has a built-in syntax for handling FSMs in a simple & refactorable way.  The below example shows a 2 way Traffic light FSM.  Note that `StateMachine` consumes the `clk` and `reset` signals. Also accepts the reset state to transition to `resetState` along with the `List` of `states` of the FSM.
 
 ```dart
@@ -721,7 +755,6 @@ The ROHD simulator is a static class accessible as [`Simulator`](https://intel.g
   - Note that this only resets the `Simulator` and not any `Module`s or `Logic` values
 - To add an action to the Simulator in the *current* timestep, use `Simulator.injectAction`.
 
-
 ## Instantiation of External Modules
 
 ROHD can instantiate external SystemVerilog modules.  The [`ExternalSystemVerilogModule`](https://intel.github.io/rohd/rohd/ExternalSystemVerilogModule-class.html) constructor requires the top level SystemVerilog module name.  When ROHD generates SystemVerilog for a model containing an `ExternalSystemVerilogModule`, it will instantiate instances of the specified `definitionName`.  This is useful for integration related activities.
@@ -730,7 +763,7 @@ The [ROHD Cosim](https://github.com/intel/rohd-cosim) package enables SystemVeri
 
 ## Unit Testing
 
-Dart has a great unit testing package available on pub.dev: https://pub.dev/packages/test
+Dart has a great unit testing package available on pub.dev: <https://pub.dev/packages/test>
 
 The ROHD package has a great set of examples of how to write unit tests for ROHD `Module`s in the test/ directory.
 
@@ -741,65 +774,77 @@ Note that when unit testing with ROHD, it is important to reset the `Simulator` 
 ROHD is under active development.  If you're interested in contributing, have feedback or a question, or found a bug, please see [CONTRIBUTING.md](https://github.com/intel/rohd/blob/main/CONTRIBUTING.md).
 
 ## Comparison with Alternatives
+
 There are a lot of options for developing hardware.  This section briefly discusses popular alternatives to ROHD and some of their strengths and weaknesses.
 
 ### SystemVerilog
+
 SystemVerilog is the most popular HDL (hardware descriptive language).  It is based on Verilog, with additional software-like constructs added on top of it.  Some major drawbacks of SystemVerilog are:
+
 - SystemVerilog is old, verbose, and limited, which makes code more bug-prone
 - Integration of IPs at SOC level with SystemVerilog is very difficult and time-consuming.
 - Validation collateral is hard to develop, debug, share, and reuse when it is written in SystemVerilog.
 - Building requires building packages with proper `include ordering based on dependencies, ordering of files read by compilers in .f files, correctly specifiying order of package and library dependencies, and correct analysis and elaboration options.  This is an area that drains many engineers' time debugging.
 - Build and simulation are dependent on expensive EDA vendor tools or incomplete open-source alternatives.  Every tool has its own intricacies, dependencies, licensing, switches, etc. and different tools may synthesize or simulate the same code in a functionally inequivalent way.
 - Designing configurable and flexible modules in pure SystemVerilog usually requires parameterization, compile-time defines, and "generate" blocks, which can be challenging to use, difficult to debug, and restrictive on approaches.
-    - People often rely on perl scripts to bridge the gap for iteratively generating more complex hardware or stitching together large numbers of modules.
+  - People often rely on perl scripts to bridge the gap for iteratively generating more complex hardware or stitching together large numbers of modules.
 - Testbenches are, at the end of the day, software.  SystemVerilog is arguably a terrible programming language, since it is primarily focused at hardware description, which makes developing testbenches excessively challenging.  Basic software quality-of-life features are missing in SystemVerilog.
-    - Mitigating the problem by connecting to other languages through DPI calls (e.g. C++ or SystemC) has it's own complexities with extra header files, difficulty modelling parallel execution and edge events, passing callbacks, etc.
-    - UVM throws macros and boilerplate at the problem, which doesn't resolve the underlying limitations.
+  - Mitigating the problem by connecting to other languages through DPI calls (e.g. C++ or SystemC) has it's own complexities with extra header files, difficulty modelling parallel execution and edge events, passing callbacks, etc.
+  - UVM throws macros and boilerplate at the problem, which doesn't resolve the underlying limitations.
 
 ROHD aims to enable all the best parts of SystemVerilog, while completely eliminating each of the above issues.  Build is automatic and part of Dart, packages and files can just be imported as needed, no vendor tools are required, hardware can be constructed using all available software constructs, and Dart is a fully-featured modern software language with modern features.
 
-You can read more about SystemVerilog here: https://en.wikipedia.org/wiki/SystemVerilog
+You can read more about SystemVerilog here: <https://en.wikipedia.org/wiki/SystemVerilog>
 
 ### Chisel
+
 Chisel is a domain specific language (DSL) built on top of <a href="https://www.scala-lang.org/">Scala</a>, which is built on top of the Java virtual machine (JVM).  The goals of Chisel are somewhat aligned with the goals of ROHD.  Chisel can also convert to SystemVerilog.
+
 - The syntax of Scala (and thus Chisel) is probably less familiar-feeling to most hardware engineers, and it can be more verbose than ROHD with Dart.
 - Scala and the JVM are arguably less user friendly to debug than Dart code.
 - Chisel is focused mostly on the hardware *designer* rather than the *validator*.  Many of the design choices for the language are centered around making it easier to parameterize and synthesize logic.  ROHD was created with validators in mind.
 - Chisel generates logic that's closer to a netlist than what a similar implementation in SystemVerilog would look like.  This can make it difficult to debug or validate generated code.  ROHD generates structurally similar SystemVerilog that looks close to how you might write it.
 
-Read more about Chisel here: https://www.chisel-lang.org/
+Read more about Chisel here: <https://www.chisel-lang.org/>
 
 ### MyHDL (Python)
+
 There have been a number of attempts to create a HDL on top of Python, but it appears the MyHDL is one of the most mature options.  MyHDL has many similar goals to ROHD, but chose to develop in Python instead of Dart.  MyHDL can also convert to SystemVerilog.
+
 - MyHDL uses "generators" and decorators to help model concurrent behavior of hardware, which is arguably less user-friendly and intuitive than async/await and event based simulation in ROHD.
 - While Python is a great programming langauge for the right purposes, some language features of Dart make it better for representing hardware.  Above is already mentioned Dart's isolates and async/await, which don't exist in the same way in Python.  Dart is statically typed with null safety while Python is dynamically typed, which can make static analysis (including intellisense, type safety, etc.) more challenging in Python.  Python can also be challenging to scale to large programs without careful architecting.
 - Python is inherently slower to execute than Dart.
 - MyHDL has support for cosimulation via VPI calls to SystemVerilog simulators.
 
-Read more about MyHDL here: http://www.myhdl.org/
+Read more about MyHDL here: <http://www.myhdl.org/>
 
 ### High-Level Synthesis (HLS)
+
 High-Level Synthesis (HLS) uses a subset of C++ and SystemC to describe algorithms and functionality, which EDA vendor tools can compile into SystemVerilog.  The real strength of HLS is that it enables design exploration to optimize a higher-level functional intent for area, power, and/or performance through proper staging and knowledge of the characteristics of the targeted process.
+
 - HLS is a step above/away from RTL-level modelling, which is a strength in some situations but might not be the right level in others.
 - HLS uses C++/SystemC, which is arguably a less "friendly" language to use than Dart.
 
-Read more about one example of an HLS tool (Cadence's Stratus tool) here: https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html
+Read more about one example of an HLS tool (Cadence's Stratus tool) here: <https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html>
 
 There are a number of other attempts to make HLS better, including [XLS](https://github.com/google/xls) and [Dahlia](https://capra.cs.cornell.edu/dahlia/) & [Calyx](https://capra.cs.cornell.edu/calyx/).  There are discussions on ways to reasonably incorporate some of the strengths of HLS approaches into ROHD.
 
 ### Transaction Level Verilog (TL-Verilog)
+
 Transaction Level Verilog (TL-Verilog) is like an extension on top of SystemVerilog that makes pipelining simpler and more concise.
+
 - TL-Verilog makes RTL design easier, but doesn't really add much in terms of verification
 - Abstraction of pipelining is something that could be achievable with ROHD, but is not (yet) implemented in base ROHD.
 
-Read more about TL-Verilog here: https://www.redwoodeda.com/tl-verilog
+Read more about TL-Verilog here: <https://www.redwoodeda.com/tl-verilog>
 
 ### PyMTL
 
 PyMTL is another attempt at creating an HDL in Python.  It is developed at Cornell University and the third version (PyMTL 3) is currently in Beta.  PyMTL aims to resolve a lot of the same things as ROHD, but with Python.  It supports conversion to SystemVerilog and simulation.
+
 - The Python language trade-offs described in the above section on MyHDL apply to PyMTL as well.
 
-Read more about PyMTL here: https://github.com/pymtl/pymtl3 or https://pymtl3.readthedocs.io/en/latest/
+Read more about PyMTL here: <https://github.com/pymtl/pymtl3> or <https://pymtl3.readthedocs.io/en/latest/>
 
 ### cocotb
 
@@ -807,13 +852,11 @@ cocotb is a Python-based testbench framework for testing SystemVerilog and VHDL 
 
 The cosimulation capabilities of cocotb are gratefully leveraged within the [ROHD Cosim](https://github.com/intel/rohd-cosim) package for cosimulation with SystemVerilog simulators.
 
-Read more about cocotb here: https://github.com/cocotb/cocotb or https://docs.cocotb.org/en/stable/
-
+Read more about cocotb here: <https://github.com/cocotb/cocotb> or <https://docs.cocotb.org/en/stable/>
 
 ----------------
-2021 August 6  
+2021 August 6
 Author: Max Korbel <<max.korbel@intel.com>>
 
- 
-Copyright (C) 2021-2022 Intel Corporation  
+Copyright (C) 2021-2022 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![License](https://img.shields.io/badge/License-BSD--3-blue)](https://github.com/intel/rohd/blob/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/intel/rohd/blob/main/CODE_OF_CONDUCT.md)
 
-Rapid Open Hardware Development (ROHD) Framework
-================================================
+# Rapid Open Hardware Development (ROHD) Framework
 
 ## Describing Hardware in Dart with ROHD
 
@@ -52,9 +51,9 @@ Dart has an excellent package manager called "pub" (<https://pub.dev>).  It is p
 
 ### The Challenge of Justifying Trying a New Language
 
-<a href="https://stackoverflow.com/questions/53007782/what-benefits-does-chisel-offer-over-classic-hardware-description-languages">This StackOverflow answer</a> about why it's worth trying Chisel (an alternative to ROHD) contains valuable insight into why it is difficult in general to justify a new language to someone who hasn't used it before:
+[This StackOverflow answer](https://stackoverflow.com/questions/53007782/what-benefits-does-chisel-offer-over-classic-hardware-description-languages) about why it's worth trying Chisel (an alternative to ROHD) contains valuable insight into why it is difficult in general to justify a new language to someone who hasn't used it before:
 
-> Language *power* is notoriously difficult to objectively evaluate. Paul Graham describes this as the "Blub Paradox" in his <a href="http://www.paulgraham.com/avg.html">"Beating the Averages" essay</a>. Graham's thesis is that an engineer proficient in a less powerful language cannot evaluate the utility of a more powerful language.
+> Language *power* is notoriously difficult to objectively evaluate. Paul Graham describes this as the "Blub Paradox" in his ["Beating the Averages" essay](http://www.paulgraham.com/avg.html). Graham's thesis is that an engineer proficient in a less powerful language cannot evaluate the utility of a more powerful language.
 
 If you're thinking "SystemVerilog is just fine, I don't need something new", it is worth reading either or both of the StackOverflow answer and the Paul Graham essay.
 
@@ -798,7 +797,7 @@ You can read more about SystemVerilog here: <https://en.wikipedia.org/wiki/Syste
 
 ### Chisel
 
-Chisel is a domain specific language (DSL) built on top of <a href="https://www.scala-lang.org/">Scala</a>, which is built on top of the Java virtual machine (JVM).  The goals of Chisel are somewhat aligned with the goals of ROHD.  Chisel can also convert to SystemVerilog.
+Chisel is a domain specific language (DSL) built on top of [Scala](https://www.scala-lang.org/), which is built on top of the Java virtual machine (JVM).  The goals of Chisel are somewhat aligned with the goals of ROHD.  Chisel can also convert to SystemVerilog.
 
 - The syntax of Scala (and thus Chisel) is probably less familiar-feeling to most hardware engineers, and it can be more verbose than ROHD with Dart.
 - Scala and the JVM are arguably less user friendly to debug than Dart code.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
-Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
+
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation.
 
 ## Reporting a Vulnerability
+
 Please report any security vulnerabilities in this project utilizing the guidelines [here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).

--- a/benchmark/BENCHMARKING.md
+++ b/benchmark/BENCHMARKING.md
@@ -4,16 +4,16 @@ Benchmarking in ROHD
 This folder contains some benchmarking related code for estimating relative performance of certain ROHD features.  It can be used to help judge the relative performance impact with and without a change in ROHD.  Benchmarks can be microbenchmarks for a specific feature, larger benchmarks for estimating performance on more realistic designs, or comparison benchmarks for similar applications relative to other frameworks and simulators.
 
 To run all benchmarks, execute the below command:
+
 ```
 dart run benchmark/benchmark.dart
 ```
+
 You can run this command (or specific benchmarks) before and after a change to get a feel if any performance covered by these benchmarks has been impacted.
 
-
 ----------------
-2022 September 28  
+2022 September 28
 Author: Max Korbel <<max.korbel@intel.com>>
 
- 
-Copyright (C) 2022 Intel Corporation  
+Copyright (C) 2022 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause

--- a/benchmark/BENCHMARKING.md
+++ b/benchmark/BENCHMARKING.md
@@ -5,7 +5,7 @@ This folder contains some benchmarking related code for estimating relative perf
 
 To run all benchmarks, execute the below command:
 
-```
+```shell
 dart run benchmark/benchmark.dart
 ```
 

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -6,41 +6,51 @@ This document describes the organization and architecture of the ROHD framework.
 ## Major Concepts
 
 ### Logic and LogicValue
+
 The `Logic` is the fundamental "wire" that connects signals throughout a hardware design.  It behaves very similarly to a `logic` in SystemVerilog.  It has a fixed width determined at the time of construction.  At any point in time, it has one value of type `LogicValue`.  A `Logic` can be connected to up to one source, and any number of destinations.  All connections must be the same width.
 
 Any time the source of a `Logic` changes, it propogates the change outwards to its destinations.  There are various events that can be subscribed to related to signal value transitions on `Logic`.
 
-A `LogicValue` represents a multi-bit (including 0-bit and 1-bit) 4-value (`1`, `0`, `x`, `z`) static value.  It is immutable. 
+A `LogicValue` represents a multi-bit (including 0-bit and 1-bit) 4-value (`1`, `0`, `x`, `z`) static value.  It is immutable.
 
 ### Module
+
 The `Module` is the fundamental building block of hardware designs in ROHD.  They have clearly defined inputs and outputs, and all logic contained within the module should connect either/both from inputs and to outputs.  The ROHD framework will determine at `build()` time which logic sits within which `Module`.  Any functional operation, whether a simple gate or a large module, is implemented as a `Module`.
 
 Every `Module` defines its own functionality.  This could be through composition of other `Module`s, or through custom functional definition.  For a custom functionality to be convertable to an output (e.g. SystemVerilog), it has to explicitly define how to convert it (via `CustomVerilog` or `InlineVerilog`).  Any time the input of a custom functionality `Module` toggles, the outputs should correspondingly change, if necessary.
 
 ### Simulator
+
 The `Simulator` acts as a staticly accessible driver of the overal simulation.  Anything can register arbitrary `Function`s to be executed at any timestamp that has not already occurred.  The `Simulator` does not need to understand much about the functionality of a design; rather, the `Module`s and `Logic`s are responsible for propogating changes throughout.
 
 ### Synthesizer
+
 A separate type of object responsible for taking a `Module` and converting it to some output, such as SystemVerilog.
 
-
 ## Organization
+
 All the code for the ROHD framework library is in lib/src/, with lib/rohd.dart exporting the main stuff for usage.
 
 ### collections
+
 Software collections that are useful for high-performance internal implementation details in ROHD.
 
 ### exceptions
+
 Exceptions that the ROHD framework may throw.
 
 ### modules
+
 Contains a collection of `Module` implementations that can be used as primitive building blocks for ROHD designs.
 
 ### synthesizers
+
 Contains logic for synthesizing `Module`s into some output.  It is structured to maximize reusability across different output types (including those not yet supported).
 
 ### utilities
+
 Various generic objects and classes that may be useful in different areas of ROHD.
 
 ### values
+
 Definitions for things related to `LogicValue`.

--- a/doc/TreeExample.md
+++ b/doc/TreeExample.md
@@ -12,7 +12,7 @@ class TreeOfTwoInputModules extends Module {
 
   TreeOfTwoInputModules(List<Logic> seq, this._op) : super(name: 'tree_of_two_input_modules') {
     if(seq.isEmpty) throw Exception("Don't use TreeOfTwoInputModules with an empty sequence");
-    
+
     for(var i = 0; i < seq.length; i++) {
       _seq.add(addInput('seq$i', seq[i], width: seq[i].width));
     }
@@ -28,10 +28,12 @@ class TreeOfTwoInputModules extends Module {
   }
 }
 ```
+
 Some interesting things to note:
+
 - The constructor for `TreeOfTwoInputModules` accepts two arguments:
-    - `seq` is a Dart `List` of arbitrary length of input elements.  The module dynamically assigns the input and output widths of the module to match the width of the input elements.  Additionally, the total number of inputs to the module is dynamically determined at run time.
-    - `_op` is a Dart `Function` (in Dart, `Function`s are first-class and can be stored in variables).  It expects a function which takes two `Logic` inputs and provides one `Logic` output.
+  - `seq` is a Dart `List` of arbitrary length of input elements.  The module dynamically assigns the input and output widths of the module to match the width of the input elements.  Additionally, the total number of inputs to the module is dynamically determined at run time.
+  - `_op` is a Dart `Function` (in Dart, `Function`s are first-class and can be stored in variables).  It expects a function which takes two `Logic` inputs and provides one `Logic` output.
 - This module recursively instantiates itself, but with different numbers of inputs each time.  The same module implementation can have a variable number of inputs and different logic without any explicit parameterization.
 
 You could instantiate this module with some code such as:

--- a/doc/tutorials/Chapter_1/00-Introduction_to_ROHD.md
+++ b/doc/tutorials/Chapter_1/00-Introduction_to_ROHD.md
@@ -7,19 +7,19 @@
 
 # Rapid Open Hardware Development (ROHD)
 
-The Rapid Open Hardware Development Framework (ROHD) is a generator framework for describing and verifying hardware using the Dart programming language. It allows for the construction and traversal of a connectivity graph between module objects using unrestricted software. ROHD is not a new language, it is not a hardware description language (HDL), and it is not a version of High-Level Synthesis (HLS). 
+The Rapid Open Hardware Development Framework (ROHD) is a generator framework for describing and verifying hardware using the Dart programming language. It allows for the construction and traversal of a connectivity graph between module objects using unrestricted software. ROHD is not a new language, it is not a hardware description language (HDL), and it is not a version of High-Level Synthesis (HLS).
 
 ROHD is a bold project with the goal of becoming the industry-standard choice for front-end hardware development, replacing SystemVerilog. It aims to address hardware problems in a similar way to Chisel, using Dart as its programming language of choice instead of Scala.
 
 Feature of ROHD include:
 
-- Full power of the modern **Dart language** for hardware design and verification.
-- Easy **IP integration** and **interfaces**; using an IP is as easy as an import. Reduces tedious, redundant, and error prone aspects of integration.
-- Develop **layers of abstraction** within a hardware design, making it more flexible and powerful.
-- Conversion of modules to equivalent, human-readable, structurally similar **SystemVerilog** for integration or downstream tool consumption.
-- **Simple and fast build**, free of complex build systems and EDA vendor tools.
-- Use **modern IDEs** like Visual Studio Code, with excellent static analysis, fast autocomplete, built-in debugger, linting, git integration, extensions, and much more.
-- Built-in event-based **fast simulator** with 4-value (0, 1, X, and Z) support and a **waveform dumper** to .vcd file format
+* Full power of the modern **Dart language** for hardware design and verification.
+* Easy **IP integration** and **interfaces**; using an IP is as easy as an import. Reduces tedious, redundant, and error prone aspects of integration.
+* Develop **layers of abstraction** within a hardware design, making it more flexible and powerful.
+* Conversion of modules to equivalent, human-readable, structurally similar **SystemVerilog** for integration or downstream tool consumption.
+* **Simple and fast build**, free of complex build systems and EDA vendor tools.
+* Use **modern IDEs** like Visual Studio Code, with excellent static analysis, fast autocomplete, built-in debugger, linting, git integration, extensions, and much more.
+* Built-in event-based **fast simulator** with 4-value (0, 1, X, and Z) support and a **waveform dumper** to .vcd file format
 
 ## Challenges in Hardware Industry
 
@@ -88,7 +88,7 @@ class Counter extends Module {
 
     // A local signal named 'nextVal'
     var nextVal = Logic(name: 'nextVal', width: width);
-    
+
     // Assignment statement of nextVal to be val+1 (<= is the assignment operator)
     nextVal <= val + 1;
 
@@ -106,11 +106,9 @@ class Counter extends Module {
 }
 ```
 
-
 ----------------
 2023 February 13
 Author: Yao Jing Quek <<yao.jing.quek@intel.com>>
 
- 
-Copyright (C) 2021-2023 Intel Corporation  
+Copyright (C) 2021-2023 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause

--- a/doc/tutorials/Chapter_1/01-Setup_Installation.md
+++ b/doc/tutorials/Chapter_1/01-Setup_Installation.md
@@ -12,9 +12,9 @@ There are three ways to develop with ROHD. The first option is to run it on GitH
 
 ### Step 1: Click on the CodeSpaces Button
 
-To access the Codespaces feature on the https://github.com/intel/rohd repository, simply click on the "Codespaces" button. 
+To access the Codespaces feature on the <https://github.com/intel/rohd> repository, simply click on the "Codespaces" button.
 
-Please note that Codespaces are free for all users with a personal GitHub account that have either a Free or Pro plan. However, there is a monthly usage limit. To learn more about this feature, visit the official GitHub Codespaces Overview page at https://docs.github.com/en/codespaces/overview.
+Please note that Codespaces are free for all users with a personal GitHub account that have either a Free or Pro plan. However, there is a monthly usage limit. To learn more about this feature, visit the official GitHub Codespaces Overview page at <https://docs.github.com/en/codespaces/overview>.
 
 > All personal GitHub.com accounts have a monthly quota of free use of GitHub Codespaces included in the Free or Pro plan. You can get started using GitHub Codespaces on your personal account without changing any settings or providing payment details. You can create and use a codespaces for any repository you can clone. You can also use a template to create codespaces that are not initially associated with a repository. If you create a codespaces from an organization-owned repository, use of the codespaces will either be charged to the organization (if the organization is configured for this), or to your personal account. Codespaces created from templates are always charged to your personal account. You can continue using GitHub Codespaces beyond your monthly included storage and compute usage by providing payment details and setting a spending limit. For more information, see "About billing for GitHub Codespaces.
 
@@ -38,34 +38,32 @@ Run `dart pub get` on the terminal of the visual studio code to pull your setup.
 
 ![step 4](assets/codespaces_setup/step_4.png)
 
-### Step 5: Run the example code 
+### Step 5: Run the example code
 
 Open up `example` folder on the left navigation panel and click on `example.dart` to bring forward the first example of ROHD. After that, navigate to the main function at below of line 58 and click on the `Run` at `Run | Debug`.
 
 ![step 5](assets/codespaces_setup/step_5.png)
 
-
 If you can see SystemVerilog code pop up on the terminal. Well, you have successfully set up your development environment on the cloud.
 
 ### Step 6: Delete the CodeSpaces (Optional)
 
-To delete the codespaces, go back to https://github.com/intel/rohd and click on codespaces just like step 1. But this time, you will see more options. Click on the `delete` option to delete codespaces.
+To delete the codespaces, go back to <https://github.com/intel/rohd> and click on codespaces just like step 1. But this time, you will see more options. Click on the `delete` option to delete codespaces.
 
 ![step 6](assets/codespaces_setup/step_6.png)
 
-
-## Local Development Setup 
+## Local Development Setup
 
 ROHD can be install in **Windows**, **Mac**, or **Linux** machine.
 
 **Pre-requiresite:**
 
-- Install Chocolatey (Dart SDK might require installation of chocolatey)
-  - https://chocolatey.org/install#individual
-- Install latest `dart` SDK from official dart website: 
-  - https://dart.dev/get-dart
-- Install Visual Studio Code
-  - https://code.visualstudio.com/Download
+* Install Chocolatey (Dart SDK might require installation of chocolatey)
+  * <https://chocolatey.org/install#individual>
+* Install latest `dart` SDK from official dart website:
+  * <https://dart.dev/get-dart>
+* Install Visual Studio Code
+  * <https://code.visualstudio.com/Download>
 
 ### Option 1: Install from Dart packages
 
@@ -75,7 +73,7 @@ Open up a terminal and create a new dart project. Note that do not create the pr
 dart create -t console rohd-project
 ```
 
-Then `cd` to the created `rohd` directory. 
+Then `cd` to the created `rohd` directory.
 
 ```shell
 cd rohd-project
@@ -215,10 +213,9 @@ dart run
 
 Well done! Your setup has been completed successfully. The successful generation of SystemVerilog code confirms that your configuration is in good order.
 
-
 ### Option 2: Install from Source
 
-Clone ROHD repository to the local directory. (Install From Source). On your terminal, run 
+Clone ROHD repository to the local directory. (Install From Source). On your terminal, run
 
 ```shell
 cd C:\
@@ -231,7 +228,7 @@ Next, open up your repository in VSCode using the command:
 code rohd
 ```
 
-You will see VSCode automatically open up your ROHD folder. 
+You will see VSCode automatically open up your ROHD folder.
 
 ![step 1](assets/local_setup/step_1.png)
 
@@ -240,14 +237,14 @@ Open up terminal in your VSCode by go to view -> terminal. Then, get the rohd pa
 ```cmd
 dart pub get
 ```
+
 Then, run Rohd example.
 
 Open up `example` folder on the left navigation panel and click on `example.dart` to bring forward the first example of ROHD. After that, navigate to the main function at below of line 58 and click on the `Run` at `Run | Debug`.
 
 ![step 2](assets/local_setup/step_2.png)
 
-If you can see SystemVerilog code pop up on the terminal. Congratulation, you are ready with ROHD development! 
-
+If you can see SystemVerilog code pop up on the terminal. Congratulation, you are ready with ROHD development!
 
 ## Docker Container Setup
 
@@ -255,10 +252,10 @@ There are another options which is to setup on lcoal docker environment. Firstly
 
 Pre-requisites:
 
-- Install docker 
-    - https://docs.docker.com/get-docker
+* Install docker
+  * <https://docs.docker.com/get-docker>
 
-Then, you need to clone rohd repository to your local PC. 
+Then, you need to clone rohd repository to your local PC.
 
 ```shell
 cd C:\
@@ -288,13 +285,11 @@ In the terminal, run:
 dart example/example.dart
 ```
 
-If you can see SystemVerilog code pop up on the terminal. Congratulation, you are ready with ROHD development! 
-
+If you can see SystemVerilog code pop up on the terminal. Congratulation, you are ready with ROHD development!
 
 ----------------
 2023 February 13
 Author: Yao Jing Quek <<yao.jing.quek@intel.com>>
 
- 
-Copyright (C) 2021-2023 Intel Corporation  
+Copyright (C) 2021-2023 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause

--- a/doc/tutorials/Content_Page.md
+++ b/doc/tutorials/Content_Page.md
@@ -1,86 +1,94 @@
 # Content Page
 
 ## Chapter 1: Getting Started
+
 - [Introduction to ROHD](./Chapter_1/00-Introduction_to_ROHD.md)
-  * [What is ROHD?](./Chapter_1/00-Introduction_to_ROHD.md) 
-  * [Challenges in Hardware Industry](./Chapter_1/00-Introduction_to_ROHD.md#challenges-in-hardware-industry)
-  * [Benefits of Dart for hardware development](./Chapter_1/00-Introduction_to_ROHD.md#benefits-of-dart-for-hardware-development)
-  * [Example of ROHD with Dart](./Chapter_1/00-Introduction_to_ROHD.md#example-of-rohd-with-dart)
+  - [What is ROHD?](./Chapter_1/00-Introduction_to_ROHD.md)
+  - [Challenges in Hardware Industry](./Chapter_1/00-Introduction_to_ROHD.md#challenges-in-hardware-industry)
+  - [Benefits of Dart for hardware development](./Chapter_1/00-Introduction_to_ROHD.md#benefits-of-dart-for-hardware-development)
+  - [Example of ROHD with Dart](./Chapter_1/00-Introduction_to_ROHD.md#example-of-rohd-with-dart)
 - [Setup & Installation](./Chapter_1/01-Setup_Installation.md)
-  * [Setup on Github Codespaces](./Chapter_1/01-Setup_Installation.md#setup-on-github-codespaces-recommended)
-  * [Local Development Setup](./Chapter_1/01-Setup_Installation.md#local-development-setup)
-  * [Docker Container Setup](./Chapter_1/01-Setup_Installation.md#docker-container-setup)
+  - [Setup on Github Codespaces](./Chapter_1/01-Setup_Installation.md#setup-on-github-codespaces-recommended)
+  - [Local Development Setup](./Chapter_1/01-Setup_Installation.md#local-development-setup)
+  - [Docker Container Setup](./Chapter_1/01-Setup_Installation.md#docker-container-setup)
 
 ## Chapter 2: Basic Gates
+
 - Basic logic
-  * Generate a two-input AND gate
-  * First gate (simple & inside a main function)
-  * Non-synthesizable signal deposition (put)
-  * Explaining Logic and LogicValue
-  * Adding widths to Logics
-  * More operations (math, shift, unary, etc.)
-  * Constants
-  * Ranges and swizzling
+  - Generate a two-input AND gate
+  - First gate (simple & inside a main function)
+  - Non-synthesizable signal deposition (put)
+  - Explaining Logic and LogicValue
+  - Adding widths to Logics
+  - More operations (math, shift, unary, etc.)
+  - Constants
+  - Ranges and swizzling
 
 ## Chapter 3: Unit Testing
-  * Full-Adder Tutorial with TDD
-  * Simple unit test of existing logic
-  * Link to test package from Dart
+
+- Full-Adder Tutorial with TDD
+- Simple unit test of existing logic
+- Link to test package from Dart
 
 ## Chapter 4: Basic Generation
-  * Basic generation: Put adder in a loop (N-Bits Adder)
-  * Conditional generation and flow control
-  * Using functions to construct hardware
-  * Using classes to construct hardware
-  * Make a function on one bit full-adder and make a for loop that loop through this adder to make N-bit full adder.
+
+- Basic generation: Put adder in a loop (N-Bits Adder)
+- Conditional generation and flow control
+- Using functions to construct hardware
+- Using classes to construct hardware
+- Make a function on one bit full-adder and make a for loop that loop through this adder to make N-bit full adder.
 
 ## Chapter 5: Basics of modules
-  * Full Adder in Module
-  * Explanation of purpose of modules (introduce formal hierarchy)
-  * First module (one input, one output, simple logic)
-  * Converting to SystemVerilog
-  * Composing modules within other modules
-  * Port
+
+- Full Adder in Module
+- Explanation of purpose of modules (introduce formal hierarchy)
+- First module (one input, one output, simple logic)
+- Converting to SystemVerilog
+- Composing modules within other modules
+- Port
 
 ## Chapter 6: Combinational Logic
-  * Combinational Logic: Simple Assignments, Full Adder but with Combinational Blocks, Add stuff together when something is equal
-  * Explanation of Conditionals
-  * Example of Combinational
-  * Conditional assignments
-  * If/Else, Case/CaseZ, etc.
+
+- Combinational Logic: Simple Assignments, Full Adder but with Combinational Blocks, Add stuff together when something is equal
+- Explanation of Conditionals
+- Example of Combinational
+- Conditional assignments
+- If/Else, Case/CaseZ, etc.
 
 ## Chapter 7: Sequential Logic
-  * Shift Register
-  * Example of Sequential
-  * Simulator (Merged with tutorial 8)
-  * Explanation of role of Simulator
-  * Registering arbitrary events
-  * Starting and running the simulator
-  * Clock generator
-  * Run a sequential logic module in the simulator
-  * Non-synthesizable signal deposition (inject vs. put)
-  * WaveDumper, and view waves
-  * Interfaces (https://en.wikipedia.org/wiki/Serial_Peripheral_Interface)
+
+- Shift Register
+- Example of Sequential
+- Simulator (Merged with tutorial 8)
+- Explanation of role of Simulator
+- Registering arbitrary events
+- Starting and running the simulator
+- Clock generator
+- Run a sequential logic module in the simulator
+- Non-synthesizable signal deposition (inject vs. put)
+- WaveDumper, and view waves
+- Interfaces (<https://en.wikipedia.org/wiki/Serial_Peripheral_Interface>)
 
 ## Chapter 8: Abstractions
-  * Pipelines: Normally Delayed exists in between a big circuit, abstractions split the logic across multiple cycles and let us decide what logic do you want it to occur in each of the cycle.
-  * Finite state machines
+
+- Pipelines: Normally Delayed exists in between a big circuit, abstractions split the logic across multiple cycles and let us decide what logic do you want it to occur in each of the cycle.
+- Finite state machines
 
 ## Chapter 9: ROHD-COSIM External SystemVerilog Modules (Coming Soon!)
-  * More functionality
-  * Using and depending on other packages
+
+- More functionality
+- Using and depending on other packages
 
 ## Chapter 10: ROHD-VF (Coming Soon!)
 
-* Contributing to ROHD
-* Building your own package
-* ROHD-VF (https://colorlesscube.com/uvm-guide-for-beginners/chapter-1-the-dut/)
-* ROHD Cosim
+- Contributing to ROHD
+- Building your own package
+- ROHD-VF (<https://colorlesscube.com/uvm-guide-for-beginners/chapter-1-the-dut/>)
+- ROHD Cosim
 
 ----------------
 2023 February 13
 Author: Yao Jing Quek <<yao.jing.quek@intel.com>>
 
- 
-Copyright (C) 2021-2023 Intel Corporation  
+Copyright (C) 2021-2023 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
## Description & Motivation

Markdown files have been formatted. This is to resolve CI errors preventing changes to <https://github.com/intel/rohd/pull/280> from being accepted.

## Related Issue(s)

No.

## Testing

Format testing will be available after accepting changes in <https://github.com/intel/rohd/pull/280>.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Most of the Markdown files are edited, many of which are part of the documentation.
