### PR TITLE
Sort ports and internal signals, fix #395

### DIFF
--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -51,11 +51,11 @@ class SystemVerilogSynthesizer extends Synthesizer {
     final connections = <String>[];
 
     // ignore: invalid_use_of_protected_member
-    module.inputs.forEach((signalName, logic) {
+    module.inputs.keys.sorted((a, b) => a.compareTo(b)).forEach((signalName) {
       connections.add('.$signalName(${inputs[signalName]})');
     });
 
-    module.outputs.forEach((signalName, logic) {
+    module.outputs.keys.sorted((a, b) => a.compareTo(b)).forEach((signalName) {
       connections.add('.$signalName(${outputs[signalName]})');
     });
 

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -7,6 +7,7 @@
 // 2021 August 26
 // Author: Max Korbel <max.korbel@intel.com>
 
+import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/collections/traverseable_collection.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
@@ -152,28 +153,28 @@ class _SystemVerilogSynthesisResult extends SynthesisResult {
 
   List<String> _verilogInputs() {
     final declarations = _synthModuleDefinition.inputs
+        .sorted((a, b) => a.name.compareTo(b.name))
         .map((sig) => 'input logic ${sig.definitionName()}')
-        .toList(growable: false)
-      ..sort();
+        .toList(growable: false);
     return declarations;
   }
 
   List<String> _verilogOutputs() {
     final declarations = _synthModuleDefinition.outputs
+        .sorted((a, b) => a.name.compareTo(b.name))
         .map((sig) => 'output logic ${sig.definitionName()}')
-        .toList(growable: false)
-      ..sort();
+        .toList(growable: false);
     return declarations;
   }
 
   String _verilogInternalNets() {
     final declarations = <String>[];
-    for (final sig in _synthModuleDefinition.internalNets) {
+    for (final sig in _synthModuleDefinition.internalNets
+        .sorted((a, b) => a.name.compareTo(b.name))) {
       if (sig.needsDeclaration) {
         declarations.add('logic ${sig.definitionName()};');
       }
     }
-    declarations.sort();
     return declarations.join('\n');
   }
 

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -153,14 +153,16 @@ class _SystemVerilogSynthesisResult extends SynthesisResult {
   List<String> _verilogInputs() {
     final declarations = _synthModuleDefinition.inputs
         .map((sig) => 'input logic ${sig.definitionName()}')
-        .toList(growable: false);
+        .toList(growable: false)
+      ..sort();
     return declarations;
   }
 
   List<String> _verilogOutputs() {
     final declarations = _synthModuleDefinition.outputs
         .map((sig) => 'output logic ${sig.definitionName()}')
-        .toList(growable: false);
+        .toList(growable: false)
+      ..sort();
     return declarations;
   }
 
@@ -171,6 +173,7 @@ class _SystemVerilogSynthesisResult extends SynthesisResult {
         declarations.add('logic ${sig.definitionName()};');
       }
     }
+    declarations.sort();
     return declarations.join('\n');
   }
 

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// sv_gen_test.dart
+// Tests for SystemVerilog generation.
+//
+// 2023 October 4
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:collection/collection.dart';
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class AlphabeticalModule extends Module {
+  AlphabeticalModule() {
+    final l = addInput('l', Logic());
+    final a = addInput('a', Logic());
+    final w = addInput('w', Logic());
+
+    final o = Logic(name: 'o');
+    final c = Logic(name: 'c');
+    final y = Logic(name: 'y');
+
+    c <= l & w;
+    o <= a | l;
+    y <= w ^ l;
+
+    addOutput('m');
+    addOutput('x') <= c + o + y;
+    addOutput('b');
+  }
+}
+
+void main() {
+  test('input, output, and internal signals are sorted', () async {
+    final mod = AlphabeticalModule();
+    await mod.build();
+    final sv = mod.generateSynth();
+
+    void checkSignalDeclarationOrder(List<String> signalNames) {
+      final expected = signalNames.map((e) => 'logic $e');
+      final indices = expected.map(sv.indexOf);
+      expect(indices.isSorted((a, b) => a.compareTo(b)), isTrue,
+          reason: 'Expected order $expected, but indices were $indices');
+    }
+
+    checkSignalDeclarationOrder(['a', 'l', 'w']);
+    checkSignalDeclarationOrder(['b', 'm', 'x']);
+    checkSignalDeclarationOrder(['c', 'o', 'y']);
+  });
+}

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -31,21 +31,53 @@ class AlphabeticalModule extends Module {
   }
 }
 
+class AlphabeticalWidthsModule extends Module {
+  AlphabeticalWidthsModule() {
+    final l = addInput('l', Logic(width: 4), width: 4);
+    final a = addInput('a', Logic(width: 3), width: 3);
+    final w = addInput('w', Logic(width: 2), width: 2);
+
+    final o = Logic(name: 'o', width: 4);
+    final c = Logic(name: 'c', width: 3);
+    final y = Logic(name: 'y', width: 2);
+
+    c <= a & a;
+    o <= l | l;
+    y <= w ^ w;
+
+    addOutput('m', width: 4) <= o + o;
+    addOutput('x', width: 2) <= y + y;
+    addOutput('b', width: 3) <= c + c;
+  }
+}
+
 void main() {
+  void checkSignalDeclarationOrder(String sv, List<String> signalNames) {
+    final expected =
+        signalNames.map((e) => RegExp(r'logic\s*\[?[:\d\s]*]?\s*' + e));
+    final indices = expected.map(sv.indexOf);
+    expect(indices.isSorted((a, b) => a.compareTo(b)), isTrue,
+        reason: 'Expected order $signalNames, but indices were $indices');
+  }
+
   test('input, output, and internal signals are sorted', () async {
     final mod = AlphabeticalModule();
     await mod.build();
     final sv = mod.generateSynth();
 
-    void checkSignalDeclarationOrder(List<String> signalNames) {
-      final expected = signalNames.map((e) => 'logic $e');
-      final indices = expected.map(sv.indexOf);
-      expect(indices.isSorted((a, b) => a.compareTo(b)), isTrue,
-          reason: 'Expected order $expected, but indices were $indices');
-    }
+    checkSignalDeclarationOrder(sv, ['a', 'l', 'w']);
+    checkSignalDeclarationOrder(sv, ['b', 'm', 'x']);
+    checkSignalDeclarationOrder(sv, ['c', 'o', 'y']);
+  });
 
-    checkSignalDeclarationOrder(['a', 'l', 'w']);
-    checkSignalDeclarationOrder(['b', 'm', 'x']);
-    checkSignalDeclarationOrder(['c', 'o', 'y']);
+  test('input, output, and internal signals are sorted (different widths)',
+      () async {
+    final mod = AlphabeticalWidthsModule();
+    await mod.build();
+    final sv = mod.generateSynth();
+
+    checkSignalDeclarationOrder(sv, ['a', 'l', 'w']);
+    checkSignalDeclarationOrder(sv, ['b', 'm', 'x']);
+    checkSignalDeclarationOrder(sv, ['c', 'o', 'y']);
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sort ports and internal signal declarations alphabetically in generated SystemVerilog.

## Related Issue(s)

Fix #395

## Testing

Added new test that checks it is sorted (confirmed failure without fix).

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

SV generated will change, but will still be functionally equivalent.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
