### PR TITLE
Mark inputs as protected in `Module`

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -57,6 +57,7 @@ abstract class Module {
 
   /// A map from input port names to this [Module] to corresponding [Logic]
   /// signals.
+  @protected
   Map<String, Logic> get inputs => UnmodifiableMapView<String, Logic>(_inputs);
 
   /// A map from output port names to this [Module] to corresponding [Logic]

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -730,6 +730,7 @@ abstract class Conditional {
         toParse.add(toParse[i].srcConnection!);
       }
       if (toParse[i].isOutput) {
+        // ignore: invalid_use_of_protected_member
         toParse.addAll(toParse[i].parentModule!.inputs.values);
       }
       if (toParse[i] is _SsaLogic &&

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -48,12 +48,16 @@ class SystemVerilogSynthesizer extends Synthesizer {
 
     //non-custom needs more details
     final connections = <String>[];
+
+    // ignore: invalid_use_of_protected_member
     module.inputs.forEach((signalName, logic) {
       connections.add('.$signalName(${inputs[signalName]})');
     });
+
     module.outputs.forEach((signalName, logic) {
       connections.add('.$signalName(${outputs[signalName]})');
     });
+
     final connectionsStr = connections.join(',');
     var parameterString = '';
     if (parameters != null) {
@@ -346,6 +350,7 @@ class _SynthModuleDefinition {
 
   _SynthModuleDefinition(this.module) {
     _synthInstantiationNameUniquifier = Uniquifier(
+        // ignore: invalid_use_of_protected_member
         reservedNames: {...module.inputs.keys, ...module.outputs.keys});
 
     // start by traversing output signals
@@ -356,6 +361,7 @@ class _SynthModuleDefinition {
     }
 
     // make sure disconnected inputs are included
+    // ignore: invalid_use_of_protected_member
     for (final input in module.inputs.values) {
       inputs.add(_getSynthLogic(input, true)!);
     }
@@ -364,6 +370,7 @@ class _SynthModuleDefinition {
     for (final subModule in module.subModules) {
       _getSynthSubModuleInstantiation(subModule);
       logicsToTraverse
+        // ignore: invalid_use_of_protected_member
         ..addAll(subModule.inputs.values)
         ..addAll(subModule.outputs.values);
     }
@@ -412,6 +419,7 @@ class _SynthModuleDefinition {
             _getSynthSubModuleInstantiation(subModule);
         subModuleInstantiation.outputMapping[synthReceiver] = receiver;
 
+        // ignore: invalid_use_of_protected_member
         logicsToTraverse.addAll(subModule.inputs.values);
       } else if (driver != null) {
         if (!module.isInput(receiver)) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Like other `input`s in `Module`, the `inputs` API should also be marked `@protected` to help prevent accidental usage of input pins outside of its containing `Module`.

## Related Issue(s)

N/A

## Testing

Just static analysis checks

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Improper usage may now get some static analysis warnings

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
