### PR TITLE
Fix defaultNextState diagram generation in FSM

### DIFF
--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -179,8 +179,19 @@ class FiniteStateMachine<StateIdentifier> {
 
     for (final state in _states) {
       for (final entry in state.events.entries) {
-        figure.addTransitions(state.identifier.toString(),
-            entry.value.toString(), entry.key.name);
+        figure.addTransitions(
+          state.identifier.toString(),
+          entry.value.toString(),
+          entry.key.name,
+        );
+      }
+
+      if (state.defaultNextState != state.identifier) {
+        figure.addTransitions(
+          state.identifier.toString(),
+          state.defaultNextState.toString(),
+          '(default)',
+        );
       }
     }
     figure.writeToFile();

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -55,7 +55,7 @@ class TestModule extends Module {
 }
 
 class DefaultStateFsmMod extends Module {
-  late final FiniteStateMachine _fsm;
+  late final FiniteStateMachine<MyStates> _fsm;
   DefaultStateFsmMod(Logic reset) {
     reset = addInput('reset', reset);
     final clk = SimpleClockGenerator(10).clk;

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -263,18 +263,18 @@ void main() {
       await SimCompare.checkFunctionalVector(pipem, vectors);
       SimCompare.checkIverilogVector(pipem, vectors);
 
-      const fsmPath = '$_tmpDir/default_next_state_fsm.md';
-      pipem._fsm.generateDiagram(outputPath: fsmPath);
-
       if (!kIsWeb) {
+        const fsmPath = '$_tmpDir/default_next_state_fsm.md';
+        pipem._fsm.generateDiagram(outputPath: fsmPath);
+
         final mermaid = File(fsmPath).readAsStringSync();
         expect(mermaid, contains('state2'));
         expect(mermaid, contains('state3'));
         expect(mermaid, contains('state4'));
         expect(mermaid, contains('(default)'));
-      }
 
-      verifyMermaidStateDiagram(fsmPath);
+        verifyMermaidStateDiagram(fsmPath);
+      }
     });
 
     test('traffic light fsm', () async {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `defaultNextState` was added to `FiniteStateMachine` but did not show up properly in the mermaid diagrams that were generated.  This PR fixes that.

Also, there was insufficient testing around `defaultNextState`, so this adds testing for it.

## Related Issue(s)

N/A

## Testing

Added a new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
