### PR TITLE
Allow constant Z driving to show up in SV without error

### DIFF
--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -854,8 +854,6 @@ class _SynthLogic {
 
   /// Finds the best name from the collection of [Logic]s.
   String _findName(Uniquifier uniquifier) {
-    assert(!isFloatingConstant, 'Should not be using floating constants.');
-
     // check for const
     if (_constLogic != null) {
       if (!_constNameDisallowed) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sometimes one may wish to explicitly drive a `Z` (floating) on a signal and have that show up in the generated SystemVerilog (e.g. testbench or behavioral code).  There was an assertion in the SV generation to prevent an accidental `z` from showing up on a floating signal (left undriven).  However, if someone explicitly connects a signal to `Const('z')` (for example) in a way that can't be collapsed away (e.g. in a `mux`), we should just generate with the `Z` in there rather than fail with an assertion.  This does not guarantee that every `Z` in the ROHD side will show up as a `Z` in the SV side, it just enables explicit floating.

## Related Issue(s)

N/A

## Testing

Added a couple tests reproducing issues as reported by a user

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
