### PR TITLE
Small set of CI/CD configuration changes

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -23,9 +23,9 @@ jobs:
           globs: '**/*.md'
 
       - name: Check Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: yes
+          use-quiet-mode: yes # output is too noisy, see https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/121
           config-file: .github/configs/mlc_config.json
 
       - name: Setup Dart
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: write # required for "JamesIves/github-pages-deploy-action"
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description & Motivation

It is proposed to slightly edit the CI/CD configuration file, namely:

* Remove hard link to beta as [new stable](https://github.com/gaurav-nelson/github-action-markdown-link-check/releases/tag/1.0.15) is available for step `gaurav-nelson/github-action-markdown-link-check`.
* Add clarification regarding the reason for using the `use-quiet-mode` option in the `gaurav-nelson/github-action-markdown-link-check` step.
* In `deploy-documentation` job, use `ubuntu-22.04` instead of `ubuntu-latest`. Major updates are best done manually.

## Related Issue(s)

No.

## Testing

No.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.