### PR TITLE
Issue#334: Added enable signal to flipflop

### DIFF
--- a/test/flop_test.dart
+++ b/test/flop_test.dart
@@ -24,6 +24,22 @@ class FlopTestModule extends Module {
   }
 }
 
+class FlopTestModuleWithEnable extends Module {
+  Logic get a => input('a');
+  Logic get en => input('en');
+  Logic get y => output('y');
+
+  FlopTestModuleWithEnable(Logic a, Logic en)
+      : super(name: 'floptestmodulewithenable') {
+    a = addInput('a', a, width: a.width);
+    en = addInput('en', en, width: en.width);
+    final y = addOutput('y', width: a.width);
+
+    final clk = SimpleClockGenerator(10).clk;
+    y <= FlipFlop(clk, a, en: en).q;
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -43,6 +59,30 @@ void main() {
       await SimCompare.checkFunctionalVector(ftm, vectors);
       final simResult = SimCompare.iverilogVector(ftm, vectors);
       expect(simResult, equals(true));
+      // expect(true, true);
+    });
+
+    test('flop bit with enable', () async {
+      final ftm = FlopTestModuleWithEnable(Logic(), Logic());
+      await ftm.build();
+      final vectors = [
+        Vector({'a': 0, 'en': 1}, {}),
+        Vector({'a': 1, 'en': 1}, {'y': 0}),
+        Vector({'a': 1, 'en': 1}, {'y': 1}),
+        Vector({'a': 0, 'en': 1}, {'y': 1}),
+        Vector({'a': 0, 'en': 1}, {'y': 0}),
+        Vector({'a': 1, 'en': 1}, {'y': 0}),
+        Vector({'a': 1, 'en': 0}, {'y': 1}),
+        Vector({'a': 0, 'en': 0}, {'y': 1}),
+        Vector({'a': 0, 'en': 1}, {'y': 1}),
+        Vector({'a': 1, 'en': 1}, {'y': 0}),
+        Vector({'a': 0, 'en': 0}, {'y': 1}),
+        Vector({'a': 1, 'en': 0}, {'y': 1}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      final simResult = SimCompare.iverilogVector(ftm, vectors);
+      expect(simResult, equals(true));
+      // expect(true, true);
     });
 
     test('flop bus', () async {
@@ -54,6 +94,30 @@ void main() {
         Vector({'a': 0xaa}, {'y': 0xff}),
         Vector({'a': 0x55}, {'y': 0xaa}),
         Vector({'a': 0x1}, {'y': 0x55}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      final simResult = SimCompare.iverilogVector(ftm, vectors);
+      expect(simResult, equals(true));
+    });
+
+    test('flop bus with enable', () async {
+      final ftm = FlopTestModuleWithEnable(Logic(width: 8), Logic());
+      await ftm.build();
+      final vectors = [
+        Vector({'a': 0, 'en': 1}, {}),
+        Vector({'a': 0xff, 'en': 1}, {'y': 0}),
+        Vector({'a': 0xaa, 'en': 1}, {'y': 0xff}),
+        Vector({'a': 0x55, 'en': 1}, {'y': 0xaa}),
+        Vector({'a': 0x1, 'en': 1}, {'y': 0x55}),
+        Vector({'a': 0, 'en': 1}, {'y': 0x1}),
+        Vector({'a': 0xff, 'en': 1}, {'y': 0}),
+        Vector({'a': 0xaa, 'en': 1}, {'y': 0xff}),
+        Vector({'a': 0x55, 'en': 0}, {'y': 0xaa}),
+        Vector({'a': 0x1, 'en': 0}, {'y': 0xaa}),
+        Vector({'a': 0x55, 'en': 1}, {'y': 0xaa}),
+        Vector({'a': 0x1, 'en': 1}, {'y': 0x55}),
+        Vector({'a': 0x55, 'en': 0}, {'y': 0x1}),
+        Vector({'a': 0x1, 'en': 1}, {'y': 0x1}),
       ];
       await SimCompare.checkFunctionalVector(ftm, vectors);
       final simResult = SimCompare.iverilogVector(ftm, vectors);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->
It would be nice to have an enable signal optionally provided as part of the built-in FlipFlop as per #334 

## Testing

<!-- Please describe how you tested your changes. -->
Update test/flop_test.dart for the same.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
Update required at official [documentation](https://intel.github.io/rohd/rohd/FlipFlop-class.html). Not included by me.