### PR TITLE
Cases

### DIFF
--- a/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
+++ b/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
@@ -18,4 +18,12 @@ class SignalWidthMismatchException extends RohdException {
       : super('Signal ${signal.name} has the wrong width.'
             ' Expected $expectedWidth but found ${signal.width}.'
             ' $additionalMessage');
+
+  /// Constructs a new [Exception] for when a dynamic has a wrong width.
+  SignalWidthMismatchException.forDynamic(
+      dynamic val, int expectedWidth, int actualWidth,
+      {String additionalMessage = ''})
+      : super('Value $val has the wrong width.'
+            ' Excepted $expectedWidth but found $actualWidth.'
+            ' $additionalMessage');
 }

--- a/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
+++ b/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
@@ -24,6 +24,6 @@ class SignalWidthMismatchException extends RohdException {
       dynamic val, int expectedWidth, int actualWidth,
       {String additionalMessage = ''})
       : super('Value $val has the wrong width.'
-            ' Excepted $expectedWidth but found $actualWidth.'
+            ' Expected $expectedWidth but found $actualWidth.'
             ' $additionalMessage');
 }

--- a/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
+++ b/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
@@ -30,6 +30,6 @@ class SignalWidthMismatchException extends RohdException {
   /// Constructs a new [Exception] for when a dynamic has no width or it could
   /// not be inferred.
   SignalWidthMismatchException.forNull(dynamic val)
-      : super('Could not infer width of value $val.'
+      : super('Could not infer width of input $val.'
             ' Please provide a valid width.');
 }

--- a/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
+++ b/lib/src/exceptions/logic/signal_width_mismatch_exception.dart
@@ -26,4 +26,10 @@ class SignalWidthMismatchException extends RohdException {
       : super('Value $val has the wrong width.'
             ' Expected $expectedWidth but found $actualWidth.'
             ' $additionalMessage');
+
+  /// Constructs a new [Exception] for when a dynamic has no width or it could
+  /// not be inferred.
+  SignalWidthMismatchException.forNull(dynamic val)
+      : super('Could not infer width of value $val.'
+            ' Please provide a valid width.');
 }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -908,14 +908,10 @@ Logic cases(Logic expression, Map<Logic, dynamic> conditions, {int? width}) {
     width ??= inferredWidth;
 
     if (width != inferredWidth && inferredWidth != null) {
-      //throw Exception('Width of (${condition.value}) '
-      //    'must match width ($width)');
       throw SignalWidthMismatchException.forDynamic(
           condition.value, width!, inferredWidth);
     }
     if (expression.width != condition.key.width) {
-      //  throw Exception('Width of (${condition.key}) '
-      //      'must match with width of ($expression)');
       throw SignalWidthMismatchException.forDynamic(
           condition.key, expression.width, condition.key.width);
     }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -933,8 +933,6 @@ Logic cases(Logic expression, Map<dynamic, dynamic> conditions,
     }
   }
 
-  if (defaultValue == null) {}
-
   for (final condition in conditions.entries) {
     if (condition.key is Logic) {
       if (expression.width != (condition.key as Logic).width) {

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -922,11 +922,6 @@ Logic cases(Logic expression, Map<dynamic, dynamic> conditions,
     }
 
     width ??= inferredWidth;
-
-    if (width != inferredWidth && inferredWidth != null) {
-      throw SignalWidthMismatchException.forDynamic(
-          conditionValue, width!, inferredWidth);
-    }
   }
 
   if (width == null) {
@@ -949,7 +944,7 @@ Logic cases(Logic expression, Map<dynamic, dynamic> conditions,
     }
   }
 
-  final result = Logic(name: 'result', width: width!);
+  final result = Logic(name: 'result', width: width);
 
   Combinational([
     Case(

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -16,6 +16,7 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd/src/collections/duplicate_detection_set.dart';
 import 'package:rohd/src/collections/traverseable_collection.dart';
 import 'package:rohd/src/exceptions/conditionals/conditional_exceptions.dart';
+import 'package:rohd/src/exceptions/exceptions.dart';
 import 'package:rohd/src/exceptions/module/port_width_mismatch_exception.dart';
 import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/synchronous_propagator.dart';
@@ -907,12 +908,16 @@ Logic cases(Logic expression, Map<Logic, dynamic> conditions, {int? width}) {
     width ??= inferredWidth;
 
     if (width != inferredWidth && inferredWidth != null) {
-      throw Exception('Width of (${condition.value}) '
-          'must match width ($width)');
+      //throw Exception('Width of (${condition.value}) '
+      //    'must match width ($width)');
+      throw SignalWidthMismatchException.forDynamic(
+          condition.value, width!, inferredWidth);
     }
     if (expression.width != condition.key.width) {
-      throw Exception('Width of (${condition.key}) '
-          'must match with width of ($expression)');
+      //  throw Exception('Width of (${condition.key}) '
+      //      'must match with width of ($expression)');
+      throw SignalWidthMismatchException.forDynamic(
+          condition.key, expression.width, condition.key.width);
     }
   }
 

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -9,15 +9,12 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:js_interop';
 
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/collections/duplicate_detection_set.dart';
 import 'package:rohd/src/collections/traverseable_collection.dart';
-import 'package:rohd/src/exceptions/conditionals/conditional_exceptions.dart';
 import 'package:rohd/src/exceptions/exceptions.dart';
-import 'package:rohd/src/exceptions/module/port_width_mismatch_exception.dart';
 import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/synchronous_propagator.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -923,14 +923,14 @@ Logic cases(Logic expression, Map<dynamic, dynamic> conditions,
 
     width ??= inferredWidth;
 
-    if (width == null && inferredWidth == null) {
-      throw SignalWidthMismatchException.forNull(conditionValue);
-    }
-
     if (width != inferredWidth && inferredWidth != null) {
       throw SignalWidthMismatchException.forDynamic(
           conditionValue, width!, inferredWidth);
     }
+  }
+
+  if (width == null) {
+    throw SignalWidthMismatchException.forNull(conditions);
   }
 
   for (final condition in conditions.entries) {
@@ -963,7 +963,7 @@ Logic cases(Logic expression, Map<dynamic, dynamic> conditions,
                 [result < condition.value])
         ],
         conditionalType: conditionalType,
-        defaultItem: defaultValue != null ? [result < defaultValue] : [])
+        defaultItem: defaultValue != null ? [result < defaultValue] : null)
   ]);
 
   return result;

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -19,7 +19,6 @@ import 'package:rohd/src/exceptions/exceptions.dart';
 import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/synchronous_propagator.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
-import 'package:test/test.dart';
 
 /// Represents a block of logic, similar to `always` blocks in SystemVerilog.
 abstract class _Always extends Module with CustomSystemVerilog {

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -499,8 +499,7 @@ void main() {
         Vector({'a': 1, 'b': 1, 'd': 8}, {'y': 1, 'z': 1, 'x': 1, 'q': 8}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
-      final simResult =
-          SimCompare.iverilogVector(mod, vectors, dontDeleteTmpFiles: true);
+      final simResult = SimCompare.iverilogVector(mod, vectors);
       expect(simResult, equals(true));
     });
 

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -445,7 +445,8 @@ void main() {
         Vector({'a': 1, 'b': 1, 'd': 8}, {'y': 1, 'z': 1, 'x': 1, 'q': 8}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
-      final simResult = SimCompare.iverilogVector(mod, vectors);
+      final simResult =
+          SimCompare.iverilogVector(mod, vectors, dontDeleteTmpFiles: true);
       expect(simResult, equals(true));
     });
 

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -187,6 +187,91 @@ void main() {
     });
   });
 
