### PR TITLE
Update to use new runners in github actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   run-checks:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run Checks
     permissions: {}
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: intel-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: write # required for "JamesIves/github-pages-deploy-action"
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: intel-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Checks
     permissions: {}
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: write # required for "JamesIves/github-pages-deploy-action"
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Updating to use a new type of self-hosted runner for GitHub actions.  This should help with the slow pick-up of jobs from the GitHub-hosted runners.

This is an experiment until it's proven out sufficiently.

## Related Issue(s)

N/A

## Testing

This is it!

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
