### PR TITLE
Simulation performance improvements for conditional assignments

### DIFF
--- a/lib/src/exceptions/conditionals/write_after_read_exception.dart
+++ b/lib/src/exceptions/conditionals/write_after_read_exception.dart
@@ -13,10 +13,9 @@ import 'package:rohd/src/exceptions/rohd_exception.dart';
 ///
 /// This is also sometimes called a "read before write" violation.
 class WriteAfterReadException extends RohdException {
-  /// Creates a [WriteAfterReadException] for [signalName].
-  WriteAfterReadException(
-    String signalName,
-  ) : super('Signal "$signalName" changed its value after being used'
+  /// Creates a [WriteAfterReadException].
+  WriteAfterReadException()
+      : super('Signal changed its value after being used'
             ' within one `Combinational` execution.'
             ' This can lead to a mismatch between simulation and synthesis.'
             ' You may be able to use `Combinational.ssa` to correct your'

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -242,10 +242,12 @@ class Combinational extends _Always {
   /// are consuming.
   void _guard(Logic toGuard) {
     if (_guarded.add(toGuard)) {
-      _guardListeners.add(toGuard.glitch.listen((args) {
-        throw WriteAfterReadException(toGuard.name);
-      }));
+      _guardListeners.add(toGuard.glitch.listen(_writeAfterRead));
     }
+  }
+
+  static void _writeAfterRead(args) {
+    throw WriteAfterReadException();
   }
 
   /// Performs the functional behavior of this block.
@@ -666,6 +668,9 @@ class ConditionalAssign extends Conditional {
   @override
   late final List<Conditional> conditionals = const [];
 
+  /// A cached copy of the result of [receiverOutput] to save on lookups.
+  late final _receiverOutput = receiverOutput(receiver);
+
   @override
   void execute(Set<Logic> drivenSignals,
       [void Function(Logic toGuard)? guard]) {
@@ -673,7 +678,7 @@ class ConditionalAssign extends Conditional {
       guard(driver);
     }
 
-    receiverOutput(receiver).put(driverValue(driver));
+    _receiverOutput.put(driverValue(driver));
 
     if (!drivenSignals.contains(receiver) || receiver.value.isValid) {
       drivenSignals.add(receiver);

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -246,6 +246,10 @@ class Combinational extends _Always {
     }
   }
 
+  /// A function that throws a [WriteAfterReadException].
+  ///
+  /// Declared as a separate static function so that it doesn't need to be
+  /// created on each [_guard] call.
   static void _writeAfterRead(args) {
     throw WriteAfterReadException();
   }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Benchmarking, profiling, and usage of recent changes in other designs revealed a few small optimizations that could be made to improve simulation performance when many conditional assignments are used.
- `WriteAfterReadException` no longer prints the signal name.  This enables creating one single `static` function for all write-after-read violations rather than creating a new one during simulation for each signal guarded.  The loss in debug visibility is minimal since signal names going into a `Conditional` are already often not well-named signals, and the full stack trace can provide much more detail.
- Looking up the receiver on each execution of `ConditionalAssign` was redundant overhead, so caching it saves some performance.

## Related Issue(s)

N/A

## Testing

Existing tests cover functionality.  `CombGuardFanoutBenchmark` demonstrated some measurable performance improvements with these changes.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
