### PR TITLE
Fix bugs in Simulator error handling and end of simulation

### DIFF
--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -387,7 +387,7 @@ abstract class Simulator {
         (_maxSimTime < 0 || _currentTimestamp < _maxSimTime)) {
       try {
         await tick();
-      } catch (__, _) {
+      } catch (_, __) {
         // trigger the end of simulation if an error occurred
         _simulationEndedCompleter.complete();
 

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -81,25 +81,101 @@ void main() {
     await Simulator.run();
   });
 
-  test('simulator end of action waits before ending', () async {
-    var endOfSimActionExecuted = false;
-    Simulator.registerAction(100, () => true);
-    Simulator.registerEndOfSimulationAction(
-        () => endOfSimActionExecuted = true);
-    unawaited(Simulator.simulationEnded
-        .then((value) => expect(endOfSimActionExecuted, isTrue)));
-    await Simulator.run();
+  group('simulator end of', () {
+    test('action waits before ending', () async {
+      var endOfSimActionExecuted = false;
+      Simulator.registerAction(100, () => true);
+      Simulator.registerEndOfSimulationAction(
+          () => endOfSimActionExecuted = true);
+      unawaited(Simulator.simulationEnded
+          .then((value) => expect(endOfSimActionExecuted, isTrue)));
+      await Simulator.run();
+    });
+
+    test('action waits async before ending', () async {
+      var endOfSimActionExecuted = false;
+      Simulator.registerAction(100, () => true);
+      Simulator.registerEndOfSimulationAction(() async {
+        await Future<void>.delayed(const Duration(microseconds: 10));
+        endOfSimActionExecuted = true;
+      });
+      await Simulator.run();
+      expect(endOfSimActionExecuted, isTrue);
+    });
+
+    test('action throws', () async {
+      var endOfSimActionExecuted = false;
+      var errorThrown = false;
+
+      Simulator.registerAction(100, () => true);
+      Simulator.registerEndOfSimulationAction(() {
+        endOfSimActionExecuted = true;
+        throw Exception('End of sim action failed');
+      });
+
+      // the Future will hang if we don't properly trigger the completion
+      unawaited(Simulator.run().onError((_, __) {
+        errorThrown = true;
+      }));
+      await Simulator.simulationEnded;
+
+      expect(endOfSimActionExecuted, isTrue);
+      expect(errorThrown, isTrue);
+    });
+
+    test('action async throws', () async {
+      var endOfSimActionExecuted = false;
+      var errorThrown = false;
+
+      Simulator.registerAction(100, () => true);
+      Simulator.registerEndOfSimulationAction(() async {
+        await Future<void>.delayed(const Duration(microseconds: 10));
+        endOfSimActionExecuted = true;
+        throw Exception('End of sim action failed');
+      });
+
+      // the Future will hang if we don't properly trigger the completion
+      unawaited(Simulator.run().onError((_, __) {
+        errorThrown = true;
+      }));
+      await Simulator.simulationEnded;
+
+      expect(endOfSimActionExecuted, isTrue);
+      expect(errorThrown, isTrue);
+    });
   });
 
-  test('simulator end of action waits async before ending', () async {
-    var endOfSimActionExecuted = false;
-    Simulator.registerAction(100, () => true);
-    Simulator.registerEndOfSimulationAction(() async {
-      await Future<void>.delayed(const Duration(microseconds: 10));
-      endOfSimActionExecuted = true;
-    });
-    await Simulator.run();
-    expect(endOfSimActionExecuted, isTrue);
+  test('registered action exception in simulator ends simulation', () async {
+    var errorThrown = false;
+
+    Simulator.registerAction(100, () => throw Exception('failed action'));
+    Simulator.registerAction(200, () => true);
+
+    unawaited(Simulator.run().onError((_, __) {
+      errorThrown = true;
+    }));
+
+    await Simulator.simulationEnded;
+
+    expect(errorThrown, isTrue);
+  });
+
+  test('simulator thrown exception ends simulation', () async {
+    var errorThrown = false;
+
+    Simulator.registerAction(
+        100,
+        () => Simulator.throwException(
+            Exception('simulator thrown exception'), StackTrace.current));
+    Simulator.registerAction(200, () => true);
+
+    unawaited(Simulator.run().onError((_, __) {
+      errorThrown = true;
+    }));
+
+    await Simulator.simulationEnded;
+
+    expect(errorThrown, isTrue);
   });
 
   test('simulator end simulation waits for simulation to end', () async {

--- a/tool/gh_actions/run_tests.sh
+++ b/tool/gh_actions/run_tests.sh
@@ -14,5 +14,5 @@ set -euo pipefail
 dart test
 
 # run tests in JS (increase heap size also)
-export NODE_OPTIONS="--max-old-space-size=6144"
+export NODE_OPTIONS="--max-old-space-size=8192"
 dart test --platform node


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There were cases where an error could occur during simulation and the simulation would not indicate that it had ended.  This PR fixes those bugs and adds tests to cover those scenarios.

For example:
- A registered action throws
- Something calls `Simulator.throwException`
- An end of simulation action throws

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
