### PR TITLE
Fix bug in internal array discovery during Module build

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -417,6 +417,12 @@ abstract class Module {
           !isInput(signal) &&
           !isInOut(signal) &&
           subModule == null) {
+        // handle expanding the search for arrays
+        if (signal.isArrayMember) {
+          await _traceInputForModuleContents(signal.parentStructure!,
+              dontAddSignal: dontAddSignal);
+        }
+
         _addInternalSignal(signal);
       }
 
@@ -514,6 +520,12 @@ abstract class Module {
           !isOutput(signal) &&
           !isInOut(signal) &&
           subModule == null) {
+        // handle expanding the search for arrays
+        if (signal.isArrayMember) {
+          await _traceOutputForModuleContents(signal.parentStructure!,
+              dontAddSignal: dontAddSignal);
+        }
+
         _addInternalSignal(signal);
         for (final dstConnection in signal.dstConnections) {
           await _traceInputForModuleContents(dstConnection);

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -758,8 +758,10 @@ class _SynthModuleDefinition {
     for (var i = 0; i < logicsToTraverse.length; i++) {
       final receiver = logicsToTraverse[i];
 
-      assert(receiver.parentModule != null,
-          'Any signal traced by this should have been detected by build.');
+      assert(
+          receiver.parentModule != null,
+          'Any signal traced by this should have been detected by build,'
+          ' but $receiver was not.');
 
       if (receiver.parentModule != module &&
           !module.subModules.contains(receiver.parentModule)) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

In certain scenarios, it is possible for internal signals to not be discovered during `Module.build()` when they are connected element-wise to `LogicArray`s and not otherwise connected to other signals or sub-modules.  This should not cause any functional issues in simulation or generated SystemVerilog, but it can affect whether signals are present in the generated outputs or discoverable by querying the `internalSignals` API.  Some tools that leverage ROHD care about these, which was how the bug was discovered.

## Related Issue(s)

N/A

## Testing

Added a new test, existing tests cover functionality

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
