### PR TITLE
Improved port already exists error message with module name

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -617,7 +617,7 @@ abstract class Module {
         inputs.containsKey(name) ||
         inOuts.containsKey(name)) {
       throw UnavailableReservedNameException.withMessage(
-          'Already defined a port with name "$name".');
+          'Already defined a port with name "$name" in module "${this.name}".');
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It is difficult to debug and identify from where (which module) `UnavailableReservedNameException` is getting thrown

## Related Issue(s)

Fixes #521 

## Testing

Added duplicate port names in example files and verified that the exception message includes the module name

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

NA

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

NA
