### PR TITLE
Issue#140: Added gt and gte for for consistency to Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ a_eq_b    <=  a.eq(b)  // equality              NOTE: == is for Object equality 
 a_lt_b    <=  a.lt(b)  // less than             NOTE: <  is for conditional assignment
 a_lte_b   <=  a.lte(b) // less than or equal    NOTE: <= is for assignment
 a_gt_b    <=  (a > b)  // greater than          NOTE: careful with order of operations, > needs parentheses in this case
+                       // Note: a_gt_b <= a.gt(b) is also supported for greater than.
 a_gte_b   <=  (a >= b) // greater than or equal NOTE: careful with order of operations, >= needs parentheses in this case
+                       // Note: a_gte_b <= a.gte(b) is also supported for greater than or equal.
 answer    <=  mux(selectA, a, b) // answer = selectA ? a : b
 ```
 

--- a/doc/tutorials/chapter_2/00_basic_logic.md
+++ b/doc/tutorials/chapter_2/00_basic_logic.md
@@ -158,7 +158,9 @@ a_eq_b    <=  a.eq(b)  // equality              NOTE: == is for Object equality 
 a_lt_b    <=  a.lt(b)  // less than             NOTE: <  is for conditional assignment
 a_lte_b   <=  a.lte(b) // less than or equal    NOTE: <= is for assignment
 a_gt_b    <=  (a > b)  // greater than          NOTE: careful with order of operations, > needs parentheses in this case
+                       // Note: a_gt_b <= a.gt(b) is also supported for greater than.
 a_gte_b   <=  (a >= b) // greater than or equal NOTE: careful with order of operations, >= needs parentheses in this case
+                       // Note: a_gte_b <= a.gte(b) is also supported for greater than or equal.
 answer    <=  mux(selectA, a, b) // answer = selectA ? a : b
 ```
 

--- a/lib/src/logic.dart
+++ b/lib/src/logic.dart
@@ -581,6 +581,12 @@ class Logic {
   Logic lte(dynamic other) => LessThanOrEqual(this, other).out;
 
   /// Greater-than.
+  Logic gt(dynamic other) => GreaterThan(this, other).out;
+
+  /// Greater-than-or-equal-to.
+  Logic gte(dynamic other) => GreaterThanOrEqual(this, other).out;
+
+  /// Greater-than.
   Logic operator >(dynamic other) => GreaterThan(this, other).out;
 
   /// Greater-than-or-equal-to.

--- a/test/comparison_test.dart
+++ b/test/comparison_test.dart
@@ -26,24 +26,32 @@ class ComparisonTestModule extends Module {
     final aLteB = addOutput('a_lte_b');
     final aGtB = addOutput('a_gt_b');
     final aGteB = addOutput('a_gte_b');
+    final aGtOperatorB = addOutput('a_gt_operator_b');
+    final aGteOperatorB = addOutput('a_gte_operator_b');
 
     final aEqC = addOutput('a_eq_c');
     final aLtC = addOutput('a_lt_c');
     final aLteC = addOutput('a_lte_c');
     final aGtC = addOutput('a_gt_c');
     final aGteC = addOutput('a_gte_c');
+    final aGtOperatorC = addOutput('a_gt_operator_c');
+    final aGteOperatorC = addOutput('a_gte_operator_c');
 
     aEqB <= a.eq(b);
     aLtB <= a.lt(b);
     aLteB <= a.lte(b);
-    aGtB <= (a > b);
-    aGteB <= (a >= b);
+    aGtB <= a.gt(b);
+    aGteB <= a.gte(b);
+    aGtOperatorB <= (a > b);
+    aGteOperatorB <= (a >= b);
 
     aEqC <= a.eq(c);
     aLtC <= a.lt(c);
     aLteC <= a.lte(c);
-    aGtC <= (a > c);
-    aGteC <= (a >= c);
+    aGtC <= a.gt(c);
+    aGteC <= a.gte(c);
+    aGtOperatorC <= (a > c);
+    aGteOperatorC <= (a >= c);
   }
 }
 
@@ -66,11 +74,15 @@ void main() {
           'a_lte_b': 1,
           'a_gt_b': 0,
           'a_gte_b': 1,
+          'a_gt_operator_b': 0,
+          'a_gte_operator_b': 1,
           'a_eq_c': 0,
           'a_lt_c': 1,
           'a_lte_c': 1,
           'a_gt_c': 0,
           'a_gte_c': 0,
+          'a_gt_operator_c': 0,
+          'a_gte_operator_c': 0,
         }),
         Vector({
           'a': 5,
@@ -81,11 +93,15 @@ void main() {
           'a_lte_b': 1,
           'a_gt_b': 0,
           'a_gte_b': 0,
+          'a_gt_operator_b': 0,
+          'a_gte_operator_b': 0,
           'a_eq_c': 1,
           'a_lt_c': 0,
           'a_lte_c': 1,
           'a_gt_c': 0,
           'a_gte_c': 1,
+          'a_gt_operator_c': 0,
+          'a_gte_operator_c': 1,
         }),
         Vector({
           'a': 9,
@@ -96,11 +112,15 @@ void main() {
           'a_lte_b': 0,
           'a_gt_b': 1,
           'a_gte_b': 1,
+          'a_gt_operator_b': 1,
+          'a_gte_operator_b': 1,
           'a_eq_c': 0,
           'a_lt_c': 0,
           'a_lte_c': 0,
           'a_gt_c': 1,
           'a_gte_c': 1,
+          'a_gt_operator_c': 1,
+          'a_gte_operator_c': 1,
         }),
       ];
       await SimCompare.checkFunctionalVector(gtm, vectors);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->
As per #140 , for equality, less than, and less than or equal to, Logic has eq, lt, and lte, respectively, since those operators have different meanings (object equality, conditional assignment, and assignment, respectively). Since greater than and greater than or equal to do not use those operators for something else, they were overloaded for > and >=. However, this is a little inconsistent and confusing to new users. It would be nice if you could also optionally use gt and gte for consistency. 

## Testing

<!-- Please describe how you tested your changes. -->
Added test cases in test/comparison_test.dart 

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
Yes. I have updated README.md and doc/tutorials/chapter_2/00_basic_logic.md for the support of _gt_ and _gte._