### PR TITLE
Fix a bug where array port element naming collisions with port names caused misconnections

### DIFF
--- a/test/logic_name_test.dart
+++ b/test/logic_name_test.dart
@@ -86,6 +86,26 @@ class DrivenOutputModule extends Module {
   }
 }
 
+class ModWithNameCollisionArrayPorts extends Module {
+  Logic get o => output('o');
+  ModWithNameCollisionArrayPorts(LogicArray portA, Logic portA2)
+      : super(name: 'submod') {
+    portA2 = addInput('portA_2', portA2);
+    portA = addInputArray('portA', portA, dimensions: [3, 1]);
+    addOutput('o') <= portA2;
+
+    addOutput('portB_1');
+    addOutputArray('portB', dimensions: [2, 1]);
+  }
+}
+
+class NameCollisionArrayTop extends Module {
+  NameCollisionArrayTop() {
+    addOutput('o') <=
+        ModWithNameCollisionArrayPorts(LogicArray([3, 1], 1), Logic()).o;
+  }
+}
+
 void main() {
   test(
       'GIVEN logic name is valid '
@@ -179,5 +199,16 @@ void main() {
       // should add a Z if it's explicitly added
       expect(sv, contains('z'));
     });
+  });
+
+  test('array port and simple port with _num name conflict', () async {
+    final mod = NameCollisionArrayTop();
+    await mod.build();
+    final sv = mod.generateSynth();
+    expect(
+        sv,
+        contains('submod(.portA_2(portA_2),.portA(portA),'
+            '.o(o),'
+            '.portB_1(portB_1),.portB(portB))'));
   });
 }


### PR DESCRIPTION

## Description & Motivation

In cases where a uniquified array element name (e.g. "ArrayX" element 0 would be "ArrayX_0" internally) collided with actual submodule port names (e.g. a non-array port named "ArrayX_0"), the SystemVerilog generated would misconnect the non-array-element port to an index of the array.  This was because array element names were assumed to be port names if their parent was a port, which is a false assumption.

This PR fixes the bug for both inputs and outputs.  It also adds more robust checking and assertions in the generation to catch any similar issue up-front.

## Related Issue(s)

N/A

## Testing

Added one new test, plus more assertions and safety in the implementation.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
