### PR TITLE
Fix #382, if block exceptions when else is wrong

### DIFF
--- a/lib/src/exceptions/conditionals/conditional_exceptions.dart
+++ b/lib/src/exceptions/conditionals/conditional_exceptions.dart
@@ -1,6 +1,7 @@
 /// Copyright (C) 2022 Intel Corporation
 /// SPDX-License-Identifier: BSD-3-Clause
 
+export 'invalid_conditional_exception.dart';
 export 'mapped_signal_already_assigned_exception.dart';
 export 'signal_redriven_exception.dart';
 export 'uninitialized_signal_exception.dart';

--- a/lib/src/exceptions/conditionals/invalid_conditional_exception.dart
+++ b/lib/src/exceptions/conditionals/invalid_conditional_exception.dart
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// invalid_conditional_exception.dart
+// An exception thrown when a conditional is built in an invalid way.
+//
+// 2023 June 13
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/exceptions.dart';
+
+/// An exception that is thrown when a [Conditional] has been constructed in
+/// an invalid way.
+class InvalidConditionalException extends RohdException {
+  /// Creates a new [InvalidConditionalException] with a [message] explaining
+  /// why the conditional was invalid.
+  InvalidConditionalException(super.message);
+}

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1240,7 +1240,21 @@ class If extends Conditional {
 
   /// Checks the conditions for [iffs] in order and executes the first one
   /// whose condition is enabled.
-  If.block(this.iffs);
+  If.block(this.iffs) {
+    for (final iff in iffs) {
+      if (iff is Else) {
+        if (iff != iffs.last) {
+          throw InvalidConditionalException(
+              'Else must come last in an IfBlock.');
+        }
+
+        if (iff == iffs.first) {
+          throw InvalidConditionalException(
+              'Else cannot be the first in an IfBlock.');
+        }
+      }
+    }
+  }
 
   @override
   void execute(Set<Logic> drivenSignals, [void Function(Logic)? guard]) {
@@ -1318,9 +1332,6 @@ class If extends Conditional {
     final padding = Conditional.calcPadding(indent);
     final verilog = StringBuffer();
     for (final iff in iffs) {
-      if (iff is Else && iff != iffs.last) {
-        throw Exception('Else must come last in an IfBlock.');
-      }
       final header = iff == iffs.first
           ? 'if'
           : iff is Else

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1219,7 +1219,9 @@ class If extends Conditional {
   ///
   /// The first item should be an [Iff], and if an [Else] is included it must
   /// be the last item.  Any other items should be [ElseIf].  It is okay to
-  /// make thefirst item an [ElseIf], it will act just like an [Iff].
+  /// make the first item an [ElseIf], it will act just like an [Iff]. If an
+  /// [Else] is included, it cannot be the only element (it must be preceded
+  /// by an [Iff] or [ElseIf]).
   final List<Iff> iffs;
 
   /// If [condition] is high, then [then] executes, otherwise [orElse] is

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -403,6 +403,18 @@ class MultipleConditionalModule extends Module {
   }
 }
 
+class OnlyElseMod extends Module {
+  OnlyElseMod(Logic a) {
+    a = addInput('a', a);
+    final b = addOutput('b');
+    Combinational([
+      If.block([
+        Else([b < a])
+      ])
+    ]);
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -454,6 +466,35 @@ void main() {
           await Simulator.simulationEnded;
         });
       }
+    });
+
+    group('bad if blocks', () {
+      test('IfBlock with only else fails', () async {
+        expect(
+            () => If.block([
+                  Else([]),
+                ]),
+            throwsException);
+      });
+
+      test('IfBlock with else in the middle fails', () {
+        expect(
+            () => If.block([
+                  ElseIf(Logic(), []),
+                  Else([]),
+                  ElseIf(Logic(), []),
+                ]),
+            throwsException);
+      });
+
+      test('IfBlock with else at the start fails', () {
+        expect(
+            () => If.block([
+                  Else([]),
+                  ElseIf(Logic(), []),
+                ]),
+            throwsException);
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fixes a set of bugs where `If`s can be constructed in an illegal way without an `Exception` being thrown.

## Related Issue(s)

Fix #382 

## Testing

Added tests for different wrong usages of `Else` in an `If.block`.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Updated doc comment clarifying requirements.
