### PR TITLE
Do not generate SystemVerilog parameter syntax when there are 0 parameters

### DIFF
--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -102,7 +102,7 @@ class SystemVerilogSynthesizer extends Synthesizer {
     final connectionsStr = connections.join(',');
 
     var parameterString = '';
-    if (parameters != null) {
+    if (parameters != null && parameters.isNotEmpty) {
       final parameterContents =
           parameters.entries.map((e) => '.${e.key}(${e.value})').join(',');
       parameterString = '#($parameterContents)';
@@ -485,7 +485,7 @@ class _SystemVerilogSynthesisResult extends SynthesisResult {
   String? _verilogParameters(Module module) {
     if (module is SystemVerilog) {
       final defParams = module.definitionParameters;
-      if (defParams == null) {
+      if (defParams == null || defParams.isEmpty) {
         return null;
       }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This is a bug fix for when parameter arguments in custom-generated SystemVerilog have provided parameter information (either instantiation or definition), but the list/map is empty (but non-null).  It is illegal SystemVerilog syntax to generate something like `#( )`, but that's what was being generated.  The fix is to look for `null` OR empty conditions.

## Related Issue(s)

N/A

## Testing

Added a new test that covers both instantiation and definition empty parameter scenarios.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
