### PR TITLE
chore(devtool): build devtool artifact and commit to other branch

### DIFF
--- a/.github/workflows/build_devtool.yml
+++ b/.github/workflows/build_devtool.yml
@@ -30,10 +30,6 @@ jobs:
         - name: Build Static Web
           run: tool/gh_actions/devtool/build_web.sh
 
-        # 1. checkout to branch artifacts
-        # 2. Do not ignore build/ folder (just for artifacts branch)
-        # 3. Commit everythings including the build/ folder
-        # 4. Push the new branch artifacts
         - name: Create artifact branch and commit
           run: |
             git config --global user.name "${GITHUB_ACTOR}"
@@ -41,8 +37,8 @@ jobs:
             git fetch origin
             git checkout -b artifacts
             git pull origin main
-            sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
             git add .
+            git add -f extension/*
             git commit -m "Add build artifacts and modify .gitignore"
 
         - name: Push changes

--- a/.github/workflows/build_devtool.yml
+++ b/.github/workflows/build_devtool.yml
@@ -1,0 +1,53 @@
+name: Build ROHD devtool
+on:
+  push:
+    branches:
+      - main
+
+# Top-level default, no permissions
+permissions: {}
+
+jobs:
+  build-devtool:
+      name: Build Devtools
+      permissions:
+        contents: write
+        pull-requests: write
+      timeout-minutes: 30
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Setup Flutter SDK
+          uses: flutter-actions/setup-flutter@v2
+          with:
+            channel: beta
+            version: 3.18.0-0.2.pre
+
+        - name: Run Flutter Test
+          run: tool/gh_actions/devtool/run_devtool_test.sh
+
+        - name: Build Static Web
+          run: tool/gh_actions/devtool/build_web.sh
+
+        # 1. checkout to branch artifacts
+        # 2. Do not ignore build/ folder (just for artifacts branch)
+        # 3. Commit everythings including the build/ folder
+        # 4. Push the new branch artifacts
+        - name: Create artifact branch and commit
+          run: |
+            git config --global user.name "${GITHUB_ACTOR}"
+            git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git fetch origin
+            git checkout -b artifacts
+            git pull origin main
+            sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
+            git add .
+            git commit -m "Add build artifacts and modify .gitignore"
+
+        - name: Push changes
+          uses: ad-m/github-push-action@master
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: artifacts
+            force: true

--- a/.github/workflows/build_devtool.yml
+++ b/.github/workflows/build_devtool.yml
@@ -21,8 +21,8 @@ jobs:
         - name: Setup Flutter SDK
           uses: flutter-actions/setup-flutter@v2
           with:
-            channel: beta
-            version: 3.18.0-0.2.pre
+            channel: stable
+            version: 3.16.9
 
         - name: Run Flutter Test
           run: tool/gh_actions/devtool/run_devtool_test.sh

--- a/.github/workflows/build_devtool.yml
+++ b/.github/workflows/build_devtool.yml
@@ -39,7 +39,7 @@ jobs:
             git pull origin main
             git add .
             git add -f extension/*
-            git commit -m "Add build artifacts and modify .gitignore"
+            git commit -m "Add build artifacts"
 
         - name: Push changes
           uses: ad-m/github-push-action@master

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -137,5 +137,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: artifacts
+          with:
+            force_with_lease: true
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -111,12 +111,17 @@ jobs:
 
       - name: Build Static Web
         run: tool/gh_actions/devtool/build_web.sh
-      
-      - name: Create release branch and push changes
+
+      # 1. checkout to branch artifacts
+      # 2. Do not ignore build/ folder (just for artifacts branch)
+      # 3. Commit everythings including the build/ folder
+      # 4. Push the new branch artifacts
+
+      - name: Create artifact branch and push changes
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git checkout -b artifact
+          git checkout -b artifacts
           sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
           git add .
           git commit -m "Add build artifacts and modify .gitignore"
@@ -127,6 +132,6 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: artifact
+          branch: artifacts
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -124,6 +124,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git checkout -b artifacts
+          git pull
           sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
           git add .
           git commit -m "Add build artifacts and modify .gitignore"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -8,7 +8,10 @@ on:
       - main
 
 # Top-level default, no permissions
-permissions: {}
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
 
 jobs:
   run-checks:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -117,7 +117,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git checkout -b artifact
-          sed -i '/build\//d' .rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
+          sed -i '/build\//d' rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
           git add .
           git commit -m "Add build artifacts"
           git push origin artifact

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -137,7 +137,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: artifacts
-          with:
-            force_with_lease: true
+          force_with_lease: true
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -111,5 +111,15 @@ jobs:
 
       - name: Build Static Web
         run: tool/gh_actions/devtool/build_web.sh
+      
+      - name: Create artifact branch and push changes
+      run: |
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git checkout -b artifact
+        sed -i '/build\//d' .rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
+        git add .
+        git commit -m "Add build artifacts"
+        git push origin artifact
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -92,23 +92,23 @@ jobs:
         with:
           folder: doc/api
           branch: docs
-          
+
   build-devtool:
-      name: Build Devtools
-      timeout-minutes: 30
-      runs-on: ubuntu-22.04
-      steps:
-        - uses: actions/checkout@v2
+    name: Build Devtools
+    timeout-minutes: 30
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
 
-        - name: Setup Flutter SDK
-          uses: flutter-actions/setup-flutter@v2
-          with:
-            channel: beta
-            version: 3.18.0-0.2.pre
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v2
+        with:
+          channel: beta
+          version: 3.18.0-0.2.pre
 
-        - name: Run Flutter Test
-          run: tool/gh_actions/devtool/run_devtool_test.sh
+      - name: Run Flutter Test
+        run: tool/gh_actions/devtool/run_devtool_test.sh
 
-        - name: Build Static Web
-          run: tool/gh_actions/devtool/build_web.sh
+      - name: Build Static Web
+        run: tool/gh_actions/devtool/build_web.sh
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -8,10 +8,7 @@ on:
       - main
 
 # Top-level default, no permissions
-permissions:
-  pull-requests: write
-  issues: write
-  repository-projects: write
+permissions: {}
 
 jobs:
   run-checks:
@@ -98,6 +95,9 @@ jobs:
 
   build-devtool:
     name: Build Devtools
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
@@ -119,7 +119,6 @@ jobs:
       # 2. Do not ignore build/ folder (just for artifacts branch)
       # 3. Commit everythings including the build/ folder
       # 4. Push the new branch artifacts
-
       - name: Create artifact branch and push changes
         run: |
           git config --global user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -112,14 +112,21 @@ jobs:
       - name: Build Static Web
         run: tool/gh_actions/devtool/build_web.sh
       
-      - name: Create artifact branch and push changes
+      - name: Create release branch and push changes
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git checkout -b artifact
-          sed -i '/build\//d' rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
+          sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
           git add .
-          git commit -m "Add build artifacts"
-          git push origin artifact
+          git commit -m "Add build artifacts and modify .gitignore"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: artifact
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -93,48 +93,4 @@ jobs:
           folder: doc/api
           branch: docs
 
-  build-devtool:
-    name: Build Devtools
-    permissions:
-      contents: write
-      pull-requests: write
-    timeout-minutes: 30
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
-        with:
-          channel: beta
-          version: 3.18.0-0.2.pre
-
-      - name: Run Flutter Test
-        run: tool/gh_actions/devtool/run_devtool_test.sh
-
-      - name: Build Static Web
-        run: tool/gh_actions/devtool/build_web.sh
-
-      # 1. checkout to branch artifacts
-      # 2. Do not ignore build/ folder (just for artifacts branch)
-      # 3. Commit everythings including the build/ folder
-      # 4. Push the new branch artifacts
-      - name: Create artifact branch and commit
-        run: |
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git fetch origin
-          git checkout -b artifacts
-          git pull origin main
-          sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
-          git add .
-          git commit -m "Add build artifacts and modify .gitignore"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: artifacts
-          force: true
-
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -119,10 +119,11 @@ jobs:
       # 2. Do not ignore build/ folder (just for artifacts branch)
       # 3. Commit everythings including the build/ folder
       # 4. Push the new branch artifacts
-      - name: Create artifact branch and push changes
+      - name: Create artifact branch and commit
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git fetch origin
           git checkout -b artifacts
           git pull origin main
           sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -92,5 +92,23 @@ jobs:
         with:
           folder: doc/api
           branch: docs
+          
+  build-devtool:
+      name: Build Devtools
+      timeout-minutes: 30
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v2
 
+        - name: Setup Flutter SDK
+          uses: flutter-actions/setup-flutter@v2
+          with:
+            channel: beta
+            version: 3.18.0-0.2.pre
+
+        - name: Run Flutter Test
+          run: tool/gh_actions/devtool/run_devtool_test.sh
+
+        - name: Build Static Web
+          run: tool/gh_actions/devtool/build_web.sh
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -113,13 +113,13 @@ jobs:
         run: tool/gh_actions/devtool/build_web.sh
       
       - name: Create artifact branch and push changes
-      run: |
-        git config --global user.name "${GITHUB_ACTOR}"
-        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-        git checkout -b artifact
-        sed -i '/build\//d' .rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
-        git add .
-        git commit -m "Add build artifacts"
-        git push origin artifact
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git checkout -b artifact
+          sed -i '/build\//d' .rohd_devtools_extension/.gitignore  # Remove the line that ignores the build directory
+          git add .
+          git commit -m "Add build artifacts"
+          git push origin artifact
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -124,7 +124,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git checkout -b artifacts
-          git pull
+          git pull origin main
           sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
           git add .
           git commit -m "Add build artifacts and modify .gitignore"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -129,14 +129,12 @@ jobs:
           sed -i '/build\//d' .gitignore  # Remove the line that ignores the build directory
           git add .
           git commit -m "Add build artifacts and modify .gitignore"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: artifacts
-          force_with_lease: true
+          force: true
 
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -123,10 +123,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: artifact
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: artifact
 
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

To test out the unreleased version of the devtool_extension, we can allow github action to commit the build artifact and modified the .gitignore. So, user can point to this package in pubspec.yaml via the use of:

```yaml

rohd:
     git:
       url: https://github.com/quekyj/rohd.git
       ref: artifacts
```

Branch that have the artifact:
- artifacts

## Testing

Tested on fork.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

no

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.