+  test('mux shorthand', () {
+    final control = Logic();
+    final d0 = Logic();
+    final d1 = Logic();
+    final result = mux(control, d1, d0);
+
+    d0.put(0);
+    d1.put(1);
+    control.put(0);
+
+    expect(result.value, LogicValue.zero);
+
+    control.put(1);
+
+    expect(result.value, LogicValue.one);
+
+    // cases(control, {d0: 0, d1: 1});
+  });
+
+  test('Cases test Int', () {
+    final control = Logic(width: 8);
+    final d0 = Logic(width: 8);
+    final d1 = Logic(width: 8);
+    final result = cases(
+        control,
+        {
+          d0: 2,
+          d1: 3,
+        },
+        width: 8);
+
+    d0.put(2);
+    d1.put(3);
+    control.put(2);
+
+    expect(result.value, LogicValue.ofInt(2, 8));
+
+    control.put(3);
+
+    expect(result.value, LogicValue.ofInt(3, 8));
+  });
+
+  test('Cases test Logic', () {
+    final control = Logic();
+    final d0 = Logic();
+    final d1 = Logic();
+    final result = cases(control, {
+      d0: LogicValue.zero,
+      d1: LogicValue.one,
+    });
+
+    d0.put(LogicValue.zero);
+    d1.put(LogicValue.one);
+
+    control.put(0);
+    expect(result.value, LogicValue.zero);
+
+    control.put(1);
+    expect(result.value, LogicValue.one);
+  });
+
+  test('Cases test Exceptions(Int)', () {
+    final control = Logic();
+    final d0 = Logic(width: 4);
+    final d1 = Logic(width: 8);
+
+    control.put(2);
+    d0.put(LogicValue.ofInt(2, 4));
+    d1.put(LogicValue.ofInt(3, 8));
+
+    expect(() => cases(control, {d0: 2, d1: 3}), throwsException);
+  });
+
+  test('Cases test Exceptions 2', () {
+    final control = Logic();
+    final d0 = Logic();
+    final d1 = Logic(width: 8);
+
+    control.put(0);
+    d0.put(LogicValue.zero);
+    d1.put(LogicValue.ofInt(1, 8));
+
+    expect(() => cases(control, {d0: 0, d1: 1}), throwsException);
+  });
+
   group('simcompare', () {
     test('NotGate single bit', () async {
       final gtm = GateTestModule(Logic(), Logic());
@@ -196,7 +281,8 @@ void main() {
         Vector({'a': 0}, {'a_bar': 1}),
       ];
       await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(gtm, vectors);
+      final simResult =
+          SimCompare.iverilogVector(gtm, vectors, dontDeleteTmpFiles: true);
       expect(simResult, equals(true));
     });
 

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -205,85 +205,114 @@ void main() {
     expect(result.value, LogicValue.one);
   });
 
-  test('Cases test Int', () {
-    final control = Logic(width: 8);
-    final d0 = Logic(width: 8);
-    final d1 = Logic(width: 8);
-    final result = cases(
-        control,
-        {
-          d0: 2,
-          d1: 3,
-        },
-        width: 8);
+  group('cases', () {
+    test('Cases test Int', () {
+      final control = Logic(width: 8);
+      final d0 = Logic(width: 8);
+      final d1 = Logic(width: 8);
+      final result = cases(
+          control,
+          {
+            d0: 2,
+            d1: 3,
+          },
+          width: 8);
 
-    d0.put(2);
-    d1.put(3);
-    control.put(2);
+      d0.put(2);
+      d1.put(3);
+      control.put(2);
 
-    expect(result.value, LogicValue.ofInt(2, 8));
+      expect(result.value, LogicValue.ofInt(2, 8));
 
-    control.put(3);
+      control.put(3);
 
-    expect(result.value, LogicValue.ofInt(3, 8));
-  });
-
-  test('Cases test Logic', () {
-    final control = Logic();
-    final d0 = Logic();
-    final d1 = Logic();
-    final result = cases(control, {
-      d0: LogicValue.zero,
-      d1: LogicValue.one,
+      expect(result.value, LogicValue.ofInt(3, 8));
     });
 
-    d0.put(LogicValue.zero);
-    d1.put(LogicValue.one);
+    test('Cases test Logic', () {
+      final control = Logic();
+      final d0 = Logic();
+      final d1 = Logic();
+      final result = cases(control, {
+        d0: LogicValue.zero,
+        d1: LogicValue.one,
+      });
 
-    control.put(0);
-    expect(result.value, LogicValue.zero);
+      d0.put(LogicValue.zero);
+      d1.put(LogicValue.one);
 
-    control.put(1);
-    expect(result.value, LogicValue.one);
-  });
+      control.put(0);
+      expect(result.value, LogicValue.zero);
 
-  test('Cases test Exceptions(Int)', () {
-    final control = Logic(width: 4);
-    final d0 = Logic(width: 4);
-    final d1 = Logic(width: 8);
+      control.put(1);
+      expect(result.value, LogicValue.one);
+    });
 
-    control.put(LogicValue.ofInt(2, 4));
-    d0.put(LogicValue.ofInt(2, 4));
-    d1.put(LogicValue.ofInt(3, 8));
+    test('Cases test Default', () {
+      final control = Logic(width: 4);
+      const d0 = 1;
+      const d1 = 2;
+      final result = cases(
+          control,
+          {
+            d0: 1,
+            d1: 2,
+          },
+          width: 4,
+          defaultValue: 3);
 
-    expect(() => cases(control, {d0: 2, d1: 3}),
-        throwsA(isA<SignalWidthMismatchException>()));
-  });
+      control.put(LogicValue.zero);
+      expect(result.value, LogicValue.ofInt(3, 4));
+    });
 
-  test('Cases test Condition width Exception', () {
-    final control = Logic();
-    final d0 = Logic();
-    final d1 = Logic(width: 8);
+    test('Cases test Exceptions(Int)', () {
+      final control = Logic(width: 4);
+      final d0 = Logic(width: 4);
+      final d1 = Logic(width: 8);
 
-    control.put(LogicValue.zero);
-    d0.put(LogicValue.zero);
-    d1.put(LogicValue.ofInt(1, 8));
+      control.put(LogicValue.ofInt(2, 4));
+      d0.put(LogicValue.ofInt(2, 4));
+      d1.put(LogicValue.ofInt(3, 8));
 
-    expect(() => cases(control, {d0: 0, d1: 1}),
-        throwsA(isA<SignalWidthMismatchException>()));
-  });
+      expect(() => cases(control, {d0: 2, d1: 3}),
+          throwsA(isA<SignalWidthMismatchException>()));
+    });
 
-  test('Cases test Expression width Exception', () {
-    final control = Logic();
-    final d0 = Logic(width: 8);
-    final d1 = Logic(width: 8);
+    test('Cases test Condition width Exception', () {
+      final control = Logic();
+      final d0 = Logic();
+      final d1 = Logic(width: 8);
 
-    control.put(LogicValue.one);
-    d0.put(LogicValue.zero);
-    d1.put(LogicValue.one);
+      control.put(LogicValue.zero);
+      d0.put(LogicValue.zero);
+      d1.put(LogicValue.ofInt(1, 8));
 
-    expect(() => cases(control, {d0: 0, d1: 1}),
-        throwsA(isA<SignalWidthMismatchException>()));
+      expect(() => cases(control, {d0: 0, d1: 1}),
+          throwsA(isA<SignalWidthMismatchException>()));
+    });
+
+    test('Cases test Expression width Exception', () {
+      final control = Logic();
+      final d0 = Logic(width: 8);
+      final d1 = Logic(width: 8);
+
+      control.put(LogicValue.one);
+      d0.put(LogicValue.zero);
+      d1.put(LogicValue.one);
+
+      expect(() => cases(control, {d0: 0, d1: 1}),
+          throwsA(isA<SignalWidthMismatchException>()));
+    });
+
+    test('Cases test Null width Exception', () {
+      final control = Logic();
+      const d0 = 2;
+      const d1 = 4;
+
+      control.put(LogicValue.zero);
+      expect(() => cases(control, {d0: 2, d1: 4}, defaultValue: 3),
+          throwsA(isA<SignalWidthMismatchException>()));
+    });
   });
 
   group('simcompare', () {

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -8,6 +8,7 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/exceptions/exceptions.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
@@ -249,27 +250,42 @@ void main() {
   });
 
   test('Cases test Exceptions(Int)', () {
-    final control = Logic();
+    final control = Logic(width: 4);
     final d0 = Logic(width: 4);
     final d1 = Logic(width: 8);
 
-    control.put(2);
+    control.put(LogicValue.ofInt(2, 4));
     d0.put(LogicValue.ofInt(2, 4));
     d1.put(LogicValue.ofInt(3, 8));
 
-    expect(() => cases(control, {d0: 2, d1: 3}), throwsException);
+    expect(() => cases(control, {d0: 2, d1: 3}),
+        throwsA(isA<SignalWidthMismatchException>()));
   });
 
-  test('Cases test Exceptions 2', () {
+  test('Cases test Condition width Exception', () {
     final control = Logic();
     final d0 = Logic();
     final d1 = Logic(width: 8);
 
-    control.put(0);
+    control.put(LogicValue.zero);
     d0.put(LogicValue.zero);
     d1.put(LogicValue.ofInt(1, 8));
 
-    expect(() => cases(control, {d0: 0, d1: 1}), throwsException);
+    expect(() => cases(control, {d0: 0, d1: 1}),
+        throwsA(isA<SignalWidthMismatchException>()));
+  });
+
+  test('Cases test Expression width Exception', () {
+    final control = Logic();
+    final d0 = Logic(width: 8);
+    final d1 = Logic(width: 8);
+
+    control.put(LogicValue.one);
+    d0.put(LogicValue.zero);
+    d1.put(LogicValue.one);
+
+    expect(() => cases(control, {d0: 0, d1: 1}),
+        throwsA(isA<SignalWidthMismatchException>()));
   });
 
   group('simcompare', () {

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -203,8 +203,6 @@ void main() {
     control.put(1);
 
     expect(result.value, LogicValue.one);
-
-    // cases(control, {d0: 0, d1: 1});
   });
 
   test('Cases test Int', () {
@@ -297,8 +295,7 @@ void main() {
         Vector({'a': 0}, {'a_bar': 1}),
       ];
       await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult =
-          SimCompare.iverilogVector(gtm, vectors, dontDeleteTmpFiles: true);
+      final simResult = SimCompare.iverilogVector(gtm, vectors);
       expect(simResult, equals(true));
     });
 

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -208,13 +208,13 @@ void main() {
   group('Cases', () {
     test('test LogicValue', () {
       final control = Logic(width: 8);
-      final d0 = LogicValue.ofInt(2, 8);
-      final d1 = LogicValue.ofInt(3, 8);
+      final d0 = Logic(width: 8)..put(LogicValue.ofInt(2, 8));
+      final d1 = Logic(width: 8)..put(LogicValue.ofInt(3, 8));
       final result = cases(
           control,
           {
-            d0: 2,
-            d1: 3,
+            d0: LogicValue.ofInt(2, 8),
+            d1: LogicValue.ofInt(3, 8),
           },
           width: 8);
 
@@ -286,11 +286,11 @@ void main() {
       d0.put(LogicValue.ofInt(2, 4));
       d1.put(LogicValue.ofInt(3, 8));
 
-      expect(() => cases(control, {d0: 2, d1: 3}),
+      expect(() => cases(control, {d0: 2, d1: 3}, width: 4),
           throwsA(isA<SignalWidthMismatchException>()));
     });
 
-    test('test Condition width Exception', () {
+    test('test Condition width mismatch Exception', () {
       final control = Logic();
       final d0 = Logic();
       final d1 = Logic(width: 8);
@@ -299,20 +299,36 @@ void main() {
       d0.put(LogicValue.zero);
       d1.put(LogicValue.ofInt(1, 8));
 
-      expect(() => cases(control, {d0: 0, d1: 1}),
+      expect(
+          () =>
+              cases(control, {d0: LogicValue.zero, d1: LogicValue.ofInt(1, 8)}),
           throwsA(isA<SignalWidthMismatchException>()));
     });
 
-    test('test Expression width Exception', () {
+    test('test Expression width mismatch Exception for Logic', () {
       final control = Logic();
       final d0 = Logic(width: 8);
       final d1 = Logic(width: 8);
 
       control.put(LogicValue.one);
-      d0.put(LogicValue.zero);
-      d1.put(LogicValue.one);
 
-      expect(() => cases(control, {d0: 0, d1: 1}),
+      expect(
+          () => cases(control, {d0: Logic(width: 8), d1: Logic(width: 8)},
+              width: 8),
+          throwsA(isA<SignalWidthMismatchException>()));
+    });
+
+    test('test Expression width mismatch Exception for LogicValue', () {
+      final control = Logic();
+      final d0 = LogicValue.ofInt(0, 8);
+      final d1 = LogicValue.ofInt(1, 8);
+
+      control.put(LogicValue.one);
+
+      expect(
+          () => cases(
+              control, {d0: LogicValue.ofInt(0, 8), d1: LogicValue.ofInt(1, 8)},
+              width: 8),
           throwsA(isA<SignalWidthMismatchException>()));
     });
 

--- a/test/gate_test.dart
+++ b/test/gate_test.dart
@@ -205,11 +205,11 @@ void main() {
     expect(result.value, LogicValue.one);
   });
 
-  group('cases', () {
-    test('Cases test Int', () {
+  group('Cases', () {
+    test('test LogicValue', () {
       final control = Logic(width: 8);
-      final d0 = Logic(width: 8);
-      final d1 = Logic(width: 8);
+      final d0 = LogicValue.ofInt(2, 8);
+      final d1 = LogicValue.ofInt(3, 8);
       final result = cases(
           control,
           {
@@ -218,8 +218,6 @@ void main() {
           },
           width: 8);
 
-      d0.put(2);
-      d1.put(3);
       control.put(2);
 
       expect(result.value, LogicValue.ofInt(2, 8));
@@ -229,17 +227,31 @@ void main() {
       expect(result.value, LogicValue.ofInt(3, 8));
     });
 
-    test('Cases test Logic', () {
+    test('test Int', () {
+      final control = Logic(width: 4)..put(LogicValue.ofInt(2, 4));
+      const d0 = 2;
+      const d1 = 3;
+
+      final result = cases(
+          control,
+          {
+            d0: 2,
+            d1: 3,
+          },
+          width: 4,
+          defaultValue: 3);
+
+      expect(result.value, LogicValue.ofInt(2, 4));
+    });
+
+    test('test Logic', () {
       final control = Logic();
-      final d0 = Logic();
-      final d1 = Logic();
+      final d0 = Logic()..put(LogicValue.zero);
+      final d1 = Logic()..put(LogicValue.one);
       final result = cases(control, {
         d0: LogicValue.zero,
         d1: LogicValue.one,
       });
-
-      d0.put(LogicValue.zero);
-      d1.put(LogicValue.one);
 
       control.put(0);
       expect(result.value, LogicValue.zero);
@@ -248,7 +260,7 @@ void main() {
       expect(result.value, LogicValue.one);
     });
 
-    test('Cases test Default', () {
+    test('test Default', () {
       final control = Logic(width: 4);
       const d0 = 1;
       const d1 = 2;
@@ -265,7 +277,7 @@ void main() {
       expect(result.value, LogicValue.ofInt(3, 4));
     });
 
-    test('Cases test Exceptions(Int)', () {
+    test('test Exceptions(Int)', () {
       final control = Logic(width: 4);
       final d0 = Logic(width: 4);
       final d1 = Logic(width: 8);
@@ -278,7 +290,7 @@ void main() {
           throwsA(isA<SignalWidthMismatchException>()));
     });
 
-    test('Cases test Condition width Exception', () {
+    test('test Condition width Exception', () {
       final control = Logic();
       final d0 = Logic();
       final d1 = Logic(width: 8);
@@ -291,7 +303,7 @@ void main() {
           throwsA(isA<SignalWidthMismatchException>()));
     });
 
-    test('Cases test Expression width Exception', () {
+    test('test Expression width Exception', () {
       final control = Logic();
       final d0 = Logic(width: 8);
       final d1 = Logic(width: 8);
@@ -304,7 +316,7 @@ void main() {
           throwsA(isA<SignalWidthMismatchException>()));
     });
 
-    test('Cases test Null width Exception', () {
+    test('test Null width Exception', () {
       final control = Logic();
       const d0 = 2;
       const d1 = 4;


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Implemented a shorthand for creating a Conditional and Case. This is for the scenario where it is needed to assign/create a signal based on a condition, similar to a mux. The output is a single `Logic` signal. The width of the output signal is optional and if not specified, is inferred from the width of the conditions.

## Related Issue(s)

Fix #304

## Testing

Added 5 new testcases which test the expression and condition match as well as width mismatch exceptions.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, API docs
