### PR TITLE
Fix #348: make `Case` and `CaseZ` use edge-sampled signals for expression evaluation

### DIFF
--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -761,8 +761,6 @@ class Case extends Conditional {
     }
   }
 
-  //TODO: This should be expression using driverValue!!! BIG BUG!
-
   /// Returns true iff [value] matches the expressions current value.
   @protected
   bool isMatch(LogicValue value, LogicValue expressionValue) =>
@@ -984,7 +982,6 @@ class CaseZ extends Case {
   @override
   bool isMatch(LogicValue value, LogicValue expressionValue) {
     for (var i = 0; i < expression.width; i++) {
-      //TODO: This should be using driverValue!!!
       if (expressionValue[i] != value[i] && value[i] != LogicValue.z) {
         return false;
       }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -761,9 +761,12 @@ class Case extends Conditional {
     }
   }
 
+  //TODO: This should be expression using driverValue!!! BIG BUG!
+
   /// Returns true iff [value] matches the expressions current value.
   @protected
-  bool isMatch(LogicValue value) => expression.value == value;
+  bool isMatch(LogicValue value, LogicValue expressionValue) =>
+      expressionValue == value;
 
   /// Returns the SystemVerilog keyword to represent this case block.
   @protected
@@ -793,7 +796,7 @@ class Case extends Conditional {
 
     for (final item in items) {
       // match on the first matchinig item
-      if (isMatch(item.value.value)) {
+      if (isMatch(driverValue(item.value), driverValue(expression))) {
         for (final conditional in item.then) {
           conditional.execute(drivenSignals, guard);
         }
@@ -979,13 +982,10 @@ class CaseZ extends Case {
   String get caseType => 'casez';
 
   @override
-  bool isMatch(LogicValue value) {
-    if (expression.width != value.width) {
-      throw Exception(
-          'Value "$value" and expression "$expression" must be equal width.');
-    }
+  bool isMatch(LogicValue value, LogicValue expressionValue) {
     for (var i = 0; i < expression.width; i++) {
-      if (expression.value[i] != value[i] && value[i] != LogicValue.z) {
+      //TODO: This should be using driverValue!!!
+      if (expressionValue[i] != value[i] && value[i] != LogicValue.z) {
         return false;
       }
     }
@@ -1088,12 +1088,12 @@ class If extends Conditional {
     }
 
     for (final iff in iffs) {
-      if (driverValue(iff.condition)[0] == LogicValue.one) {
+      if (driverValue(iff.condition) == LogicValue.one) {
         for (final conditional in iff.then) {
           conditional.execute(drivenSignals, guard);
         }
         break;
-      } else if (driverValue(iff.condition)[0] != LogicValue.zero) {
+      } else if (driverValue(iff.condition) != LogicValue.zero) {
         // x and z propagation
         for (final receiver in receivers) {
           receiverOutput(receiver).put(driverValue(iff.condition)[0]);

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -152,8 +152,6 @@ class SeqCondModule extends Module {
   }
 }
 
-// TODO: make one for If also with sequential
-
 class IfBlockModule extends Module {
   IfBlockModule(Logic a, Logic b) : super(name: 'ifblockmodule') {
     a = addInput('a', a);

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -7,6 +7,8 @@
 // 2021 May 7
 // Author: Max Korbel <max.korbel@intel.com>
 
+import 'dart:async';
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/exceptions/conditionals/conditional_exceptions.dart';
 import 'package:rohd/src/exceptions/sim_compare/sim_compare_exceptions.dart';
@@ -113,6 +115,44 @@ class CaseModule extends Module {
     ]);
   }
 }
+
+enum SeqCondModuleType { caseNormal, caseZ, ifNormal }
+
+class SeqCondModule extends Module {
+  Logic get equal => output('equal');
+  SeqCondModule(Logic clk, Logic a, {required SeqCondModuleType combType}) {
+    a = addInput('a', a, width: 8);
+    clk = addInput('clk', clk);
+
+    addOutput('equal');
+
+    final aIncr = a + 1;
+
+    final aIncrDelayed = FlipFlop(clk, aIncr).q;
+
+    final genCase =
+        combType == SeqCondModuleType.caseNormal ? Case.new : CaseZ.new;
+
+    Sequential(clk, [
+      if (combType == SeqCondModuleType.ifNormal)
+        If(
+          aIncr.eq(aIncrDelayed),
+          then: [equal < 1],
+          orElse: [equal < 0],
+        )
+      else
+        genCase(aIncr, [
+          CaseItem(aIncrDelayed, [
+            equal < 1,
+          ])
+        ], defaultItem: [
+          equal < 0,
+        ]),
+    ]);
+  }
+}
+
+// TODO: make one for If also with sequential
 
 class IfBlockModule extends Module {
   IfBlockModule(Logic a, Logic b) : super(name: 'ifblockmodule') {
@@ -358,12 +398,39 @@ void main() {
           expect(e.runtimeType, WriteAfterReadException);
         }
       });
+
       test('ssa', () async {
         final mod = LoopyCombModuleSsa(Logic());
         await mod.build();
         mod.a.put(1);
         expect(mod.x.value.toInt(), equals(0));
       });
+    });
+
+    group('flopped expressions for conditionals', () {
+      for (final condType in SeqCondModuleType.values) {
+        test(condType.name, () async {
+          final clk = SimpleClockGenerator(10).clk;
+          final a = Logic(name: 'a', width: 8);
+          final mod = SeqCondModule(clk, a, combType: condType);
+
+          a.put(0);
+
+          Simulator.setMaxSimTime(100);
+
+          unawaited(Simulator.run());
+
+          await clk.nextPosedge;
+          a.put(1);
+          await clk.nextPosedge;
+          a.put(2);
+          await clk.nextPosedge;
+
+          expect(mod.equal.value.toBool(), false);
+
+          await Simulator.simulationEnded;
+        });
+      }
     });
   });
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

`Case` and `CaseZ` were not properly using edge-sampled signals for expression evaluation in `Sequentials`.  This PR fixes that bug (#348) and also add tests for both, as well as `If` for good measure.

## Related Issue(s)

Fix #348 

## Testing

Added new tests covering the bug, confirmed failure without the fix.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
