### PR TITLE
Upgrade and improve `Uniquifier` API

### DIFF
--- a/test/uniquifier_test.dart
+++ b/test/uniquifier_test.dart
@@ -37,6 +37,27 @@ void main() {
     expect(name1, isNot(name2));
   });
 
+  test('uniquify incrementing name', () {
+    final uniq = Uniquifier(reservedNames: {'apple_4'});
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple');
+    expect(uniq.getUniqueName(initialName: 'apple_2'), 'apple_2');
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple_0');
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple_1');
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple_3');
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple_5');
+    expect(
+        uniq.getUniqueName(initialName: 'apple_4', reserved: true), 'apple_4');
+    expect(uniq.getUniqueName(initialName: 'apple'), 'apple_6');
+  });
+
+  test('null starter uniquify', () {
+    final uniq = Uniquifier();
+    expect(uniq.getUniqueName(nullStarter: 'a'), 'a');
+    expect(uniq.getUniqueName(nullStarter: 'a'), 'a_0');
+    expect(uniq.getUniqueName(), 'i');
+    expect(uniq.getUniqueName(), 'i_0');
+  });
+
   group('isAvailable', () {
     test('available name', () {
       final uniq = Uniquifier();

--- a/test/uniquifier_test.dart
+++ b/test/uniquifier_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // uniquifier_test.dart
@@ -18,5 +18,50 @@ void main() {
 
     expect(() => uniq.getUniqueName(initialName: 'apple', reserved: true),
         throwsA(isA<UnavailableReservedNameException>()));
+  });
+
+  test('uniquify name if requested twice', () {
+    final uniq = Uniquifier();
+    final name1 = uniq.getUniqueName(initialName: 'apple');
+    final name2 = uniq.getUniqueName(initialName: 'apple');
+    expect(name1, 'apple');
+    expect(name1, isNot(name2));
+  });
+
+  test('uniquify name if reserved', () {
+    final uniq = Uniquifier(reservedNames: {'apple'});
+    final name1 = uniq.getUniqueName(initialName: 'apple');
+    final name2 = uniq.getUniqueName(initialName: 'apple', reserved: true);
+    expect(name1, isNot('apple'));
+    expect(name2, 'apple');
+    expect(name1, isNot(name2));
+  });
+
+  group('isAvailable', () {
+    test('available name', () {
+      final uniq = Uniquifier();
+      expect(uniq.isAvailable('apple'), isTrue);
+    });
+
+    test('taken name', () {
+      final uniq = Uniquifier()..getUniqueName(initialName: 'apple');
+      expect(uniq.isAvailable('apple'), isFalse);
+    });
+
+    test('reserved name not available', () {
+      final uniq = Uniquifier(reservedNames: {'apple'});
+      expect(uniq.isAvailable('apple'), isFalse);
+    });
+
+    test('reserved name available for reserved', () {
+      final uniq = Uniquifier(reservedNames: {'apple'});
+      expect(uniq.isAvailable('apple', reserved: true), isTrue);
+    });
+
+    test('already used reserved name unavailable', () {
+      final uniq = Uniquifier(reservedNames: {'apple'})
+        ..getUniqueName(initialName: 'apple', reserved: true);
+      expect(uniq.isAvailable('apple', reserved: true), isFalse);
+    });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `Uniquifier` in ROHD is useful in many situations, but not exposed as a public API of ROHD (yet?).  Because it is private, the API is a little bit confusing as it relates to reserved items and was also not heavily unit tested.

This PR:
- Adds better testing for the Uniquifier
- Upgrades the `isAvailable` API to properly consider whether a reserved item should be considered available or not
- Optimizes the implementation to be a little more performant, since it is called many times

## Related Issue(s)

Related to #134, but not closing it

## Testing

Added new tests, and existing tests help protect that nothing broke

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Only if someone relied on the weird API behavior of an internal utility of ROHD

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
