### PR TITLE
Update analysis options, lint cleanup, SDK workaround removal

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,7 +36,7 @@ linter:
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
     - avoid_init_to_null
-    # - avoid_js_rounded_ints
+    - avoid_js_rounded_ints
     - avoid_multiple_declarations_per_line
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
@@ -102,6 +102,7 @@ linter:
     - lines_longer_than_80_chars
     - literal_only_boolean_expressions
     - matching_super_parameters
+    - missing_code_block_language_in_doc_comment
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
@@ -193,6 +194,7 @@ linter:
     - unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive
+    - unnecessary_library_name
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable

--- a/lib/src/modules/gates.dart
+++ b/lib/src/modules/gates.dart
@@ -619,7 +619,7 @@ class LShift extends _ShiftGate {
 /// Performs a multiplexer/ternary operation.
 ///
 /// This is equivalent to something like:
-/// ```
+/// ```SystemVerilog
 /// control ? d1 : d0
 /// ```
 Logic mux(Logic control, Logic d1, Logic d0) => Mux(control, d1, d0).out;

--- a/lib/src/selection.dart
+++ b/lib/src/selection.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // selection.dart
@@ -21,7 +21,7 @@ extension IndexedLogic on List<Logic> {
   /// Alternatively we can approach this with `index.selectFrom(logicList)`
   ///
   /// Example:
-  /// ```
+  /// ```dart
   /// // ordering matches closer to array indexing with `0` index-based.
   /// List<Logic> logicList = [/* Add your Logic elements here */];
   /// selected <= logicList.selectIndex(index);

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -800,7 +800,7 @@ class Logic {
   /// Alternatively we can approach this with `busList.selectIndex(index)`
   ///
   /// Example:
-  /// ```
+  /// ```dart
   /// // ordering matches closer to array indexing with `0` index-based.
   /// selected <= index.selectFrom(busList);
   /// ```

--- a/lib/src/signals/logic_array.dart
+++ b/lib/src/signals/logic_array.dart
@@ -242,7 +242,7 @@ class LogicArray extends LogicStructure {
   /// to the length of the [updatedSubset].
   ///
   /// Example:
-  /// ```
+  /// ```dart
   /// LogicArray sampleLogic;
   /// // Note: updatedSubset.length < (sampleLogic.length - start)
   /// List<Logic> updatedSubset;

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -380,7 +380,7 @@ abstract class SimCompare {
             }
             return line;
           })
-          .whereNotNull()
+          .nonNulls
           .join('\n');
       if (maskedOutput.isNotEmpty) {
         print(maskedOutput);

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -870,7 +870,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
   /// Bitwise tristate merge.  No width comparison.
   ///
   /// Truth table for reference:
-  /// ```
+  /// ```csv
   /// s0	value0	invalid0	s1	value1	invalid1	result	value	invalid
   /// 0	0	0	0	0	0	0	0	0
   /// 0	0	0	1	1	0	x	0	1

--- a/test/translations_test.dart
+++ b/test/translations_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // translations_test.dart
@@ -8,12 +8,6 @@
 // Author: Max Korbel <max.korbel@intel.com>
 
 // ignore_for_file: avoid_multiple_declarations_per_line
-
-// TODO(mkorbel1): reenable this test on JavaScript pending dart sdk issue,
-//  https://github.com/dart-lang/sdk/issues/54329.
-
-@TestOn('vm')
-library;
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A handful of housekeeping things:
- Update the `analysis_options.yaml` with the latest options, enabling what we want to include
- Clean up lint violations, including deprecations from newer versions of libraries (e.g. `collection`)
- Remove a workaround (for https://github.com/dart-lang/sdk/issues/54329) that had disabled some javascript testing

Found one issue in https://github.com/intel/rohd/pull/494, so just fixed a handful more with it.

## Related Issue(s)

N/A

## Testing

PR should cover it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
