### PR TITLE
Make conditional assign a little more optimistic with invalid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.2
 
-- Added APIs for accessing indices of a `List<Logic>` using another `Logic`: `Logic.selectFrom` and `List<Logic>.selectIndex`.
+- Added APIs for accessing indices of a `List<Logic>` using another `Logic`: `Logic.selectFrom` and `List<Logic>.selectIndex` (<https://github.com/intel/rohd/pull/438>).
 - Added/fixed support for compiling ROHD to JavaScript via bug fixes, compile-time arithmetic precision consideration, and testing (<https://github.com/intel/rohd/pull/445>).
 - Added `isZero` to `LogicValue`.
 - Improved `Pipeline` abstraction via bug fixes, better error checking, improved documentation, and new APIs (<https://github.com/intel/rohd/pull/447>).

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -201,13 +201,13 @@ abstract class Module {
     return hierarchyQueue;
   }
 
-  /// Indicates whether this [Module] has had the [build()] method called on it.
+  /// Indicates whether this [Module] has had the [build] method called on it.
   bool get hasBuilt => _hasBuilt;
   bool _hasBuilt = false;
 
   /// Builds the [Module] and all [subModules] within it.
   ///
-  /// It is recommended not to override [build()] nor put logic in [build()]
+  /// It is recommended not to override [build] nor put logic in [build]
   /// unless you have good reason to do so.  Aim to build up relevant logic in
   /// the constructor.
   ///

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -909,7 +909,9 @@ class ConditionalAssign extends Conditional {
 
     final currentValue = driverValue(driver);
     if (!currentValue.isValid) {
-      _receiverOutput.put(LogicValue.x);
+      // Use bitwise & to turn Z's into X's, but keep valid signals as-is.
+      // It's too pessimistic to convert the whole bus to X.
+      _receiverOutput.put(currentValue & currentValue);
     } else {
       _receiverOutput.put(currentValue);
     }

--- a/lib/src/synthesizers/synth_builder.dart
+++ b/lib/src/synthesizers/synth_builder.dart
@@ -9,6 +9,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
 
 /// A generic class which can convert a module into a generated output using
@@ -87,6 +88,9 @@ class SynthBuilder {
       newName = _instanceTypeUniquifier.getUniqueName(
           initialName: newName, reserved: module.reserveDefinitionName);
     }
+
+    assert(Sanitizer.isSanitary(newName),
+        'Module definition names should be sanitary.');
 
     _moduleToInstanceTypeMap[module] = newName;
     return newName;

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -11,6 +11,7 @@ import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/collections/traverseable_collection.dart';
+import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
 
 /// A [Synthesizer] which generates equivalent SystemVerilog as the
@@ -762,7 +763,15 @@ class _SynthLogicArrayElement extends _SynthLogic {
   bool get needsDeclaration => false;
 
   @override
-  String get name => '${parentArray.name}[${logic.arrayIndex!}]';
+  String get name {
+    final n = '${parentArray.name}[${logic.arrayIndex!}]';
+    assert(
+      Sanitizer.isSanitary(
+          n.substring(0, n.contains('[') ? n.indexOf('[') : null)),
+      'Array name should be sanitary, but found $n',
+    );
+    return n;
+  }
 
   /// The element of the [parentArray].
   final Logic logic;
@@ -840,7 +849,13 @@ class _SynthLogic {
   /// The chosen name of this.
   ///
   /// Must call [pickName] before this is accessible.
-  String get name => _name!;
+  String get name {
+    assert(isConstant || Sanitizer.isSanitary(_name!),
+        'Signal names should be sanitary, but found $_name.');
+
+    return _name!;
+  }
+
   String? _name;
 
   /// Picks a [name].

--- a/test/conditionals_test.dart
+++ b/test/conditionals_test.dart
@@ -167,8 +167,8 @@ class ConditionalAssignModule extends Module {
   ConditionalAssignModule(
     Logic a,
   ) : super(name: 'ConditionalAssignModule') {
-    a = addInput('a', a);
-    final c = addOutput('c');
+    a = addInput('a', a, width: a.width);
+    final c = addOutput('c', width: a.width);
     Combinational([c < a]);
   }
 }
@@ -614,6 +614,22 @@ void main() {
         Vector({'a': LogicValue.x}, {'c': LogicValue.x}),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
+      // no SV run here, ROHD converts Z to X
+    });
+
+    test('Conditional assign module with invalid inputs wider than 1 bit',
+        () async {
+      final mod = ConditionalAssignModule(Logic(width: 8));
+      await mod.build();
+      final vectors = [
+        Vector({'a': 0xa5}, {'c': 0xa5}),
+        Vector({'a': LogicValue.z}, {'c': LogicValue.x}),
+        Vector({'a': LogicValue.x}, {'c': LogicValue.x}),
+        Vector({'a': LogicValue.ofString('01zzxx10')},
+            {'c': LogicValue.ofString('01xxxx10')}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      // no SV run here, ROHD converts Z to X
     });
 
     test('single elseifblock comb', () async {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Previous changes made any invalid value on a conditional assignment turn the entire bus to `X`, which is very pessimistic, probably too much.  Better would be to convert any `Z` bit to `X`, but leave the valid bits alone.  That's the main change in this PR.

Also:
- Fix some doc comments
- Fix a missing link in CHANGELOG
- Add some assertions to help catch SV generation issues in case users override built-in functionality from `Logic`, `Module`, etc.
- Add a more interesting test on `CustomSystemVerilog` SV generation.

## Related Issue(s)

N/A

## Testing

Added new tests, plus existing tests cover a lot

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, but behavior will be slightly more optimistic now (closer to previous implementation).

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
