### PR TITLE
Simulator upgrades for rohme compatibility (registering now and cancelling)

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -1,4 +1,5 @@
 // Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2024 Adam Rose
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simulator.dart
@@ -6,9 +7,10 @@
 //
 // 2021 May 7
 // Author: Max Korbel <max.korbel@intel.com>
-
-// Some modification from Adam Rose <adam.david.rose@gmail.com>
-
+//
+// 2024 Feb 28th
+// Amended by Adam Rose <adam.david.rose@gmail.com> for Rohme compatibility
+//
 import 'dart:async';
 import 'dart:collection';
 
@@ -195,7 +197,9 @@ abstract class Simulator {
     _pendingTimestamps[timestamp]!.add(action);
   }
 
-  /// cancels an [action] previously scheduled for [timestamp]
+  /// Cancels an [action] previously scheduled for [timestamp].
+  ///
+  /// Returns true iff a [action] was previously registered at [timestamp].
   static bool cancelAction( int timestamp, dynamic Function() action ) {
     if( !_pendingTimestamps.containsKey( timestamp ) )
     {

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -200,20 +200,17 @@ abstract class Simulator {
   /// Cancels an [action] previously scheduled for [timestamp].
   ///
   /// Returns true iff a [action] was previously registered at [timestamp].
-  static bool cancelAction( int timestamp, dynamic Function() action ) {
-    if( !_pendingTimestamps.containsKey( timestamp ) )
-    {
+  static bool cancelAction(int timestamp, dynamic Function() action) {
+    if (!_pendingTimestamps.containsKey(timestamp)) {
       return false;
     }
 
-    if( !_pendingTimestamps[timestamp]!.remove( action ) )
-    {
+    if (!_pendingTimestamps[timestamp]!.remove(action)) {
       return false;
     }
 
-    if( _pendingTimestamps[timestamp]!.isEmpty )
-    {
-      _pendingTimestamps.remove( timestamp );
+    if (_pendingTimestamps[timestamp]!.isEmpty) {
+      _pendingTimestamps.remove(timestamp);
     }
 
     return true;

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -261,7 +261,7 @@ abstract class Simulator {
 
     _currentTimestamp = nextTimeStamp;
 
-    var pendingList = _pendingTimestamps[nextTimeStamp]!;
+    final pendingList = _pendingTimestamps[nextTimeStamp]!;
     _pendingTimestamps.remove(_currentTimestamp);
 
     await tickExecute(() async {

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -31,7 +31,10 @@ void main() {
   test('simulator supports cancelation of previously scheduled actions',
       () async {
     var actionCount = 0;
-    var incrementCount = () => actionCount++;
+
+    void incrementCount() {
+      actionCount++;
+    }
 
     Simulator.registerAction(
         50, () => Simulator.cancelAction(100, incrementCount));
@@ -136,19 +139,21 @@ void main() {
 
   group('Rohme compatibility tests', () {
     test('simulator supports delta cycles', () async {
-      List<String> testLog = [];
+      // ignore: omit_local_variable_types
+      final List<String> testLog = [];
 
-      void Function(int t, int i) deltaFunc = (t, i) {
+      void deltaFunc(int t, int i) {
         testLog.add('wake up $i');
         Simulator.registerAction(100, () => testLog.add('delta $i'));
-      };
+      }
 
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 0));
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 1));
 
       await Simulator.run();
 
-      List<String> expectedLog = [
+      // ignore: omit_local_variable_types
+      final List<String> expectedLog = [
         'wake up 0',
         'wake up 1',
         'delta 0',
@@ -170,9 +175,10 @@ void main() {
     });
 
     test('deltas occur after end of delta', () async {
-      List<String> testLog = [];
+      // ignore: omit_local_variable_types
+      final List<String> testLog = [];
 
-      void Function(int t, int i) deltaFunc = (t, i) {
+      void deltaFunc(int t, int i) {
         testLog.add('first delta $i');
 
         Simulator.registerAction(t, () {
@@ -180,14 +186,15 @@ void main() {
               Simulator.time, () => testLog.add('next delta $i'));
           Simulator.injectAction(() => testLog.add('end delta $i'));
         });
-      };
+      }
 
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 0));
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 1));
 
       await Simulator.run();
 
-      List<String> expectedLog = [
+      // ignore: omit_local_variable_types
+      final List<String> expectedLog = [
         'first delta 0',
         'first delta 1',
         'end delta 0',


### PR DESCRIPTION
## Description & Motivation

The intention of these changes is to enable Rohme / Rohd interoperability by Layering Rohme on top of the Rohd simulator.

Rohd needs three kinds of callback:

1.  Post to a future time ( Timer( SimDuration(...) , callback )
2.  Post to the next delta ( Timer( SimDuration.zero , callback )
3.  Post to "end of this delta" ( scheduleMicrotask )

Statistically speaking, (1) and (2) are common while (3) is rare.

As a result of (2), one time slot may have many delta cycles. Each time slot looks like this:

delta 0:
- { callbacks originally scheduled for this time slot}
- { microtasks scheduled by callbacks in delta 0}
delta 1:
- { zero time callbacks scheduled in delta 0}
- { micro tasks scheduled by callbacks in delta 1 }
...
delta n:
- { time zero callbacks scheduled by delta n-1 }
- { microtasks  scheduled in this delta n }

The timeslot finishes when there have been no zero delay ( type (2) ) callbacks posted.

The following Rohme code uses type (2) zero time delays:

 ``` dart
await Future.delayed( SimDuration.zero );
print('a');
await Future.delayed( SimDuration.zero );
print('b');
await Future.delayed( SimDuration.zero );
print('c');
```

Each call to Future.delayed( t ) above actually creates a Timer( current_time + t ).

Conceptually, it is very similar to the following SV code:

```
#0;
$display("a");
#0;
$display("b");
#0;
$display("c");
```

These zero delays are used for example to create mutexs which are fair and deterministic.

Mapping from Rohme to Rohd
1. Posting to the future is mapped to registerAction( timestamp ) , where timestamps > Simulator.time
- added a cancelAction( timestamp , action ) to support cancel ( and therefore suspend / resume )
2. Posting to the next delta is done using registerAction( Simulator.time )
- this creates another complete tickExecute at the current time
3. End of delta ( ie, microtask ) callbacks are mapped to injectAction

## Testing

All existing Rohd tests pass as previously. A few new tests have been added in test/simulator_test.dart.

## Backwards-compatibility

Given that all current tests pass, there should be no backward compatibility issues.

## Documentation

The small number of changes to the Simulator class have been documented inline.

## Further Work

### Package Organisation

For Rohme to use the Rohd simulator, it has to pull in the entire Rohd package. It would be easier for Rohme if the Rohd simulator was split out into its own package. We could also consider putting the Rohme simulator in this shared package. An external simulator might be useful for other packages which want to share the underlying timing with Rohme and Rohd.

### Incremental execution

A feature of the Rohme simulator is that it can run for some time and then run again for a little more time. This might be useful in the future tool integrations where the simulator needs to be started and stopped. It isn't obvious if this feature is supported, or whether it is viable in Rohd ( since there are end-of-simulation events etc ).

### Time zero reset

I ran a few experiments with doing Simulator.reset() before running a simulation. It seems that Simulator.reset() only works after a simulation has been run ( eg in a teardown method ). The reason I would like to run it before the simulation runs is that the Rohme simulator is an actual class with a constuctor, so it would be nice to put the reset in the constructor rather than a teardown method. That way a single test.dart can instantiate many Rohme simulators as it moves though the different tests. This might be as simple as doing nothing if a simulation has never been run. Alternatively, we could introduce a 'hasBeenRun' getter into the Rohd simulator so that Rohme could check for it before attempting to call Simulator.reset().



