### PR TITLE
Reset for flops and try ports

### DIFF
--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -48,6 +48,9 @@ class Interface<TagType> {
       ? _ports[name]!
       : throw Exception('Port name "$name" not found on this interface.');
 
+  /// Provides the [port] named [name] if it exists, otherwise `null`.
+  Logic? tryPort(String name) => _ports[name];
+
   /// Connects [module]'s inputs and outputs up to [srcInterface] and this
   /// [Interface].
   ///

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -91,12 +91,18 @@ abstract class Module {
   /// Accesses the [Logic] associated with this [Module]s input port
   /// named [name].
   ///
-  /// Logic within this [Module] should consume this signal.
+  /// Only logic within this [Module] should consume this signal.
   @protected
   Logic input(String name) => _inputs.containsKey(name)
       ? _inputs[name]!
       : throw Exception(
           'Input name "$name" not found as an input to this Module.');
+
+  /// Provides the [input] named [name] if it exists, otherwise `null`.
+  ///
+  /// Only logic within this [Module] should consume this signal.
+  @protected
+  Logic? tryInput(String name) => _inputs[name];
 
   /// Accesses the [Logic] associated with this [Module]s output port
   /// named [name].
@@ -107,6 +113,9 @@ abstract class Module {
       ? _outputs[name]!
       : throw Exception(
           'Output name "$name" not found as an output of this Module.');
+
+  /// Provides the [output] named [name] if it exists, otherwise `null`.
+  Logic? tryOutput(String name) => _outputs[name];
 
   /// Returns true iff [net] is the same [Logic] as the input port of this
   /// [Module] with the same name.

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1563,7 +1563,7 @@ Logic flop(
   Logic d, {
   Logic? en,
   Logic? reset,
-  dynamic resetValue = 0,
+  dynamic resetValue,
 }) =>
     FlipFlop(
       clk,

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -256,6 +256,8 @@ abstract class LogicValue implements Comparable<LogicValue> {
           return LogicValue.ofIterable(val).zeroExtend(width);
         }
       }
+    } else if (val == null) {
+      throw LogicValueConstructionException('Cannot construct from `null`.');
     } else {
       throw LogicValueConstructionException('Unrecognized value type "$val" - '
           'Unknown type ${val.runtimeType}'

--- a/test/flop_test.dart
+++ b/test/flop_test.dart
@@ -12,24 +12,26 @@ import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
 class FlopTestModule extends Module {
-  Logic get a => input('a');
-  Logic get y => output('y');
-  Logic get en => input('en');
-
-  FlopTestModule(Logic a, {Logic? en}) : super(name: 'floptestmodule') {
+  FlopTestModule(Logic a, {Logic? en, Logic? reset, dynamic resetValue})
+      : super(name: 'floptestmodule') {
     a = addInput('a', a, width: a.width);
+
     if (en != null) {
-      en = addInput('en', en, width: en.width);
+      en = addInput('en', en);
+    }
+
+    if (reset != null) {
+      reset = addInput('reset', reset);
+    }
+
+    if (resetValue != null && resetValue is Logic) {
+      resetValue = addInput('resetValue', resetValue, width: a.width);
     }
 
     final y = addOutput('y', width: a.width);
     final clk = SimpleClockGenerator(10).clk;
 
-    if (en != null) {
-      y <= flop(clk, a, en: en);
-    } else {
-      y <= flop(clk, a);
-    }
+    y <= flop(clk, a, en: en, reset: reset, resetValue: resetValue);
   }
 }
 
@@ -50,9 +52,7 @@ void main() {
         Vector({'a': 0}, {'y': 0}),
       ];
       await SimCompare.checkFunctionalVector(ftm, vectors);
-      final simResult = SimCompare.iverilogVector(ftm, vectors);
-      expect(simResult, equals(true));
-      // expect(true, true);
+      SimCompare.checkIverilogVector(ftm, vectors);
     });
 
     test('flop bit with enable', () async {
@@ -73,9 +73,7 @@ void main() {
         Vector({'a': 1, 'en': 0}, {'y': 1}),
       ];
       await SimCompare.checkFunctionalVector(ftm, vectors);
-      final simResult = SimCompare.iverilogVector(ftm, vectors);
-      expect(simResult, equals(true));
-      // expect(true, true);
+      SimCompare.checkIverilogVector(ftm, vectors);
     });
 
     test('flop bus', () async {
@@ -89,8 +87,7 @@ void main() {
         Vector({'a': 0x1}, {'y': 0x55}),
       ];
       await SimCompare.checkFunctionalVector(ftm, vectors);
-      final simResult = SimCompare.iverilogVector(ftm, vectors);
-      expect(simResult, equals(true));
+      SimCompare.checkIverilogVector(ftm, vectors);
     });
 
     test('flop bus with enable', () async {
@@ -113,8 +110,90 @@ void main() {
         Vector({'a': 0x1, 'en': 1}, {'y': 0x1}),
       ];
       await SimCompare.checkFunctionalVector(ftm, vectors);
-      final simResult = SimCompare.iverilogVector(ftm, vectors);
-      expect(simResult, equals(true));
+      SimCompare.checkIverilogVector(ftm, vectors);
+    });
+
+    test('flop bus reset, no reset value', () async {
+      final ftm = FlopTestModule(Logic(width: 8), reset: Logic());
+      await ftm.build();
+      final vectors = [
+        Vector({'reset': 1}, {}),
+        Vector({'reset': 0, 'a': 0xa5}, {'y': 0}),
+        Vector({'a': 0xff}, {'y': 0xa5}),
+        Vector({}, {'y': 0xff}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      SimCompare.checkIverilogVector(ftm, vectors);
+    });
+
+    test('flop bus reset, const reset value', () async {
+      final ftm = FlopTestModule(
+        Logic(width: 8),
+        reset: Logic(),
+        resetValue: 3,
+      );
+      await ftm.build();
+      final vectors = [
+        Vector({'reset': 1}, {}),
+        Vector({'reset': 0, 'a': 0xa5}, {'y': 3}),
+        Vector({'a': 0xff}, {'y': 0xa5}),
+        Vector({}, {'y': 0xff}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      SimCompare.checkIverilogVector(ftm, vectors);
+    });
+
+    test('flop bus reset, logic reset value', () async {
+      final ftm = FlopTestModule(
+        Logic(width: 8),
+        reset: Logic(),
+        resetValue: Logic(width: 8),
+      );
+      await ftm.build();
+      final vectors = [
+        Vector({'reset': 1, 'resetValue': 5}, {}),
+        Vector({'reset': 0, 'a': 0xa5}, {'y': 5}),
+        Vector({'a': 0xff}, {'y': 0xa5}),
+        Vector({}, {'y': 0xff}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      SimCompare.checkIverilogVector(ftm, vectors);
+    });
+
+    test('flop bus no reset, const reset value', () async {
+      final ftm = FlopTestModule(
+        Logic(width: 8),
+        resetValue: 9,
+      );
+      await ftm.build();
+      final vectors = [
+        Vector({}, {}),
+        Vector({'a': 0xa5}, {}),
+        Vector({'a': 0xff}, {'y': 0xa5}),
+        Vector({}, {'y': 0xff}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      SimCompare.checkIverilogVector(ftm, vectors);
+    });
+
+    test('flop bus, enable, reset, const reset value', () async {
+      final ftm = FlopTestModule(
+        Logic(width: 8),
+        en: Logic(),
+        reset: Logic(),
+        resetValue: 12,
+      );
+      await ftm.build();
+      final vectors = [
+        Vector({'reset': 1, 'en': 0}, {}),
+        Vector({'reset': 0, 'a': 0xa5}, {'y': 12}),
+        Vector({}, {'y': 12}),
+        Vector({'en': 1}, {'y': 12}),
+        Vector({'a': 0xff}, {'y': 0xa5}),
+        Vector({}, {'y': 0xff}),
+      ];
+      await SimCompare.checkFunctionalVector(ftm, vectors);
+      SimCompare.checkIverilogVector(ftm, vectors);
     });
   });
 }

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -68,12 +68,12 @@ void main() {
   });
 
   group('maybe port', () {
-    test('tryInput, exists', () {
+    test('tryPort, exists', () {
       final intf = MaybePortInterface(includePort: true);
       expect(intf.p, isNotNull);
     });
 
-    test('tryInput, doesnt exist', () {
+    test('tryPort, doesnt exist', () {
       final intf = MaybePortInterface(includePort: false);
       expect(intf.p, null);
     });

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -37,6 +37,16 @@ class UncleanPortInterface extends Interface<MyDirection> {
   }
 }
 
+class MaybePortInterface extends Interface<MyDirection> {
+  Logic? get p => tryPort('p');
+
+  MaybePortInterface({required bool includePort}) {
+    if (includePort) {
+      setPorts([Port('p')], {MyDirection.dir1});
+    }
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -55,5 +65,17 @@ void main() {
     expect(() async {
       UncleanPortInterface();
     }, throwsException);
+  });
+
+  group('maybe port', () {
+    test('tryInput, exists', () {
+      final intf = MaybePortInterface(includePort: true);
+      expect(intf.p, isNotNull);
+    });
+
+    test('tryInput, doesnt exist', () {
+      final intf = MaybePortInterface(includePort: false);
+      expect(intf.p, null);
+    });
   });
 }

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// module_test.dart
+// Unit tests for Module APIs
+//
+// 2023 September 11
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class ModuleWithMaybePorts extends Module {
+  Logic? get i => tryInput('i');
+  Logic? get o => tryOutput('o');
+  ModuleWithMaybePorts({required bool addIn, required bool addOut}) {
+    if (addIn) {
+      addInput('i', Logic());
+    }
+    if (addOut) {
+      addOutput('o');
+    }
+  }
+}
+
+void main() {
+  test('tryInput, exists', () {
+    final mod = ModuleWithMaybePorts(addIn: true, addOut: false);
+    expect(mod.i, isNotNull);
+  });
+
+  test('tryInput, doesnt exist', () {
+    final mod = ModuleWithMaybePorts(addIn: false, addOut: false);
+    expect(mod.i, null);
+  });
+
+  test('tryOutput, exists', () {
+    final mod = ModuleWithMaybePorts(addIn: false, addOut: true);
+    expect(mod.o, isNotNull);
+  });
+
+  test('tryOutput, doesnt exist', () {
+    final mod = ModuleWithMaybePorts(addIn: false, addOut: false);
+    expect(mod.o, null);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR has a couple things in one:
- "try" ports, where it will return `null` if a port doesn't exist (on a `Module` or an `Interface`)
- Reset (and reset value) on `flop` and `FlipFlop`.

## Related Issue(s)

Fix #69
Fix #405

## Testing

Added tests for new functionality

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Updated API docs
