### PR TITLE
    Refactored tick() in simulator.dart

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -249,16 +249,16 @@ abstract class Simulator {
   /// If there are no timestamps pending to execute, nothing will execute.
   static Future<void> tick() async {
     if (_injectedActions.isNotEmpty) {
-       // case 1 : ( the usual Rohd case )
-       //   The previous delta cycle did NOT do 'registerAction( _currentTimeStamp );'.
-       //   In that case, _pendingTimestamps[_currentTimestamp] is null so we will
-       //   add a new empty list, which will trigger a new delta cycle.
-       // case 2 :
-       //   The previous delta cycle DID do 'registerAction( _currentTimestamp );'.
-       //   In that case, there is *already* another tick scheduled for
-       //   _currentTimestamp, and the injected actions will get called in
-       //   the normal way.
-      _pendingTimestamps.putIfAbsent( _currentTimestamp , () => ListQueue() );
+      // case 1 : ( the usual Rohd case )
+      //   The previous delta cycle did NOT do 'registerAction( _currentTimeStamp );'.
+      //   In that case, _pendingTimestamps[_currentTimestamp] is null so we will
+      //   add a new empty list, which will trigger a new delta cycle.
+      // case 2 :
+      //   The previous delta cycle DID do 'registerAction( _currentTimestamp );'.
+      //   In that case, there is *already* another tick scheduled for
+      //   _currentTimestamp, and the injected actions will get called in
+      //   the normal way.
+      _pendingTimestamps.putIfAbsent(_currentTimestamp, () => ListQueue());
       // Either way, the end result is that a whole new tick gets scheduled for
       // _currentTimestamp and any outstanding injected actions get executed.
     }

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -250,17 +250,22 @@ abstract class Simulator {
   static Future<void> tick() async {
     if (_injectedActions.isNotEmpty) {
       // case 1 : ( the usual Rohd case )
-      //   The previous delta cycle did NOT do 'registerAction( _currentTimeStamp );'.
-      //   In that case, _pendingTimestamps[_currentTimestamp] is null so we will
-      //   add a new empty list, which will trigger a new delta cycle.
+      // The previous delta cycle did NOT do
+      // 'registerAction( _currentTimeStamp );'.
+      // In that case, _pendingTimestamps[_currentTimestamp] is null so we will
+      // add a new empty list, which will trigger a new delta cycle.
+      //
       // case 2 :
-      //   The previous delta cycle DID do 'registerAction( _currentTimestamp );'.
-      //   In that case, there is *already* another tick scheduled for
-      //   _currentTimestamp, and the injected actions will get called in
-      //   the normal way.
-      _pendingTimestamps.putIfAbsent(_currentTimestamp, () => ListQueue());
+      // The previous delta cycle DID do 'registerAction( _currentTimestamp );'.
+      // In that case, there is *already* another tick scheduled for
+      // _currentTimestamp, and the injected actions will get called in
+      //  the normal way.
+      //
       // Either way, the end result is that a whole new tick gets scheduled for
       // _currentTimestamp and any outstanding injected actions get executed.
+
+      // ignore: unnecessary_lambdas
+      _pendingTimestamps.putIfAbsent(_currentTimestamp, () => ListQueue());
     }
 
     // the main event loop


### PR DESCRIPTION
 <!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Refactored tick() method in simulator.dart.

The high level motivation is to move towards a common scheduler shared by the Rohd and Rohm simulators. This is preparatory refactoring with that in mind.

Concretely, I have added a method for each phase.
    - all phase methods update _phase and add an event to their controller to let listeners know the new phase is now in progress
    - some phases are synchronous and not awaited
    - other phases are asychronous and are awaited
    - the asynchronous phases do something important before or after transitioning to the phase in question
    
The tick method now looks like this:

```
  static Future<void> tick() async {
    if (_injectedActions.isNotEmpty) {
      _pendingTimestamps.putIfAbsent( _currentTimestamp , () => ListQueue() );
    }

    // the main event loop
    if (_updateTimeStamp()) {
      _preTick();
      await _mainTick();
      _clkStable();
      await _outOfTick();
    }
  }
```

The justification is as follows:
```
       // case 1 : ( the usual Rohd case )
       //   The previous delta cycle did NOT do 'registerAction( _currentTimeStamp );'.
       //   In that case, _pendingTimestamps[_currentTimestamp] is currently
       //   null, so putIfAbsent will add a new empty list, which will trigger
       //   a new delta cycle.
       // case 2 :
       //   The previous delta cycle DID do 'registerAction( _currentTimestamp );'.
       //   In that case, there is *already* another tick scheduled for
       //   _currentTimestamp, and the injected actions will get called in
       //   the normal way.
       ...
      // Either way, the end result is that a whole new tick gets scheduled for
      // _currentTimestamp and any outstanding injected actions get executed.
```

## Testing

All Rohme and Rohd tests pass using this code.

## Backwards-compatibility

The user facing API has not changed and tool integrations _should_ be unaffected.

## Documentation

Documentation is inline ( including for the new private methods ).
