### PR TITLE
Make `Simulator.endSimulation` return a `Future`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ ROHD is under active development.  If you're interested in contributing, have fe
 
 ----------------
 
-Copyright (C) 2021-2023 Intel Corporation  
+Copyright (C) 2021-2024 Intel Corporation  
 SPDX-License-Identifier: BSD-3-Clause

--- a/doc/tutorials/chapter_7/answers/exercise_1_d_flip_flop.dart
+++ b/doc/tutorials/chapter_7/answers/exercise_1_d_flip_flop.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // exercise_1_d_flip_flop.dart

--- a/doc/tutorials/chapter_7/answers/exercise_1_d_flip_flop.dart
+++ b/doc/tutorials/chapter_7/answers/exercise_1_d_flip_flop.dart
@@ -80,6 +80,6 @@ Future<void> main() async {
     printFlop('Third tick, end simulation.');
     expect(dff.q.value.toInt(), equals(0));
 
-    Simulator.endSimulation();
+    await Simulator.simulationEnded;
   });
 }

--- a/doc/tutorials/chapter_7/shift_register.dart
+++ b/doc/tutorials/chapter_7/shift_register.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // shift_register.dart

--- a/doc/tutorials/chapter_7/shift_register.dart
+++ b/doc/tutorials/chapter_7/shift_register.dart
@@ -167,7 +167,5 @@ void main() async {
 
     Simulator.setMaxSimTime(100);
     await Simulator.run();
-
-    Simulator.endSimulation();
   });
 }

--- a/doc/user_guide/_docs/A01-sample-example.md
+++ b/doc/user_guide/_docs/A01-sample-example.md
@@ -2,7 +2,7 @@
 title: "ROHD Example"
 permalink: /docs/sample-example/
 excerpt: "Sample example of using ROHD."
-last_modified_at: 2022-12-21
+last_modified_at: 2024-01-04
 toc: true
 ---
 

--- a/doc/user_guide/_docs/B02-comparisons-with-alternatives.md
+++ b/doc/user_guide/_docs/B02-comparisons-with-alternatives.md
@@ -2,7 +2,7 @@
 title: "Comparison with Alternatives"
 permalink: /docs/comparison-with-alternatives/
 excerpt: "Comparison with Alternatives"
-last_modified_at: 2023-6-19
+last_modified_at: 2024-01-04
 toc: true
 ---
 

--- a/doc/user_guide/_get-started/01-overview.md
+++ b/doc/user_guide/_get-started/01-overview.md
@@ -2,7 +2,7 @@
 title: "Overview"
 permalink: /get-started/overview/
 excerpt: "Overview of ROHD framework."
-last_modified_at: 2022-12-05
+last_modified_at: 2024-01-04
 toc: true
 ---
 

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // finite_state_machine.dart

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -270,8 +270,14 @@ abstract class Simulator {
 
   /// Halts the simulation.  Allows the current [tick] to finish, if there
   /// is one.
-  static void endSimulation() {
+  ///
+  /// The [Future] returned is equivalent to [simulationEnded] and completes
+  /// once the simulation has actually ended.
+  static Future<void> endSimulation() async {
     _simulationEndRequested = true;
+
+    // wait for the simulation to actually end
+    await simulationEnded;
   }
 
   /// Collects an [exception] and associated [stackTrace] triggered

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simulator.dart

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // fsm_test.dart

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simulator_test.dart

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -80,6 +80,17 @@ void main() {
     expect(endOfSimActionExecuted, isTrue);
   });
 
+  test('simulator end simulation waits for simulation to end', () async {
+    final signal = Logic()..put(0);
+    Simulator.setMaxSimTime(1000);
+    Simulator.registerAction(100, () => signal.inject(1));
+    unawaited(Simulator.run());
+    await signal.nextPosedge;
+    await Simulator.endSimulation();
+    expect(Simulator.simulationHasEnded, isTrue);
+    expect(Simulator.time, 100);
+  });
+
   test('simulator waits for async registered actions to complete', () async {
     var registeredActionExecuted = false;
     Simulator.registerAction(100, () => true);

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -43,7 +43,8 @@ void main() {
     const haltTime = 650;
     Simulator.registerAction(100, () => farEnough = true);
     Simulator.registerAction(1000, () => tooFar = true);
-    Simulator.registerAction(haltTime, Simulator.endSimulation);
+    Simulator.registerAction(
+        haltTime, () => unawaited(Simulator.endSimulation()));
     await Simulator.run();
     expect(Simulator.time, equals(haltTime));
     expect(tooFar, equals(false));
@@ -51,7 +52,7 @@ void main() {
   });
 
   test('simulator reset waits for simulation to complete', () async {
-    Simulator.registerAction(100, Simulator.endSimulation);
+    Simulator.registerAction(100, () => unawaited(Simulator.endSimulation()));
     Simulator.registerAction(100, () {
       unawaited(Simulator.reset());
     });


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sometimes when ending a simulation, you may want to wait for it to actually end.  This PR makes `Simulator.endSimulation` return a `Future<void>` which is the same as `Simulator.simulationEnded`, saving some time and lines.

## Related Issue(s)

N/A

## Testing

Added new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Probably not, but you may get a lint warning depending on settings for unawaited futures, or you may get some behavior changes if you have things that behave differently on Futures vs voids.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
