### PR TITLE
Add `inputSource` and `inOutSource` to `Module`

### DIFF
--- a/lib/src/diagnostics/inspector_service.dart
+++ b/lib/src/diagnostics/inspector_service.dart
@@ -34,7 +34,6 @@ extension _ModuleDevToolUtils on Module {
   Map<String, dynamic> toJson({bool skipCustomModules = true}) {
     final json = {
       'name': name,
-      // ignore: invalid_use_of_protected_member
       'inputs': inputs.map((key, value) => MapEntry(key, value.toMap())),
       'outputs': outputs.map((key, value) => MapEntry(key, value.toMap())),
     };

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -85,7 +85,6 @@ class Interface<TagType> {
       for (final port in getPorts(inputTags).values) {
         port <=
             (port is LogicArray
-                // ignore: invalid_use_of_protected_member
                 ? module.addInputArray(
                     uniquify(port.name),
                     srcInterface.port(port.name),
@@ -93,7 +92,6 @@ class Interface<TagType> {
                     elementWidth: port.elementWidth,
                     numUnpackedDimensions: port.numUnpackedDimensions,
                   )
-                // ignore: invalid_use_of_protected_member
                 : module.addInput(
                     uniquify(port.name),
                     srcInterface.port(port.name),
@@ -105,14 +103,12 @@ class Interface<TagType> {
     if (outputTags != null) {
       for (final port in getPorts(outputTags).values) {
         final output = (port is LogicArray
-            // ignore: invalid_use_of_protected_member
             ? module.addOutputArray(
                 uniquify(port.name),
                 dimensions: port.dimensions,
                 elementWidth: port.elementWidth,
                 numUnpackedDimensions: port.numUnpackedDimensions,
               )
-            // ignore: invalid_use_of_protected_member
             : module.addOutput(
                 uniquify(port.name),
                 width: port.width,
@@ -136,7 +132,6 @@ class Interface<TagType> {
 
         port <=
             (port is LogicArray
-                // ignore: invalid_use_of_protected_member
                 ? module.addInOutArray(
                     uniquify(port.name),
                     srcInterface.port(port.name),
@@ -144,7 +139,6 @@ class Interface<TagType> {
                     elementWidth: port.elementWidth,
                     numUnpackedDimensions: port.numUnpackedDimensions,
                   )
-                // ignore: invalid_use_of_protected_member
                 : module.addInOut(
                     uniquify(port.name),
                     srcInterface.port(port.name),

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -262,6 +262,9 @@ class LogicStructure implements Logic {
 
   /// Performs a recursive call of setting [parentModule] on all of [elements]
   /// and their [elements] for any sub-[LogicStructure]s.
+  ///
+  /// This should *only* be called by [Module.build].  It is used to optimize
+  /// search.
   @protected
   void setAllParentModule(Module? newParentModule) {
     parentModule = newParentModule;

--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -74,7 +74,6 @@ class SystemVerilogSynthesizer extends Synthesizer {
           instanceType,
           instanceName,
           Map.fromEntries(ports.entries
-              // ignore: invalid_use_of_protected_member
               .where((element) => module.inputs.containsKey(element.key))),
           Map.fromEntries(ports.entries
               .where((element) => module.outputs.containsKey(element.key))),
@@ -85,7 +84,6 @@ class SystemVerilogSynthesizer extends Synthesizer {
     //non-custom needs more details
     final connections = <String>[];
 
-    // ignore: invalid_use_of_protected_member
     for (final signalName in module.inputs.keys) {
       connections.add('.$signalName(${ports[signalName]!})');
     }
@@ -94,7 +92,6 @@ class SystemVerilogSynthesizer extends Synthesizer {
       connections.add('.$signalName(${ports[signalName]!})');
     }
 
-    // ignore: invalid_use_of_protected_member
     for (final signalName in module.inOuts.keys) {
       connections.add('.$signalName(${ports[signalName]!})');
     }
@@ -548,7 +545,6 @@ class _SynthSubModuleInstantiation {
   /// Adds an input mapping from [name] to [synthLogic].
   void setInputMapping(String name, _SynthLogic synthLogic,
       {bool replace = false}) {
-    // ignore: invalid_use_of_protected_member
     assert(module.inputs.containsKey(name),
         'Input $name not found in module ${module.name}.');
     assert(
@@ -584,7 +580,6 @@ class _SynthSubModuleInstantiation {
 
   void setInOutMapping(String name, _SynthLogic synthLogic,
       {bool replace = false}) {
-    // ignore: invalid_use_of_protected_member
     assert(module.inOuts.containsKey(name),
         'InOut $name not found in module ${module.name}.');
     assert(
@@ -815,17 +810,14 @@ class _SynthModuleDefinition {
   _SynthModuleDefinition(this.module)
       : _synthInstantiationNameUniquifier = Uniquifier(
           reservedNames: {
-            // ignore: invalid_use_of_protected_member
             ...module.inputs.keys,
             ...module.outputs.keys,
-            // ignore: invalid_use_of_protected_member
             ...module.inOuts.keys,
           },
         ) {
     // start by traversing output signals
     final logicsToTraverse = TraverseableCollection<Logic>()
       ..addAll(module.outputs.values)
-      // ignore: invalid_use_of_protected_member
       ..addAll(module.inOuts.values);
 
     for (final output in module.outputs.values) {
@@ -833,13 +825,11 @@ class _SynthModuleDefinition {
     }
 
     // make sure disconnected inputs are included
-    // ignore: invalid_use_of_protected_member
     for (final input in module.inputs.values) {
       inputs.add(_getSynthLogic(input)!);
     }
 
     // make sure disconnected inouts are included, also
-    // ignore: invalid_use_of_protected_member
     for (final inOut in module.inOuts.values) {
       inOuts.add(_getSynthLogic(inOut)!);
     }
@@ -855,10 +845,8 @@ class _SynthModuleDefinition {
     for (final subModule in module.subModules) {
       _getSynthSubModuleInstantiation(subModule);
       logicsToTraverse
-        // ignore: invalid_use_of_protected_member
         ..addAll(subModule.inputs.values)
         ..addAll(subModule.outputs.values)
-        // ignore: invalid_use_of_protected_member
         ..addAll(subModule.inOuts.values);
     }
 
@@ -942,7 +930,6 @@ class _SynthModuleDefinition {
               .setInOutMapping(receiver.name, synthReceiver);
         }
 
-        // ignore: invalid_use_of_protected_member
         logicsToTraverse.addAll(subModule.inOuts.values);
       }
 
@@ -958,9 +945,7 @@ class _SynthModuleDefinition {
         }
 
         logicsToTraverse
-          // ignore: invalid_use_of_protected_member
           ..addAll(subModule.inputs.values)
-          // ignore: invalid_use_of_protected_member
           ..addAll(subModule.inOuts.values);
       } else if (driver != null) {
         if (!module.isInput(receiver) && !module.isInOut(receiver)) {
@@ -1044,7 +1029,6 @@ class _SynthModuleDefinition {
   void _assignSubmodulePortMapping() {
     for (final submoduleInstantiation
         in moduleToSubModuleInstantiationMap.values) {
-      // ignore: invalid_use_of_protected_member
       for (final inputName in submoduleInstantiation.module.inputs.keys) {
         final orig = submoduleInstantiation.inputMapping[inputName]!;
         submoduleInstantiation.setInputMapping(
@@ -1059,7 +1043,6 @@ class _SynthModuleDefinition {
             replace: true);
       }
 
-      // ignore: invalid_use_of_protected_member
       for (final inOutName in submoduleInstantiation.module.inOuts.keys) {
         final orig = submoduleInstantiation.inOutMapping[inOutName]!;
         submoduleInstantiation.setInOutMapping(

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simcompare.dart
@@ -77,7 +77,6 @@ class Vector {
   /// Converts this vector into a SystemVerilog check.
   String toTbVerilog(Module module) {
     final assignments = inputValues.keys.map((signalName) {
-      // ignore: invalid_use_of_protected_member
       final signal = module.tryInOut(signalName) ?? module.input(signalName);
 
       if (signal is LogicArray) {
@@ -102,7 +101,6 @@ class Vector {
     for (final expectedOutput in expectedOutputValues.entries) {
       final outputName = expectedOutput.key;
       final outputPort =
-          // ignore: invalid_use_of_protected_member
           module.tryInOut(outputName) ?? module.output(outputName);
       final expected = expectedOutput.value;
       final expectedValue = LogicValue.of(
@@ -152,7 +150,6 @@ abstract class SimCompare {
       Simulator.registerAction(timestamp, () {
         for (final signalName in vector.inputValues.keys) {
           final value = vector.inputValues[signalName];
-          // ignore: invalid_use_of_protected_member
           (module.tryInput(signalName) ?? module.inOut(signalName)).put(value);
         }
 
@@ -161,7 +158,6 @@ abstract class SimCompare {
             for (final signalName in vector.expectedOutputValues.keys) {
               final value = vector.expectedOutputValues[signalName];
               final o =
-                  // ignore: invalid_use_of_protected_member
                   module.tryOutput(signalName) ?? module.inOut(signalName);
 
               final errorReason =
@@ -307,7 +303,6 @@ abstract class SimCompare {
     final logicToWireMapping = Map.fromEntries(vectors
         .map((v) => v.inputValues.keys)
         .flattened
-        // ignore: invalid_use_of_protected_member
         .where((name) => module.tryInOut(name) != null)
         .map((name) => MapEntry(name, toTbWireName(name))));
 

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface_test.dart
@@ -6,9 +6,6 @@
 //
 // 2021 November 30
 // Author: Max Korbel <max.korbel@intel.com>
-
-// ignore_for_file: avoid_multiple_declarations_per_line
-// ignore_for_file: invalid_use_of_protected_member
 
 import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -108,34 +108,62 @@ class SubModWithArray extends Module {
 }
 
 void main() {
-  test('tryInput, exists', () {
-    final mod = ModuleWithMaybePorts(addIn: true);
-    expect(mod.i, isNotNull);
+  group('try ports', () {
+    test('tryInput, exists', () {
+      final mod = ModuleWithMaybePorts(addIn: true);
+      expect(mod.i, isNotNull);
+    });
+
+    test('tryInput, doesnt exist', () {
+      final mod = ModuleWithMaybePorts();
+      expect(mod.i, null);
+    });
+
+    test('tryOutput, exists', () {
+      final mod = ModuleWithMaybePorts(addOut: true);
+      expect(mod.o, isNotNull);
+    });
+
+    test('tryOutput, doesnt exist', () {
+      final mod = ModuleWithMaybePorts();
+      expect(mod.o, null);
+    });
+
+    test('tryInOut, exists', () {
+      final mod = ModuleWithMaybePorts(addIo: true);
+      expect(mod.io, isNotNull);
+    });
+
+    test('tryInOut, doesnt exist', () {
+      final mod = ModuleWithMaybePorts();
+      expect(mod.io, null);
+    });
   });
 
-  test('tryInput, doesnt exist', () {
-    final mod = ModuleWithMaybePorts();
-    expect(mod.i, null);
-  });
+  group('port sources', () {
+    test('input port source', () {
+      final src = Logic();
+      final mod = FlexibleModule()..addInput('a', src);
+      expect(mod.inputSource('a'), src);
+    });
 
-  test('tryOutput, exists', () {
-    final mod = ModuleWithMaybePorts(addOut: true);
-    expect(mod.o, isNotNull);
-  });
+    test('inout port source', () {
+      final src = LogicNet();
+      final mod = FlexibleModule()..addInOut('a', src);
+      expect(mod.inOutSource('a'), src);
+    });
 
-  test('tryOutput, doesnt exist', () {
-    final mod = ModuleWithMaybePorts();
-    expect(mod.o, null);
-  });
+    test('input array port source', () {
+      final src = LogicArray([1], 1);
+      final mod = FlexibleModule()..addInputArray('a', src);
+      expect(mod.inputSource('a'), src);
+    });
 
-  test('tryInOut, exists', () {
-    final mod = ModuleWithMaybePorts(addIo: true);
-    expect(mod.io, isNotNull);
-  });
-
-  test('tryInOut, doesnt exist', () {
-    final mod = ModuleWithMaybePorts();
-    expect(mod.io, null);
+    test('inout array port source', () {
+      final src = LogicArray([1], 1);
+      final mod = FlexibleModule()..addInOutArray('a', src);
+      expect(mod.inOutSource('a'), src);
+    });
   });
 
   test('self-containing hierarchy', () async {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds new APIs to `Module` to access the original "driver" or "source" when an input or inOut port was created.

See #501 for more information on motivation, etc.

Also, removed the `@protected` on various APIs related to accessing inputs and inOuts on Modules since (a) it wasn't really protecting much during hardware generation since modules could access it without lint warning, and (b) because the proper use and connectivity of the APIs is already dependent on user understanding of in/out rules for module building.
 
## Related Issue(s)

Fix #501

## Testing

Add tests for new APIs + existing tests to make sure nothing broke

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Variable name changes from `x` to `source` on port creation APIs may trigger warnings on overrides of those functions, but not breaking.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
