### PR TITLE
Fix bugs in `LogicStructure` instrumentation calls to `packed` and `changed` issues across `Simulator.reset`

### DIFF
--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -281,10 +281,12 @@ class LogicStructure implements Logic {
   Logic? get srcConnection => null;
 
   @override
-  LogicValue get value => packed.value;
+  LogicValue get value =>
+      elements.map((e) => e.value).toList(growable: false).rswizzle();
 
   @override
-  LogicValue? get previousValue => packed.previousValue;
+  LogicValue? get previousValue =>
+      elements.map((e) => e.value).toList(growable: false).rswizzle();
 
   @override
   late final int width = elements.map((e) => e.width).sum;
@@ -396,10 +398,32 @@ class LogicStructure implements Logic {
   @Deprecated('Use `value` instead.'
       '  Check `width` separately to confirm single-bit.')
   @override
+  // Can rely on `packed` here because it must be 1 bit.
   LogicValue get bit => packed.bit;
 
   @override
-  Stream<LogicValueChanged> get changed => packed.changed;
+  late final Stream<LogicValueChanged> changed = _internalPacked.changed;
+
+  /// An internal version of [packed] for instrumentation operations on this
+  /// [LogicStructure].
+  late final _internalPacked = _generateInternalPacked();
+
+  /// Generates and subscribes to be stored lazily into [_internalPacked].
+  Logic _generateInternalPacked() {
+    final internalPacked = Logic(width: width)..put(value);
+
+    void updateInternalPacked() {
+      internalPacked.put(value);
+    }
+
+    for (final element in elements) {
+      element.glitch.listen((args) {
+        updateInternalPacked();
+      });
+    }
+
+    return internalPacked;
+  }
 
   @override
   Logic eq(dynamic other) => packed.eq(other);
@@ -408,7 +432,8 @@ class LogicStructure implements Logic {
   Logic neq(dynamic other) => packed.neq(other);
 
   @override
-  SynchronousEmitter<LogicValueChanged> get glitch => packed.glitch;
+  late final SynchronousEmitter<LogicValueChanged> glitch =
+      _internalPacked.glitch;
 
   @override
   Logic gt(dynamic other) => packed.gt(other);
@@ -424,28 +449,32 @@ class LogicStructure implements Logic {
 
   @Deprecated('Use value.isValid instead.')
   @override
-  bool hasValidValue() => packed.hasValidValue();
+  bool hasValidValue() => value.isValid;
 
   @Deprecated('Use value.isFloating instead.')
   @override
-  bool isFloating() => packed.isFloating();
+  bool isFloating() => value.isFloating;
 
   @override
   Logic isIn(List<dynamic> list) => packed.isIn(list);
 
   @override
+  // Can rely on `packed` here because it must be 1 bit.
   Stream<LogicValueChanged> get negedge => packed.negedge;
 
   @override
+  // Can rely on `packed` here because it must be 1 bit.
   Stream<LogicValueChanged> get posedge => packed.posedge;
 
   @override
-  Future<LogicValueChanged> get nextChanged => packed.nextChanged;
+  Future<LogicValueChanged> get nextChanged => changed.first;
 
   @override
+  // Can rely on `packed` here because it must be 1 bit.
   Future<LogicValueChanged> get nextNegedge => packed.nextNegedge;
 
   @override
+  // Can rely on `packed` here because it must be 1 bit.
   Future<LogicValueChanged> get nextPosedge => packed.nextPosedge;
 
   @override
@@ -460,13 +489,14 @@ class LogicStructure implements Logic {
   @override
   Logic zeroExtend(int newWidth) => packed.zeroExtend(newWidth);
 
+  @Deprecated('Use `value` instead.'
+      '  Check `width` separately to confirm single-bit.')
   @override
-  // ignore: deprecated_member_use_from_same_package
-  BigInt get valueBigInt => packed.valueBigInt;
+  BigInt get valueBigInt => value.toBigInt();
 
+  @Deprecated('Use value.toInt() instead.')
   @override
-  // ignore: deprecated_member_use_from_same_package
-  int get valueInt => packed.valueInt;
+  int get valueInt => value.toInt();
 
   @override
   Logic? get _srcConnection => throw UnsupportedError('Delegated to elements');

--- a/tool/gh_actions/run_tests.sh
+++ b/tool/gh_actions/run_tests.sh
@@ -13,5 +13,6 @@ set -euo pipefail
 
 dart test
 
-# run tests in JS
+# run tests in JS (increase heap size also)
+export NODE_OPTIONS="--max-old-space-size=6144"
 dart test --platform node


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR addresses two categories of issues:
- Non-synthesizable (instrumentation) calls to `LogicStructure`s would call `packed` sometimes, which could result in non-functional generation impact and unexpected `null`s in things like `previousValue`.  https://github.com/intel/rohd/issues/457
- The `changed` mechanism in `Logic` did not work properly across `Simulator.reset` calls, so this PR also fixes these issues.  This was discovered during fixes to the first bullet.

## Related Issue(s)

Fix #457 

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
