### PR TITLE
Add `previousValue` to `Logic`

### DIFF
--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -120,8 +120,8 @@ class Logic {
   Future<LogicValueChanged> get nextNegedge => _wire.nextNegedge;
 
   /// The [value] of this signal before the most recent [Simulator.tick] had
-  /// completed. The first time it is called, it creates a pre-tick listener,
-  /// so until the first tick after the first call, it will return `null`.
+  /// completed. It will be `null` before the first tick after this signal is
+  /// created.
   ///
   /// If this is called mid-tick, it will be the value from before the tick
   /// started. If this is called post-tick, it will be the value from before

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -119,6 +119,22 @@ class Logic {
   /// Throws an exception if [width] is not `1`.
   Future<LogicValueChanged> get nextNegedge => _wire.nextNegedge;
 
+  /// The [value] of this signal before the most recent [Simulator.tick] had
+  /// completed. The first time it is called, it creates a pre-tick listener,
+  /// so until the first tick after the first call, it will return `null`.
+  ///
+  /// If this is called mid-tick, it will be the value from before the tick
+  /// started. If this is called post-tick, it will be the value from before
+  /// that last tick started.
+  ///
+  /// This is useful for querying the value of a signal in a testbench before
+  /// some change event occurred, for example sampling a signal before a clock
+  /// edge for code that was triggered on that edge.
+  ///
+  /// Note that if a signal is connected to another signal, the listener may
+  /// be reset.
+  LogicValue? get previousValue => _wire.previousValue;
+
   /// The [Module] that this [Logic] exists within.
   ///
   /// For internal signals, this only gets populated after its parent [Module],

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -286,6 +286,9 @@ class LogicStructure implements Logic {
   LogicValue get value => packed.value;
 
   @override
+  LogicValue? get previousValue => packed.previousValue;
+
+  @override
   late final int width = elements.isEmpty
       ? 0
       : elements.map((e) => e.width).reduce((w1, w2) => w1 + w2);

--- a/lib/src/signals/wire.dart
+++ b/lib/src/signals/wire.dart
@@ -91,8 +91,7 @@ class _Wire {
 
   /// The subscription to the [Simulator]'s `preTick`.
   ///
-  /// Non-null if [_changedBeingWatched] is true or someone has requested the
-  /// [previousValue].
+  /// Non-null after the first tick has occurred after creation of `this`.
   StreamSubscription<void>? _preTickSubscription;
 
   /// The subscription to the [Simulator]'s `postTick`.

--- a/lib/src/signals/wire.dart
+++ b/lib/src/signals/wire.dart
@@ -13,7 +13,9 @@ part of signals;
 /// more [Logic]s.
 class _Wire {
   _Wire({required this.width})
-      : _currentValue = LogicValue.filled(width, LogicValue.z);
+      : _currentValue = LogicValue.filled(width, LogicValue.z) {
+    _setupPreTickListener();
+  }
 
   /// The current active value of this signal.
   LogicValue get value => _currentValue;
@@ -53,8 +55,6 @@ class _Wire {
       // them! saves performance!
       _changedBeingWatched = true;
 
-      _setupPreTickListener();
-
       _postTickSubscription ??= Simulator.postTick.listen((event) {
         if (value != _preTickValue && _preTickValue != null) {
           _changedController.add(LogicValueChanged(value, _preTickValue!));
@@ -74,8 +74,8 @@ class _Wire {
   }
 
   /// The [value] of this signal before the most recent [Simulator.tick] had
-  /// completed. The first time it is called, it creates a pre-tick listener,
-  /// so until the first tick after the first call, it will return `null`.
+  /// completed. It will be `null` before the first tick after this signal is
+  /// created.
   ///
   /// If this is called mid-tick, it will be the value from before the tick
   /// started. If this is called post-tick, it will be the value from before
@@ -87,10 +87,7 @@ class _Wire {
   ///
   /// Note that if a signal is connected to another signal, the listener may
   /// be reset.
-  LogicValue? get previousValue {
-    _setupPreTickListener();
-    return _preTickValue;
-  }
+  LogicValue? get previousValue => _preTickValue;
 
   /// The subscription to the [Simulator]'s `preTick`.
   ///

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -315,4 +315,38 @@ void main() {
     Simulator.setMaxSimTime(5000);
     await Simulator.run();
   });
+
+  test('chain of changed and injects', () async {
+    final a = Logic()..put(0);
+    final b = Logic()..put(0);
+    final c = Logic()..put(0);
+    final d = Logic()..put(0);
+
+    var changeCount = 0;
+
+    a.changed.listen((event) {
+      b.inject(~b.value);
+    });
+
+    b.changed.listen((event) {
+      c.inject(~c.value);
+    });
+
+    c.changed.listen((event) {
+      d.inject(~d.value);
+    });
+
+    d.changed.listen((event) {
+      changeCount++;
+    });
+
+    Simulator.registerAction(10, () => a.put(~a.value));
+    Simulator.registerAction(20, () => a.put(~a.value));
+
+    Simulator.setMaxSimTime(500);
+
+    await Simulator.run();
+
+    expect(changeCount, 2);
+  });
 }

--- a/test/previous_value_test.dart
+++ b/test/previous_value_test.dart
@@ -27,8 +27,6 @@ void main() {
 
     Simulator.registerAction(11, () => a.put(1));
 
-    c.previousValue;
-
     clk.posedge.listen((event) {
       if (Simulator.time == 25) {
         expect(c.previousValue!.toInt(), 0);
@@ -49,8 +47,6 @@ void main() {
     final c = flop(clk, b);
 
     Simulator.registerAction(11, () => a.put(1));
-
-    c.previousValue;
 
     Future<void> clkLoop() async {
       while (!Simulator.simulationHasEnded) {

--- a/test/previous_value_test.dart
+++ b/test/previous_value_test.dart
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// previous_value_Test.dart
+// previous_value_test.dart
 // Tests for Logic.previousValue
 //
 // 2023 June 16

--- a/test/previous_value_test.dart
+++ b/test/previous_value_test.dart
@@ -1,0 +1,70 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// previous_value_Test.dart
+// Tests for Logic.previousValue
+//
+// 2023 June 16
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'dart:async';
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  test('sample on flop with listen', () async {
+    final clk = SimpleClockGenerator(10).clk;
+
+    final a = Logic()..put(0);
+
+    final b = flop(clk, a);
+    final c = flop(clk, b);
+
+    Simulator.registerAction(11, () => a.put(1));
+
+    c.previousValue;
+
+    clk.posedge.listen((event) {
+      if (Simulator.time == 25) {
+        expect(c.previousValue!.toInt(), 0);
+        expect(c.value.toInt(), 1);
+      }
+    });
+
+    Simulator.setMaxSimTime(200);
+    await Simulator.run();
+  });
+
+  test('sample on flop with await', () async {
+    final clk = SimpleClockGenerator(10).clk;
+
+    final a = Logic()..put(0);
+
+    final b = flop(clk, a);
+    final c = flop(clk, b);
+
+    Simulator.registerAction(11, () => a.put(1));
+
+    c.previousValue;
+
+    Future<void> clkLoop() async {
+      while (!Simulator.simulationHasEnded) {
+        await clk.nextPosedge;
+        if (Simulator.time == 25) {
+          expect(c.previousValue!.toInt(), 0);
+          expect(c.value.toInt(), 1);
+        }
+      }
+    }
+
+    unawaited(clkLoop());
+
+    Simulator.setMaxSimTime(200);
+    await Simulator.run();
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

In testbenches, it can be useful to see the "previous" value of a signal before a clock edge when sampling something, e.g. for modelling hardware.  This PR includes a `previousValue` onto `Logic` that shows the value of a signal before the most recent `Simulator.tick`.

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

API docs yes
