### PR TITLE
Fix bug where unconnected array drivers may be omitted incorrectly

### DIFF
--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -180,7 +180,7 @@ class Logic {
 
   /// Sets the value of [parentModule] to [newParentModule].
   ///
-  /// This should *only* be called by [Module.build()].  It is used to
+  /// This should *only* be called by [Module.build].  It is used to
   /// optimize search.
   @protected
   set parentModule(Module? newParentModule) {

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -251,7 +251,17 @@ class LogicStructure implements Logic {
         'Should only set parent module once.');
 
     _parentModule = newParentModule;
+  }
+
+  /// Performs a recursive call of setting [parentModule] on all of [elements]
+  /// and their [elements] for any sub-[LogicStructure]s.
+  @protected
+  void setAllParentModule(Module? newParentModule) {
+    parentModule = newParentModule;
     for (final element in elements) {
+      if (element is LogicStructure) {
+        element.setAllParentModule(newParentModule);
+      }
       element.parentModule = newParentModule;
     }
   }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Similar to the changes in https://github.com/intel/rohd/pull/494, this is an expansion to search properly for potentially undriven or unconventionally connected elements of `LogicArray`s and `LogicStructure`s which could sometimes be missed from being added to `internalSignals`.  This doesn't affect functionality during simulation, and wouldn't really affect generated SystemVerilog either, but the SystemVerilog generation may hit assertions and break assumptions with the missing signals.  It can also make results confusing for anything depending on `internalSignals` APIs.

This PR fixes the issues.

## Related Issue(s)

N/A

## Testing

Add new test + existing tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
