### PR TITLE
Bug fix: shuffled array assignments incorrectly collapsed in generated SV

### DIFF
--- a/lib/src/synthesizers/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog.dart
@@ -1218,8 +1218,8 @@ class _SynthModuleDefinition {
           final srcArray = src.parentArray;
           final dstArray = dst.parentArray;
 
-          assert(srcArray.logics.length == 1, 'should be 1');
-          assert(dstArray.logics.length == 1, 'should be 1');
+          assert(srcArray.logics.length == 1, 'should be 1 name for the array');
+          assert(dstArray.logics.length == 1, 'should be 1 name for the array');
 
           if (srcArray.logics.first.elements.length !=
                   dstArray.logics.first.elements.length ||
@@ -1236,7 +1236,31 @@ class _SynthModuleDefinition {
 
       for (final MapEntry(key: (srcArray, dstArray), value: arrAssignments)
           in groupedAssignments.entries) {
-        if (arrAssignments.length == srcArray.logics.first.elements.length) {
+        assert(
+            srcArray.logics.first.elements.length ==
+                dstArray.logics.first.elements.length,
+            'should be equal lengths of elements in both arrays by now');
+
+        // first requirement is that all elements have been assigned
+        var shouldMerge =
+            arrAssignments.length == srcArray.logics.first.elements.length;
+
+        if (shouldMerge) {
+          // only check each element if the lengths match
+          for (final arrAssignment in arrAssignments) {
+            final arrAssignmentSrc =
+                (arrAssignment.src as _SynthLogicArrayElement).logic;
+            final arrAssignmentDst =
+                (arrAssignment.dst as _SynthLogicArrayElement).logic;
+
+            if (arrAssignmentSrc.arrayIndex! != arrAssignmentDst.arrayIndex!) {
+              shouldMerge = false;
+              break;
+            }
+          }
+        }
+
+        if (shouldMerge) {
           reducedAssignments.add(_SynthAssignment(srcArray, dstArray));
         } else {
           reducedAssignments.addAll(arrAssignments);


### PR DESCRIPTION
## Description & Motivation

The checks for collapsing array assignments in generated SystemVerilog had checked that all elements from one array are assigned to all elements of another array.  However, it did not check that the order on the driver matched the order on the receiver.  This means if you did all elements from one array to all elements of another array, but shuffled the order, the assignments would be incorrectly collapsed and the generated SV would be incorrect.

This PR introduces a fix for this bug and adds a test which failed prior to the fix, but now passes.

## Related Issue(s)

N/A

## Testing

Added new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
