### PR TITLE
two tests, one fix for wide bitvector comparison

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -699,7 +699,11 @@ abstract class LogicValue {
       return LogicValue.filled(other.width, LogicValue.x);
     }
 
-    if (this is _BigLogicValue || other is BigInt || other is _BigLogicValue) {
+    if (this is _BigLogicValue ||
+        other is BigInt ||
+        other is _BigLogicValue ||
+        (this is _FilledLogicValue) && this.width >= 64 ||
+        (other is _FilledLogicValue) && other.width >= 64) {
       final a = toBigInt();
       final b = other is BigInt
           ? other
@@ -775,7 +779,11 @@ abstract class LogicValue {
 
     dynamic a;
     dynamic b;
-    if (this is _BigLogicValue || other is BigInt || other is _BigLogicValue) {
+    if (this is _BigLogicValue ||
+        other is BigInt ||
+        other is _BigLogicValue ||
+        (this is _FilledLogicValue) && this.width >= 64 ||
+        (other is _FilledLogicValue) && other.width >= 64) {
       a = toBigInt();
       b = other is BigInt
           ? other

--- a/test/bigint_test.dart
+++ b/test/bigint_test.dart
@@ -1,0 +1,36 @@
+//
+// bigint_test.dart
+// Test of very wide bitvector comparison failure
+//
+//
+
+import 'dart:math';
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('crash compare', () {
+    final input = Const(BigInt.from(2).pow(128), width: 129);
+    final output = Logic();
+    Combinational([
+      IfBlock([
+        Iff(input.getRange(0, 128) > BigInt.from(0),
+            [output < Const(1, width: 1)]),
+        Else([output < Const(0, width: 1)]),
+      ])
+    ]);
+  });
+  test('bad compare', () {
+    const i = 64;
+    final input = Const(BigInt.from(1) << (i - 1), width: i);
+    final output = Logic();
+    Combinational([
+      IfBlock([
+        Iff(input > BigInt.from(0), [output < Const(1, width: 1)]),
+        Else([output < Const(0, width: 1)]),
+      ])
+    ]);
+    final b = ~input.eq(0);
+    expect(output.value, equals(b.value));
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds two tests for wide bitvector comparisons.  Adds a fix for one of them.
The remaining problem is that shifting a 1 into the signed position and then converting to bigint results in a negative number regardless.

## Related Issue(s)

None

## Testing

Created two tests that do comparisons.  One just breaks the length check.  The other puts a 1 in the sign location just before conversion to BigInt (the fix for the first).

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

The change is in the core logic comparison operation so more tests may be needed.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
