### PR TITLE
Fix bug where FSM may cause inferred latch

### DIFF
--- a/lib/src/state_machine.dart
+++ b/lib/src/state_machine.dart
@@ -8,10 +8,10 @@
 /// Author: Shubham Kumar <shubham.kumar@intel.com>
 ///
 
-import 'dart:collection';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
 
 /// Simple class for FSM [StateMachine].
@@ -91,7 +91,20 @@ class StateMachine<StateIdentifier> {
                   ]))
               .toList(growable: false),
           conditionalType: ConditionalType.unique,
-          defaultItem: [nextState < currentState])
+          defaultItem: [
+            nextState < currentState,
+
+            // zero out all other receivers from state actions...
+            // even though out-of-state is unreachable,
+            // we don't want any inferred latches
+            ..._states
+                .map((state) => state.actions)
+                .flattened
+                .map((conditional) => conditional.receivers)
+                .flattened
+                .toSet()
+                .map((receiver) => receiver < 0)
+          ])
     ]);
 
     Sequential(clk, [

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -34,7 +34,9 @@ class TestModule extends Module {
       }, actions: [
         b < c,
       ]),
-      State<MyStates>(MyStates.state2, events: {}, actions: []),
+      State<MyStates>(MyStates.state2, events: {}, actions: [
+        b < 1,
+      ]),
       State<MyStates>(MyStates.state3, events: {}, actions: [
         b < ~c,
       ]),
@@ -119,6 +121,15 @@ void main() {
   });
 
   setUpAll(() => Directory(_tmpDir).createSync(recursive: true));
+
+  test('zero-out receivers in default case', () async {
+    final pipem = TestModule(Logic(), Logic(), Logic());
+    await pipem.build();
+
+    final sv = pipem.generateSynth();
+
+    expect(sv, contains("b = 1'h0;"));
+  });
 
   group('simcompare', () {
     test('simple fsm', () async {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Even though the FSM should never allow the case statement to reach an invalid state, synthesis tools may still infer a latch for receivers in the actions which are not assigned in the `default` case.  This PR fixes this issue by zeroing out all receivers mentioned in any actions in the `default`, even though it should never happen.

## Related Issue(s)

N/A

## Testing

Added a test that the zero-out happens.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
