### PR TITLE
Issue#257: Added flop like function to construct FlipFlop

### DIFF
--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1380,6 +1380,14 @@ ${padding}end ''');
   }
 }
 
+/// Constructs a positive edge triggered flip flop on [clk].
+///
+/// It returns [FlipFlop.q]. When optional [en] is provided, an additional
+/// input will be created for flop. If optional [en] is high or not provided,
+/// output will vary as per input[d]. For low [en], output remains frozen
+/// irrespective of input [d]
+Logic flop(Logic clk, Logic d, {Logic? en}) => FlipFlop(clk, d, en: en).q;
+
 /// Represents a single flip-flop with no reset.
 class FlipFlop extends Module with CustomSystemVerilog {
   /// Name for the enable input of this flop

--- a/test/flop_test.dart
+++ b/test/flop_test.dart
@@ -26,9 +26,9 @@ class FlopTestModule extends Module {
     final clk = SimpleClockGenerator(10).clk;
 
     if (en != null) {
-      y <= FlipFlop(clk, a, en: en).q;
+      y <= flop(clk, a, en: en);
     } else {
-      y <= FlipFlop(clk, a).q;
+      y <= flop(clk, a);
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->
Currently, to make a flop requires `FlipFlop(clk, d).q`, but it would be nicer to write `flop(clk, d)` to get the same thing as per #257 
## Related Issue(s)

Fix #257 

## Testing

<!-- Please describe how you tested your changes. -->
Updated `test/flop_test.dart` with added `flop()`

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
Yes, need to mention additional `flop()` function support (not included by me).