### PR TITLE
Fix bug where generated SV has lint issues with plus and shift-left due to SV width expansion

### DIFF
--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -141,7 +141,10 @@ abstract class _TwoInputBitwiseGate extends Module with InlineSystemVerilog {
   late final Logic _in1 = input(_in1Name);
 
   /// The output of this gate.
-  late final Logic out = output(_outName);
+  late final Logic out = _outputSvWidthExpansion
+      // this is sub-optimal, but it's tricky to make special SV for it
+      ? BusSubset(output(_outName), 0, width - 1).subset
+      : output(_outName);
 
   /// The output of this gate.
   ///
@@ -155,6 +158,13 @@ abstract class _TwoInputBitwiseGate extends Module with InlineSystemVerilog {
   /// The `String` representing the operation to perform in generated code.
   final String _opStr;
 
+  /// The width of the inputs and outputs for this operation.
+  final int width;
+
+  /// If true, then the output generated SystemVerilog may have a larger width
+  /// than the inputs, which should be considered in generated verilog.
+  final bool _outputSvWidthExpansion;
+
   /// Constructs a two-input bitwise gate for an abitrary custom functional
   /// implementation.
   ///
@@ -163,22 +173,23 @@ abstract class _TwoInputBitwiseGate extends Module with InlineSystemVerilog {
   /// String between the two input signal names (e.g. if [_opStr] was "&",
   /// generated SystemVerilog may look like "a & b").
   _TwoInputBitwiseGate(this._op, this._opStr, Logic in0, dynamic in1,
-      {String name = 'gate2'})
-      : super(name: name) {
+      {String name = 'gate2', bool outputSvWidthExpansion = false})
+      : width = in0.width,
+        _outputSvWidthExpansion = outputSvWidthExpansion,
+        super(name: name) {
     if (in1 is Logic && in0.width != in1.width) {
-      throw Exception('Input widths must match,'
-          ' but found $in0 and $in1 with different widths.');
+      throw PortWidthMismatchException.equalWidth(in0, in1);
     }
 
-    final in1Logic = in1 is Logic ? in1 : Const(in1, width: in0.width);
+    final in1Logic = in1 is Logic ? in1 : Const(in1, width: width);
 
     _in0Name = Module.unpreferredName('in0_${in0.name}');
     _in1Name = Module.unpreferredName('in1_${in1Logic.name}');
     _outName = Module.unpreferredName('${in0.name}_${name}_${in1Logic.name}');
 
-    addInput(_in0Name, in0, width: in0.width);
-    addInput(_in1Name, in1Logic, width: in1Logic.width);
-    addOutput(_outName, width: in0.width);
+    addInput(_in0Name, in0, width: width);
+    addInput(_in1Name, in1Logic, width: width);
+    addOutput(_outName, width: width);
 
     _setup();
   }
@@ -327,7 +338,10 @@ class _ShiftGate extends Module with InlineSystemVerilog {
   late final Logic _shiftAmount = input(_shiftAmountName);
 
   /// The output of this gate.
-  late final Logic out = output(_outName);
+  late final Logic out = _outputSvWidthExpansion
+      // this is sub-optimal, but it's tricky to make special SV for it
+      ? BusSubset(output(_outName), 0, width - 1).subset
+      : output(_outName);
 
   /// The functional operation to perform for this gate.
   final LogicValue Function(LogicValue in_, LogicValue shiftAmount) _op;
@@ -338,6 +352,13 @@ class _ShiftGate extends Module with InlineSystemVerilog {
   /// Whether or not this gate operates on a signed number.
   final bool signed;
 
+  /// The width of the output for this operation.
+  final int width;
+
+  /// If true, then the output generated SystemVerilog may have a larger width
+  /// than the inputs, which should be considered in generated verilog.
+  final bool _outputSvWidthExpansion;
+
   /// Constructs a two-input shift gate for an abitrary custom functional
   /// implementation.
   ///
@@ -346,8 +367,12 @@ class _ShiftGate extends Module with InlineSystemVerilog {
   /// String between the two input signal names (e.g. if [_opStr] was ">>",
   /// generated SystemVerilog may look like "a >> b").
   _ShiftGate(this._op, this._opStr, Logic in_, dynamic shiftAmount,
-      {String name = 'gate2', this.signed = false})
-      : super(name: name) {
+      {String name = 'gate2',
+      this.signed = false,
+      bool outputSvWidthExpansion = false})
+      : width = in_.width,
+        _outputSvWidthExpansion = outputSvWidthExpansion,
+        super(name: name) {
     final shiftAmountLogic = shiftAmount is Logic
         ? shiftAmount
         : Const(LogicValue.ofInferWidth(shiftAmount));
@@ -360,7 +385,7 @@ class _ShiftGate extends Module with InlineSystemVerilog {
 
     addInput(_inName, in_, width: in_.width);
     addInput(_shiftAmountName, shiftAmountLogic, width: shiftAmountLogic.width);
-    addOutput(_outName, width: in_.width);
+    addOutput(_outName, width: width);
 
     _setup();
   }
@@ -437,7 +462,8 @@ class Add extends _TwoInputBitwiseGate {
   ///
   /// [in1] can be either a [Logic] or [int].
   Add(Logic in0, dynamic in1, {String name = 'add'})
-      : super((a, b) => a + b, '+', in0, in1, name: name);
+      : super((a, b) => a + b, '+', in0, in1,
+            name: name, outputSvWidthExpansion: true);
 }
 
 /// A two-input subtraction module.
@@ -574,7 +600,8 @@ class ARShift extends _ShiftGate {
 class LShift extends _ShiftGate {
   /// Calculates the value of [in_] shifted left by [shiftAmount].
   LShift(Logic in_, dynamic shiftAmount, {String name = 'lshift'})
-      : super((a, shamt) => a << shamt, '<<', in_, shiftAmount, name: name);
+      : super((a, shamt) => a << shamt, '<<', in_, shiftAmount,
+            name: name, outputSvWidthExpansion: true);
 }
 
 /// Performs a multiplexer/ternary operation.

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -322,23 +322,15 @@ class Logic {
   Logic pow(dynamic exponent) => Power(this, exponent).out;
 
   /// Addition.
-  ///
-  /// WARNING: Signed math is not fully tested.
   Logic operator +(dynamic other) => Add(this, other).out;
 
   /// Subtraction.
-  ///
-  /// WARNING: Signed math is not fully tested.
   Logic operator -(dynamic other) => Subtract(this, other).out;
 
   /// Multiplication.
-  ///
-  /// WARNING: Signed math is not fully tested.
   Logic operator *(dynamic other) => Multiply(this, other).out;
 
   /// Division.
-  ///
-  /// WARNING: Signed math is not fully tested.
   Logic operator /(dynamic other) => Divide(this, other).out;
 
   /// Modulo operation.

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -737,6 +737,11 @@ abstract class LogicValue implements Comparable<LogicValue> {
     final modifiedEndIndex =
         IndexUtilities.wrapIndex(endIndex, width, allowWidth: true);
 
+    // if we're getting the whole thing, just return itself immediately
+    if (modifiedStartIndex == 0 && modifiedEndIndex == width) {
+      return this;
+    }
+
     IndexUtilities.validateRange(modifiedStartIndex, modifiedEndIndex);
 
     return _getRange(modifiedStartIndex, modifiedEndIndex);

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -73,13 +73,32 @@ void main() {
     await Simulator.reset();
   });
 
+  test('sv expansion does slices', () async {
+    final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
+    await gtm.build();
+
+    final sv = gtm.generateSynth();
+    final lines = sv.split('\n');
+
+    final bannedLines = [
+      // should never assign directly off a +
+      RegExp(r'plus.*\+'),
+
+      // should never assign directly off a <<
+      RegExp(r'sl.*\<<'),
+    ];
+
+    for (final bannedLine in bannedLines) {
+      expect(lines.where(bannedLine.hasMatch), isEmpty);
+    }
+  });
+
   group('simcompare', () {
     Future<void> runMathVectors(List<Vector> vectors) async {
       final gtm = MathTestModule(Logic(width: 8), Logic(width: 8));
       await gtm.build();
       await SimCompare.checkFunctionalVector(gtm, vectors);
-      final simResult = SimCompare.iverilogVector(gtm, vectors);
-      expect(simResult, equals(true));
+      SimCompare.checkIverilogVector(gtm, vectors);
     }
 
     test('power', () async {
@@ -105,8 +124,6 @@ void main() {
         Vector({'a': 1, 'b': 1}, {'a_plus_b': 2}),
         Vector({'a': 6, 'b': 7}, {'a_plus_b': 13}),
         Vector({'a': 6}, {'a_plus_const': 11}),
-        // Vector({'a': -6, 'b': 7}, {'a_plus_b': 1}),
-        // Vector({'a': -6, 'b': 2}, {'a_plus_b': -4}),
       ]);
     });
 

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -80,16 +80,21 @@ void main() {
     final sv = gtm.generateSynth();
     final lines = sv.split('\n');
 
-    final bannedLines = [
-      // should never assign directly off a +
-      RegExp(r'plus.*\+'),
+    // should never assign directly off a +
+    expect(lines.where(RegExp(r'plus.*\+').hasMatch), isEmpty);
 
-      // should never assign directly off a <<
-      RegExp(r'sl.*\<<'),
-    ];
+    // ensure the width of intermediate signals appropriate for add
+    for (final line in lines) {
+      if (RegExp('logic.*a_add').hasMatch(line)) {
+        expect(line, contains('8:0'));
+      }
+    }
 
-    for (final bannedLine in bannedLines) {
-      expect(lines.where(bannedLine.hasMatch), isEmpty);
+    // ensure we never lshift by a constant directly
+    for (final line in lines) {
+      if (RegExp('assign.*a_lshift.*const.*=').hasMatch(line)) {
+        expect(line, contains('shiftAmount'));
+      }
     }
   });
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Some operations (`+`, `<<`) can cause the output of the operation to be larger than the inputs.  In ROHD, the output width equals the input width (strictly).  The generated SV properly did truncation, but in a way that could flag lint errors due to signal width mismatches.

This change makes it so that we explicitly slice the relevant range rather than rely on SV behavior for signal width mismatch, thus removing lint issues.

## Related Issue(s)

Fix #298 

## Testing

Added a new test that ensures `+` and `<<` use a slice operation.  Don't have an open-source lint tool available for the test suite, but will test it separately to ensure that the fix works properly.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
