### PR TITLE
Adjust CI timeout and runners

### DIFF
--- a/.github/workflows/build_devtool.yml
+++ b/.github/workflows/build_devtool.yml
@@ -14,7 +14,7 @@ jobs:
         contents: write
         pull-requests: write
       timeout-minutes: 30
-      runs-on: ubuntu-22.04
+      runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
       steps:
         - uses: actions/checkout@v2
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -14,7 +14,7 @@ jobs:
   run-checks:
     name: Run Checks
     permissions: {}
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -97,7 +97,7 @@ jobs:
   build-devtool:
     name: Build Devtools
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Follow-up to https://github.com/intel/rohd/pull/417

A couple things:
- The Intel runners seem to run a little slower than the GitHub ones, so increasing timeouts to allow for it 
- Some jobs didn't have the updated runners, so updating those also

## Related Issue(s)

N/A

## Testing

This PR tests it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
