### PR TITLE
[Fix 324] Add `WaveDumper` ability to create missing output directories

### DIFF
--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -1,12 +1,11 @@
-/// Copyright (C) 2021-2023 Intel Corporation
-/// SPDX-License-Identifier: BSD-3-Clause
-///
-/// wave_dumper.dart
-/// Waveform dumper for a given module hierarchy, dumps to .vcd file.
-///
-/// 2021 May 7
-/// Author: Max Korbel <max.korbel@intel.com>
-///
+// Copyright (C) 2021-2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// wave_dumper.dart
+// Waveform dumper for a given module hierarchy, dumps to ".vcd" file.
+//
+// 2021 May 7
+// Author: Max Korbel <max.korbel@intel.com>
 
 import 'dart:io';
 import 'package:rohd/rohd.dart';

--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -58,7 +58,7 @@ class WaveDumper {
   /// Attaches a [WaveDumper] to record all signal changes in a simulation of
   /// [module] in a VCD file at [outputPath].
   WaveDumper(this.module, {this.outputPath = 'waves.vcd'})
-      : _outputFile = File(outputPath) {
+      : _outputFile = File(outputPath)..createSync(recursive: true) {
     if (!module.hasBuilt) {
       throw Exception(
           'Module must be built before passed to dumper.  Call build() first.');

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -1,12 +1,11 @@
-/// Copyright (C) 2021-2023 Intel Corporation
-/// SPDX-License-Identifier: BSD-3-Clause
-///
-/// wave_dumper_test.dart
-/// Tests for the WaveDumper
-///
-/// 2021 November 4
-/// Author: Max Korbel <max.korbel@intel.com>
-///
+// Copyright (C) 2021-2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// wave_dumper_test.dart
+// Tests for the WaveDumper
+//
+// 2021 November 4
+// Author: Max Korbel <max.korbel@intel.com>
 
 import 'dart:async';
 import 'dart:io';
@@ -220,5 +219,20 @@ void main() {
     );
 
     deleteTemporaryDump(dumpName);
+  });
+
+  test('create non-existent output directories', () async {
+    final mod = SimpleModule(Logic());
+    await mod.build();
+
+    const dir1Path = '$tempDumpDir/dir1';
+
+    final waveDumper = WaveDumper(mod, outputPath: '$dir1Path/dir2/waves.vcd');
+
+    expect(File(waveDumper.outputPath).existsSync(), equals(true));
+
+    if (File(waveDumper.outputPath).existsSync()) {
+      File(dir1Path).deleteSync(recursive: true);
+    }
   });
 }


### PR DESCRIPTION
## Description & Motivation

These changes fix the issue https://github.com/intel/rohd/issues/324

## Related Issue(s)

Fix https://github.com/intel/rohd/issues/324

## Testing

Added test to check if missing directories can be created.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.
