### PR TITLE
Fix long comment lines not caught by lint

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -470,20 +470,26 @@ abstract class LogicValue {
   ///
   /// [startIndex] must come before the [endIndex] on position. If [startIndex]
   /// and [endIndex] are equal, then a zero-width value is returned.
-  /// Negative/Positive index values are allowed. (The negative indexing starts from the end=[width]-1)
+  /// Both negative and positive index values are allowed. Negative indexing
+  /// starts from the end=[width]-1.
   ///
   /// If [endIndex] is not provided, [width] of the [LogicValue] will
   /// be used as the default values which assign it to the last index.
   ///
-  /// ```dart [TODO]
-  /// LogicValue.ofString('0101').getRange(0, 2);   // == LogicValue.ofString('01')
-  /// LogicValue.ofString('0101').getRange(1, -2);  // == LogicValue.zero
-  /// LogicValue.ofString('0101').getRange(-3, 4);  // == LogicValue.ofString('010')
-  /// LogicValue.ofString('0101').getRange(1);      // == LogicValue.ofString('010')
+  /// ```dart
+  /// LogicValue.ofString('0101').getRange(0, 2);  // LogicValue.ofString('01')
+  /// LogicValue.ofString('0101').getRange(1, -2); // LogicValue.zero
+  /// LogicValue.ofString('0101').getRange(-3, 4); // LogicValue.ofString('010')
+  /// LogicValue.ofString('0101').getRange(1);     // LogicValue.ofString('010')
   ///
-  /// LogicValue.ofString('0101').getRange(-1, -2); // Error - negative end index and start > end - error! start must be less than end
-  /// LogicValue.ofString('0101').getRange(2, 1);   // Error - bad inputs start > end
-  /// LogicValue.ofString('0101').getRange(0, 7);   // Error - bad inputs end > length-1
+  /// // Error - negative end index and start > end! start must be less than end
+  /// LogicValue.ofString('0101').getRange(-1, -2);
+  ///
+  /// // Error - bad inputs start > end
+  /// LogicValue.ofString('0101').getRange(2, 1);
+  ///
+  /// // Error - bad inputs end > length-1
+  /// LogicValue.ofString('0101').getRange(0, 7);
   /// ```
   ///
   LogicValue getRange(int startIndex, [int? endIndex]) {
@@ -521,12 +527,12 @@ abstract class LogicValue {
   /// If [endIndex] is less than [startIndex], the returned value will be
   /// reversed relative to the original value.
   ///
-  /// ```dart [TODO]
-  /// LogicValue.ofString('xz01').slice(2, 1);    // == LogicValue.ofString('z0')
-  /// LogicValue.ofString('xz01').slice(-2, -3);  // == LogicValue.ofString('z0')
-  /// LogicValue.ofString('xz01').slice(1, 3);    // == LogicValue.ofString('0zx')
-  /// LogicValue.ofString('xz01').slice(-3, -1);  // == LogicValue.ofString('0zx')
-  /// LogicValue.ofString('xz01').slice(-2, -2);  // == LogicValue.ofString('z')
+  /// ```dart
+  /// LogicValue.ofString('xz01').slice(2, 1);    // LogicValue.ofString('z0')
+  /// LogicValue.ofString('xz01').slice(-2, -3);  // LogicValue.ofString('z0')
+  /// LogicValue.ofString('xz01').slice(1, 3);    // LogicValue.ofString('0zx')
+  /// LogicValue.ofString('xz01').slice(-3, -1);  // LogicValue.ofString('0zx')
+  /// LogicValue.ofString('xz01').slice(-2, -2);  // LogicValue.ofString('z')
   /// ```
   LogicValue slice(int endIndex, int startIndex) {
     final modifiedStartIndex =

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -16,6 +16,10 @@ import 'package:test/test.dart';
 
 enum MyStates { state1, state2, state3, state4 }
 
+const _tmpDir = 'tmp_test';
+const _simpleFSMPath = '$_tmpDir/simple_fsm.md';
+const _trafficFSMPath = '$_tmpDir/traffic_light_fsm.md';
+
 class TestModule extends Module {
   TestModule(Logic a, Logic c, Logic reset) {
     a = addInput('a', a);
@@ -37,7 +41,7 @@ class TestModule extends Module {
     ];
 
     StateMachine<MyStates>(clk, reset, MyStates.state1, states)
-        .generateDiagram(outputPath: 'tmp_test/simple_fsm.md');
+        .generateDiagram(outputPath: _simpleFSMPath);
   }
 }
 
@@ -105,7 +109,7 @@ class TrafficTestModule extends Module {
     ];
 
     StateMachine<LightStates>(clk, reset, LightStates.northFlowing, states)
-        .generateDiagram(outputPath: 'tmp_test/traffic_light_fsm.md');
+        .generateDiagram(outputPath: _trafficFSMPath);
   }
 }
 
@@ -114,8 +118,7 @@ void main() {
     await Simulator.reset();
   });
 
-  const simpleFSMPath = 'tmp_test/simple_fsm.md';
-  const trafficFSMPath = 'tmp_test/traffic_light_fsm.md';
+  setUpAll(() => Directory(_tmpDir).createSync(recursive: true));
 
   group('simcompare', () {
     test('simple fsm', () async {
@@ -134,7 +137,7 @@ void main() {
 
       expect(simResult, equals(true));
 
-      verifyMermaidStateDiagram(simpleFSMPath);
+      verifyMermaidStateDiagram(_simpleFSMPath);
     });
 
     test('traffic light fsm', () async {
@@ -164,7 +167,7 @@ void main() {
       final simResult = SimCompare.iverilogVector(pipem, vectors);
 
       expect(simResult, equals(true));
-      verifyMermaidStateDiagram(trafficFSMPath);
+      verifyMermaidStateDiagram(_trafficFSMPath);
     });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There are some comment lines in `logic_value.dart` which are longer than 80 characters.  They were not caught by the lint.  Filed this issue on the linter (https://github.com/dart-lang/linter/issues/4126), but for now just fix these ones.

Also, fixing a race condition in the FSM tests that happened to fail in this PR that had to do with `tmp_test` directory creation.

## Related Issue(s)

Linter bug: https://github.com/dart-lang/linter/issues/4126

## Testing

No, just comment changes, and linter doesn't work.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Changes doc slightly since comment was reformatted.