### PR TITLE
Rohme interop

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -1,4 +1,5 @@
 // Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2024 Adam Rose
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simulator.dart
@@ -6,9 +7,10 @@
 //
 // 2021 May 7
 // Author: Max Korbel <max.korbel@intel.com>
-
-// Some modification from Adam Rose <adam.david.rose@gmail.com>
-
+//
+// 2024 Feb 28th
+// Amended by Adam Rose <adam.david.rose@gmail.com> for Rohme compatibility
+//
 import 'dart:async';
 import 'dart:collection';
 
@@ -195,7 +197,9 @@ abstract class Simulator {
     _pendingTimestamps[timestamp]!.add(action);
   }
 
-  /// cancels an [action] previously scheduled for [timestamp]
+  /// Cancels an [action] previously scheduled for [timestamp].
+  ///
+  /// Returns true iff a [action] was previously registered at [timestamp].
   static bool cancelAction( int timestamp, dynamic Function() action ) {
     if( !_pendingTimestamps.containsKey( timestamp ) )
     {

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -200,20 +200,17 @@ abstract class Simulator {
   /// Cancels an [action] previously scheduled for [timestamp].
   ///
   /// Returns true iff a [action] was previously registered at [timestamp].
-  static bool cancelAction( int timestamp, dynamic Function() action ) {
-    if( !_pendingTimestamps.containsKey( timestamp ) )
-    {
+  static bool cancelAction(int timestamp, dynamic Function() action) {
+    if (!_pendingTimestamps.containsKey(timestamp)) {
       return false;
     }
 
-    if( !_pendingTimestamps[timestamp]!.remove( action ) )
-    {
+    if (!_pendingTimestamps[timestamp]!.remove(action)) {
       return false;
     }
 
-    if( _pendingTimestamps[timestamp]!.isEmpty )
-    {
-      _pendingTimestamps.remove( timestamp );
+    if (_pendingTimestamps[timestamp]!.isEmpty) {
+      _pendingTimestamps.remove(timestamp);
     }
 
     return true;

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -261,7 +261,7 @@ abstract class Simulator {
 
     _currentTimestamp = nextTimeStamp;
 
-    var pendingList = _pendingTimestamps[nextTimeStamp]!;
+    final pendingList = _pendingTimestamps[nextTimeStamp]!;
     _pendingTimestamps.remove(_currentTimestamp);
 
     await tickExecute(() async {

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -31,7 +31,10 @@ void main() {
   test('simulator supports cancelation of previously scheduled actions',
       () async {
     var actionCount = 0;
-    var incrementCount = () => actionCount++;
+
+    void incrementCount() {
+      actionCount++;
+    }
 
     Simulator.registerAction(
         50, () => Simulator.cancelAction(100, incrementCount));
@@ -136,19 +139,21 @@ void main() {
 
   group('Rohme compatibility tests', () {
     test('simulator supports delta cycles', () async {
-      List<String> testLog = [];
+      // ignore: omit_local_variable_types
+      final List<String> testLog = [];
 
-      void Function(int t, int i) deltaFunc = (t, i) {
+      void deltaFunc(int t, int i) {
         testLog.add('wake up $i');
         Simulator.registerAction(100, () => testLog.add('delta $i'));
-      };
+      }
 
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 0));
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 1));
 
       await Simulator.run();
 
-      List<String> expectedLog = [
+      // ignore: omit_local_variable_types
+      final List<String> expectedLog = [
         'wake up 0',
         'wake up 1',
         'delta 0',
@@ -170,9 +175,10 @@ void main() {
     });
 
     test('deltas occur after end of delta', () async {
-      List<String> testLog = [];
+      // ignore: omit_local_variable_types
+      final List<String> testLog = [];
 
-      void Function(int t, int i) deltaFunc = (t, i) {
+      void deltaFunc(int t, int i) {
         testLog.add('first delta $i');
 
         Simulator.registerAction(t, () {
@@ -180,14 +186,15 @@ void main() {
               Simulator.time, () => testLog.add('next delta $i'));
           Simulator.injectAction(() => testLog.add('end delta $i'));
         });
-      };
+      }
 
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 0));
       Simulator.registerAction(100, () => deltaFunc(Simulator.time, 1));
 
       await Simulator.run();
 
-      List<String> expectedLog = [
+      // ignore: omit_local_variable_types
+      final List<String> expectedLog = [
         'first delta 0',
         'first delta 1',
         'end delta 0',


### PR DESCRIPTION
## Description & Motivation

 Allow immediate scheduling of an action within the same delta cycle

    This is a Rohme inspired enhancement to enable things like external IO inside
    a non Future timer callback.

```
        var publisher = publish(loops, Duration(milliseconds: 250));

        Simulator simulator = Simulator(clockPeriod: SimDuration(picoseconds: 10));

        simulator.run((simulator) async {
          Future.delayed(tickTime(5), () async {
            expect(simulator.elapsedTicks, 5);

            await simulator.immediate(() => subscribe(publisher) );

            expect(simulator.elapsedTicks, 5);
          });

          Future.delayed(tickTime(10), () async {
            expect(simulator.elapsedTicks, 10);
          });
        });

        await simulator.elapse(SimDuration(picoseconds: 1000));


```
    The Rohme call simulator.immediate( action ) is a thinish wrapper around the new
    Rohd call Simulator.registerImmediateAction( action ) [ It just wraps a Completer
    around the underlying action ].

    This preserves the ability to do things like

 ```
     simulator.run((simulator) async {
        Future.delayed( tickTime(10) , () async {
          a();
          await Future.delayed( tickTime( 10 ) );
          b();
        });
        Future.delayed( tickTime(11) , () async {
          c();
          await Future.delayed( tickTime( 10 ) );
          d();
        });
      });
 
```

    in Rohme, but also provide the ability to do "genuinely asynchronous" communication in zero
    simulation time.

## Testing

Two new tests in simulator_test.dart

## Backwards-compatibility

All tests still pass, and this is a new API, so no backward compatibility issues anticipated.

## Documentation

Code is documented in line.
