### PR TITLE
Add youtube channel link to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For documentation, guides, and more, [**visit the ROHD Website!**](https://intel
 - [Try it in-browser](https://dartpad.dev/?id=375e800a9d0bd402c9bfa5ebe2210c40)
 - [User Guide](https://intel.github.io/rohd-website/docs/sample-example/)
 - [Tutorials](https://github.com/intel/rohd/tree/main/doc/tutorials)
+- [YouTube Channel](https://www.youtube.com/@ROHD-DEV)
 - [API Docs](https://intel.github.io/rohd/rohd/rohd-library.html)
 - [Blog](https://intel.github.io/rohd-website/blog/)
 - [Contributing](https://github.com/intel/rohd/blob/main/CONTRIBUTING.md)

--- a/doc/tutorials/README.md
+++ b/doc/tutorials/README.md
@@ -1,5 +1,7 @@
 # Content Page
 
+Below are the ROHD tutorial content page, you can also find ROHD tutorial in our [YouTube playlist](https://www.youtube.com/watch?v=9eBV5DOn9mI&list=PLQiWLKsqVT-q5aJmcWWoPKHDxOEPhPExy).
+
 ## Chapter 1: Getting Started
 
 - [Introduction to ROHD](./chapter_1/00_introduction_to_rohd.md)


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Add YouTube link to let audience to find the tutorials easier.

## Related Issue(s)

None

## Testing

None

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No