### PR TITLE
[Issue 246] SynthBuilder should check for Module.build()

### DIFF
--- a/lib/src/synthesizers/synth_builder.dart
+++ b/lib/src/synthesizers/synth_builder.dart
@@ -10,6 +10,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/module/module_not_built_exception.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
 
 /// A generic class which can convert a module into a generated output using
@@ -38,6 +39,10 @@ class SynthBuilder {
   /// Constructs a [SynthBuilder] based on the [top] module and
   /// using [synthesizer] for generating outputs.
   SynthBuilder(this.top, this.synthesizer) {
+    if (!top.hasBuilt) {
+      throw ModuleNotBuiltException();
+    }
+
     final modulesToParse = <Module>[top];
     for (var i = 0; i < modulesToParse.length; i++) {
       final moduleI = modulesToParse[i];

--- a/test/synth_builder_test.dart
+++ b/test/synth_builder_test.dart
@@ -1,0 +1,70 @@
+/// Copyright (C) 2021-2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// synth_builder_test.dart
+/// Unit tests for generation of the system verilog using synth builder.
+///
+/// 2023 April 10
+/// Author: Yao Jing Quek <yao.jing.quek@intel.com>
+///
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:test/test.dart';
+
+class TopModule extends Module {
+  TopModule(Logic a, Logic b) : super(name: 'topmodule') {
+    a = addInput('a', a, width: a.width);
+    b = addInput('b', b, width: b.width);
+    final y = addOutput('y', width: a.width);
+    final z = addOutput('z', width: b.width);
+    final z2 = addOutput('z2', width: b.width);
+
+    y <= AModule(a).y;
+    z <= BModule(b).zz;
+    z2 <= BModule(b).zz;
+  }
+}
+
+class AModule extends Module {
+  Logic get y => output('y');
+
+  AModule(Logic a) : super(name: 'amodule') {
+    a = addInput('a', a, width: a.width);
+    final y = addOutput('y', width: a.width);
+
+    final tmp = Logic(width: a.width);
+    y <= tmp;
+    tmp <= a;
+  }
+}
+
+class BModule extends Module {
+  Logic get zz => output('zz');
+  BModule(Logic bb) : super(name: 'bmodule') {
+    bb = addInput('bb', bb, width: bb.width);
+    final zz = addOutput('zz', width: bb.width);
+
+    zz <= ~bb;
+  }
+}
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  group('simcompare', () {
+    test('multimodules', () async {
+      final mod = TopModule(Logic(width: 4), Logic());
+
+      final bmod = BModule(Logic());
+      await bmod.build();
+
+      final syn = SynthBuilder(bmod, SystemVerilogSynthesizer());
+
+      print(syn.toString());
+
+      // expect(simResult, equals(true));
+    });
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It's possible to generate outputs using a Synthesizer and SynthBuilder rather than through Module.generateSynth. However, the SynthBuilder does not check that Module.build is called, only generateSynth does. This can produce unexpected outputs (e.g. SystemVerilog with no submodules) without any helpful error message indicating why.

## Related Issue(s)

Fix #246 

## Testing

Tested with module not built and catch exception. 

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes. 

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No. Just added validation and test.
