### PR TITLE
Fix #295, signed arithmetic shift right

### DIFF
--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -409,19 +409,15 @@ class _ShiftGate extends Module with InlineSystemVerilog, FullyCombinational {
     final in_ = inputs[_inName]!;
     final shiftAmount = inputs[_shiftAmountName]!;
 
-    String signWrap(String original) {
-      if (signed) {
-        return '\$signed($original)';
-      } else {
-        return original;
-      }
-    }
+    String signWrap(String original) =>
+        signed ? '\$signed($original)' : original;
 
     final aStr = signWrap(in_);
 
-    // it is necessary to sign wrap the whole expression due to the way
-    // SystemVerilog handles signed and unsigned expressions near eachother
-    return signWrap('$aStr $_opStr $shiftAmount');
+    final shiftStr = '$aStr $_opStr $shiftAmount';
+
+    // In case of signed, wrap in {} to make it self-determined.
+    return signed ? '{$shiftStr}' : shiftStr;
   }
 }
 

--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -408,8 +408,20 @@ class _ShiftGate extends Module with InlineSystemVerilog, FullyCombinational {
     }
     final in_ = inputs[_inName]!;
     final shiftAmount = inputs[_shiftAmountName]!;
-    final aStr = signed ? '\$signed($in_)' : in_;
-    return '$aStr $_opStr $shiftAmount';
+
+    String signWrap(String original) {
+      if (signed) {
+        return '\$signed($original)';
+      } else {
+        return original;
+      }
+    }
+
+    final aStr = signWrap(in_);
+
+    // it is necessary to sign wrap the whole expression due to the way
+    // SystemVerilog handles signed and unsigned expressions near eachother
+    return signWrap('$aStr $_opStr $shiftAmount');
   }
 }
 

--- a/test/arithmetic_shift_right_test.dart
+++ b/test/arithmetic_shift_right_test.dart
@@ -1,0 +1,46 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// arithmetic_shift_right_test.dart
+/// Tests related to special circumstances around arithmetic right-shift.
+///
+/// 2023 March 1
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class SraUnsignedTestModule extends Module {
+  Logic get result => output('result');
+  SraUnsignedTestModule(Logic toShift, Logic shiftAmount, Logic maskBit) {
+    toShift = addInput('toShift', toShift, width: toShift.width);
+    shiftAmount =
+        addInput('shiftAmount', shiftAmount, width: shiftAmount.width);
+    maskBit = addInput('maskBit', maskBit);
+
+    addOutput('result', width: toShift.width);
+
+    result <= (toShift >> shiftAmount) & maskBit.replicate(toShift.width);
+  }
+}
+
+void main() {
+  test('arithmetic shift right and mask', () async {
+    final mod =
+        SraUnsignedTestModule(Logic(width: 32), Logic(width: 32), Logic());
+    await mod.build();
+    final vectors = [
+      Vector({'toShift': 0xe0000000, 'shiftAmount': 4, 'maskBit': 1},
+          {'result': 0xfe000000}),
+      Vector({'toShift': 0x10000000, 'shiftAmount': 4, 'maskBit': 1},
+          {'result': 0x01000000}),
+      Vector({'toShift': 0xe0000000, 'shiftAmount': 4, 'maskBit': 0},
+          {'result': 0}),
+    ];
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    final simResult = SimCompare.iverilogVector(mod, vectors);
+    expect(simResult, equals(true));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Shift-right arithmetic (SRA) is broken in generated SystemVerilog if an unsigned operation is applied to the result (see #295)

This fix maintains that the SystemVerilog still uses `>>>` so that it is similar to the original implementation but adds an additional set of `{}` around the result to guarantee safety.

Thank you to @saw235 for the implementation suggestion in https://github.com/intel/rohd/issues/295#issuecomment-1454651572

## Related Issue(s)

Fix #295

## Testing

Added a new test that failed before the fix.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
