### PR TITLE
Fix bugs where SSA could potentially generate inferred latches

### DIFF
--- a/.github/configs/mlc_config.json
+++ b/.github/configs/mlc_config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://www.cadence.com/en_US/home/tools/digital-design-and-signoff/synthesis/stratus-high-level-synthesis.html$"
+    },
+    {
+      "pattern":"^https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html$"
     }
   ]
 }

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Lint Markdown files
-        uses: DavidAnson/markdownlint-cli2-action@v9
+        uses: DavidAnson/markdownlint-cli2-action@v11
         with:
           globs: '**/*.md'
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-CommunityCodeofConduct@intel.com.
+<CommunityCodeofConduct@intel.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sometimes an intermediate SSA signal in a `Combinational` that generates phi signals could be undriven in other clauses (`If` and `Case`).  This is functionally fine since those intermediate signals are unused in the other clauses, however synthesis tools may infer a latch on them.  This also means SV linting tools will flag errors, since the synthesis tool may infer a latch.

This PR sets these unimportant intermediate signals to 0 in unused cases.  It would be better if synthesis tools could be told to treat something as a dont-care instead of 0, but this is the best solution for now without that.

Also, this fixes a bug in `Case` where SSA could be missing a default item, which breaks the phi logic.
Also, this fixes a bug in `If` where an extra empty "else" clause is generated sometimes in SSA.

## Related Issue(s)

N/A

## Testing

Added new tests to check for inferred latches (indicated by X's in certain situations in the ROHD simulations since signals are undriven).

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, only if someone was depending on the bugs.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
