### PR TITLE
Async Reset Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Improved error and exception messages.
 - Fixed a bug where asynchronous events could sometimes show up late in generated waveforms from `WaveDumper`.
 - Added support for negative edge triggers to `Sequential.multi` for cases where synthesis may interpret an inverted `posedge` as different from a `negedge`.
+- Fixed a bug where `resetValues` would not take effect in `Pipeline`s.
 
 ## 0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Breaking: `Simulator.run` now yields execution of the Dart event loop prior to beginning the simulation. This makes actions taken before starting the simulation more predictable, but may slightly change behavior in existing testbenches that relied on a potential delay.
 - Improved error and exception messages.
 - Fixed a bug where asynchronous events could sometimes show up late in generated waveforms from `WaveDumper`.
+- Added support for negative edge triggers to `Sequential.multi` for cases where synthesis may interpret an inverted `posedge` as different from a `negedge`.
 
 ## 0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - Breaking: Updated APIs for `Synthesizer.synthesize` and down the stack to use a `Function` to calculate the instance type of a module instead of a `Map` look-up table.
 - Added `srcConnections` API to `Logic` to make it easier to trace drivers of subtypes of `Logic` which contain multiple drivers.
 - Breaking: `Const` constructor updated so that specified `width` takes precedence over the inherent width of a provided `LogicValue` `val`.
+- Added flags to support an `asyncReset` option in places where sequential reset automation was already present.
+- Breaking: `Sequential` has new added strictness checking when triggers and non-triggers change simultaneously (in the same `Simulator` tick) when it may be unpredictable how the hardware would synthesize, driving `X`s on outputs instead of just picking an order. Descriptions that imply asynchronous resets are predictable and therefore unaffected.
+- Breaking: injected actions in the `Simulator` can now occur in either the `mainTick` or `clkStable` phases. This API will generally continue to work as expected and as it always has, but in some scenarios could slightly change the behavior of existing testbenches.
+- Breaking: `Simulator.run` now yields execution of the Dart event loop prior to beginning the simulation. This makes actions taken before starting the simulation more predictable, but may slightly change behavior in existing testbenches that relied on a potential delay.
+- Improved error and exception messages.
+- Fixed a bug where asynchronous events could sometimes show up late in generated waveforms from `WaveDumper`.
 
 ## 0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed a bug where asynchronous events could sometimes show up late in generated waveforms from `WaveDumper`.
 - Added support for negative edge triggers to `Sequential.multi` for cases where synthesis may interpret an inverted `posedge` as different from a `negedge`.
 - Fixed a bug where `resetValues` would not take effect in `Pipeline`s.
+- Fixed a bug where a multi-triggered `Sequential` may not generate X's if one trigger is valid and another trigger is invalid.
 
 ## 0.5.3
 

--- a/doc/user_guide/_get-started/01-overview.md
+++ b/doc/user_guide/_get-started/01-overview.md
@@ -60,6 +60,6 @@ If you're thinking "SystemVerilog is just fine, I don't need something new", it 
 
 Try out Dart instantly from your browser here (it supports ROHD too!): <https://dartpad.dev/?null_safety=true>
 
-See some Dart language samples here: <https://dart.dev/samples>
+See some Dart language samples here: <https://dart.dev/language>
 
 For more information on Dart and tutorials, see <https://dart.dev/> and <https://dart.dev/overview>

--- a/lib/src/exceptions/name/invalid_reserved_name_exception.dart
+++ b/lib/src/exceptions/name/invalid_reserved_name_exception.dart
@@ -11,12 +11,12 @@ import 'package:rohd/src/exceptions/rohd_exception.dart';
 
 /// An exception that thrown when a reserved name is invalid.
 class InvalidReservedNameException extends RohdException {
-  /// Display error [message] on invalid reserved name.
+  /// An exception with an error [message] for an invalid reserved name.
   ///
   /// Creates a [InvalidReservedNameException] with an optional error [message].
-  InvalidReservedNameException(
-      [super.message = 'Reserved Name need to follow proper naming '
-          'convention if reserved'
-          ' name set to true']);
-  //TODO: make this error message better (what's the name, fix grammar)
+  InvalidReservedNameException(String name)
+      : super('The name "$name" was reserved but does not follow'
+            ' safe naming conventions. '
+            'Generally, reserved names should be valid variable identifiers'
+            ' in languages such as Dart and SystemVerilog.');
 }

--- a/lib/src/exceptions/name/invalid_reserved_name_exception.dart
+++ b/lib/src/exceptions/name/invalid_reserved_name_exception.dart
@@ -18,4 +18,5 @@ class InvalidReservedNameException extends RohdException {
       [super.message = 'Reserved Name need to follow proper naming '
           'convention if reserved'
           ' name set to true']);
+  //TODO: make this error message better (what's the name, fix grammar)
 }

--- a/lib/src/exceptions/name/invalid_reserved_name_exception.dart
+++ b/lib/src/exceptions/name/invalid_reserved_name_exception.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // invalid_reserved_name_exception.dart

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -80,6 +80,9 @@ class FiniteStateMachine<StateIdentifier> {
   /// Width of the state.
   final int _stateWidth;
 
+  /// If `true`, the [reset] signal is asynchronous.
+  final bool asyncReset;
+
   /// Creates an finite state machine for the specified list of [_states], with
   /// an initial state of [resetState] (when synchronous [reset] is high) and
   /// transitions on positive [clk] edges.
@@ -87,14 +90,18 @@ class FiniteStateMachine<StateIdentifier> {
     Logic clk,
     Logic reset,
     StateIdentifier resetState,
-    List<State<StateIdentifier>> states,
-  ) : this.multi([clk], reset, resetState, states);
+    List<State<StateIdentifier>> states, {
+    bool asyncReset = false,
+  }) : this.multi([clk], reset, resetState, states, asyncReset: asyncReset);
+
+  //TODO: test FSMs with async reset
 
   /// Creates an finite state machine for the specified list of [_states], with
   /// an initial state of [resetState] (when synchronous [reset] is high) and
   /// transitions on positive edges of any of [_clks].
   FiniteStateMachine.multi(
-      this._clks, this.reset, this.resetState, this._states)
+      this._clks, this.reset, this.resetState, this._states,
+      {this.asyncReset = false})
       : _stateWidth = _logBase(_states.length, 2),
         currentState =
             Logic(name: 'currentState', width: _logBase(_states.length, 2)),
@@ -147,7 +154,7 @@ class FiniteStateMachine<StateIdentifier> {
           ])
     ]);
 
-    Sequential.multi(_clks, reset: reset, resetValues: {
+    Sequential.multi(_clks, reset: reset, asyncReset: asyncReset, resetValues: {
       currentState: _stateValueLookup[_stateLookup[resetState]]
     }, [
       currentState < nextState,

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -96,6 +96,7 @@ class FiniteStateMachine<StateIdentifier> {
 
   //TODO: test FSMs with async reset
 
+  // TODO: allow FSM to support async reset
   /// Creates an finite state machine for the specified list of [_states], with
   /// an initial state of [resetState] (when synchronous [reset] is high) and
   /// transitions on positive edges of any of [_clks].

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -96,10 +96,11 @@ class FiniteStateMachine<StateIdentifier> {
 
   //TODO: test FSMs with async reset
 
-  // TODO: allow FSM to support async reset
   /// Creates an finite state machine for the specified list of [_states], with
-  /// an initial state of [resetState] (when synchronous [reset] is high) and
-  /// transitions on positive edges of any of [_clks].
+  /// an initial state of [resetState] (when [reset] is high) and transitions on
+  /// positive edges of any of [_clks].
+  ///
+  /// If [asyncReset] is `true`, the [reset] signal is asynchronous.
   FiniteStateMachine.multi(
       this._clks, this.reset, this.resetState, this._states,
       {this.asyncReset = false})

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -94,8 +94,6 @@ class FiniteStateMachine<StateIdentifier> {
     bool asyncReset = false,
   }) : this.multi([clk], reset, resetState, states, asyncReset: asyncReset);
 
-  //TODO: test FSMs with async reset
-
   /// Creates an finite state machine for the specified list of [_states], with
   /// an initial state of [resetState] (when [reset] is high) and transitions on
   /// positive edges of any of [_clks].

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -47,7 +47,7 @@ class Interface<TagType> {
   Logic port(String name) => _ports.containsKey(name)
       ? _ports[name]!
       : throw PortDoesNotExistException(
-          'Port named "$name" not found on this interface.');
+          'Port named "$name" not found on this interface: $this.');
 
   /// Provides the [port] named [name] if it exists, otherwise `null`.
   Logic? tryPort(String name) => _ports[name];

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1965,6 +1965,4 @@ class FlipFlop extends Module with SystemVerilog {
 
     return svBuffer.toString();
   }
-
-  //TODO: test sequential, sequential.multi, flipflop, and flop all! SV too!
 }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -527,18 +527,17 @@ class Sequential extends _Always {
     super.name = 'sequential',
     this.allowMultipleAssignments = true,
     List<Logic> negedgeTriggers = const [],
-  }) {
+  }) : super(reset: reset) {
     _registerInputTriggers(posedgeTriggers, isPosedge: true);
     _registerInputTriggers(negedgeTriggers, isPosedge: false);
 
-    if (_triggers.isEmpty) {
-      throw IllegalConfigurationException('Must provide at least one clock.');
+    if (reset != null && asyncReset) {
+      _triggers.add(_SequentialTrigger(_assignedDriverToInputMap[reset]!,
+          isPosedge: true));
     }
 
-    //TODO: trash cleanup
-    if (reset != null) {
-      _clks.add(_assignedDriverToInputMap[reset]!);
-      _preTickClkValues.add(null);
+    if (_triggers.isEmpty) {
+      throw IllegalConfigurationException('Must provide at least one trigger.');
     }
 
     _setup();
@@ -558,7 +557,7 @@ class Sequential extends _Always {
           addInput(
               _portUniquifier.getUniqueName(
                   initialName: Sanitizer.sanitizeSV(
-                      Naming.unpreferredName('clk${i}_${trigger.name}'))),
+                      Naming.unpreferredName('trigger${i}_${trigger.name}'))),
               trigger),
           isPosedge: isPosedge));
     }

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -1705,12 +1705,17 @@ ${padding}end ''');
 /// When the optional [reset] is provided, the flop will be reset (active-high).
 /// If no [resetValue] is provided, the reset value is always `0`. Otherwise,
 /// it will reset to the provided [resetValue].
+///
+/// If [asyncReset] is true, the [reset] signal (if provided) will be treated
+/// as an async reset. If [asyncReset] is false, the reset signal will be
+/// treated as synchronous.
 Logic flop(
   Logic clk,
   Logic d, {
   Logic? en,
   Logic? reset,
   dynamic resetValue,
+  bool asyncReset = false,
 }) =>
     FlipFlop(
       clk,
@@ -1718,6 +1723,7 @@ Logic flop(
       en: en,
       reset: reset,
       resetValue: resetValue,
+      asyncReset: asyncReset,
     ).q;
 
 /// Represents a single flip-flop with no reset.

--- a/lib/src/modules/conditional.dart
+++ b/lib/src/modules/conditional.dart
@@ -567,12 +567,13 @@ class Sequential extends _Always {
   /// as an async reset. If [asyncReset] is false, the reset signal will be
   /// treated as synchronous.
   ///
-  /// If a trigger is sampled within the `conditionals`, the value will be the
-  /// "new" value of that trigger. This is meant to help model how an
-  /// asynchronous trigger (e.g. async reset) could affect the behavior of the
-  /// sequential elements implied. One must be careful to describe logic which
-  /// is synthesizable. The [Sequential] will attempt to drive `X` in scenarios
-  /// it can detect may not simulate and synthesize the same way, but it cannot
+  /// If a trigger signal is sampled within the `conditionals`, the value will
+  /// be the "new" value of that trigger, as opposed to the "old" value as with
+  /// other non-trigger signals. This is meant to help model how an asynchronous
+  /// trigger (e.g. async reset) could affect the behavior of the sequential
+  /// elements implied. One must be careful to describe logic which is
+  /// synthesizable. The [Sequential] will attempt to drive `X` in scenarios it
+  /// can detect may not simulate and synthesize the same way, but it cannot
   /// guarantee it. If both a trigger and an input that is not a trigger glitch
   /// simultaneously during the phases of the [Simulator], then all outputs of
   /// this [Sequential] will be driven to [LogicValue.x].

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -159,7 +159,6 @@ class Pipeline {
             reset: reset,
             asyncReset: asyncReset);
 
-  // TODO: allow Pipeline to support async reset
   /// Constructs a [Pipeline] with multiple triggers on any of [_clks].
   Pipeline.multi(this._clks,
       {List<List<Conditional> Function(PipelineStageInfo p)> stages = const [],
@@ -261,22 +260,6 @@ class Pipeline {
           : ffAssign.driver;
       return ffAssign.receiver < driver;
     });
-
-    //TODO: can we just delete this??
-    // if (reset != null) {
-    //   ffAssignsWithStall = <Conditional>[
-    //     If.block([
-    //       Iff(
-    //         reset!,
-    //         ffAssigns.map((conditional) {
-    //           conditional as ConditionalAssign;
-    //           return conditional.receiver < (resetValue ?? 0);
-    //         }).toList(growable: false),
-    //       ),
-    //       Else(ffAssignsWithStall)
-    //     ])
-    //   ];
-    // }
 
     Sequential.multi(
         _clks,

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -356,6 +356,7 @@ class ReadyValidPipeline extends Pipeline {
     Map<Logic, Const> resetValues = const {},
     List<Logic> signals = const [],
     Logic? reset,
+    bool asyncReset = false,
   }) : this.multi(
           [clk],
           validPipeIn,
@@ -364,6 +365,7 @@ class ReadyValidPipeline extends Pipeline {
           resetValues: resetValues,
           signals: signals,
           reset: reset,
+          asyncReset: asyncReset,
         );
 
   /// Creates a [ReadyValidPipeline] with multiple triggers.
@@ -375,6 +377,7 @@ class ReadyValidPipeline extends Pipeline {
     super.resetValues,
     List<Logic> signals = const [],
     super.reset,
+    super.asyncReset,
   }) : super.multi(
           stages: stages,
           signals: [validPipeIn, ...signals],

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -159,6 +159,7 @@ class Pipeline {
             reset: reset,
             asyncReset: asyncReset);
 
+  // TODO: allow Pipeline to support async reset
   /// Constructs a [Pipeline] with multiple triggers on any of [_clks].
   Pipeline.multi(this._clks,
       {List<List<Conditional> Function(PipelineStageInfo p)> stages = const [],

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pipeline.dart
@@ -236,11 +236,6 @@ class Pipeline {
 
   /// Adds a new signal to be pipelined across all stages.
   void _add(Logic newLogic) {
-    // dynamic resetValue;
-    // if (_resetValues.containsKey(newLogic)) {
-    //   resetValue = _resetValues[newLogic];
-    // }
-
     for (var i = 0; i < _stages.length; i++) {
       _stages[i]._addLogic(newLogic, i);
     }

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -328,7 +328,6 @@ abstract class Simulator {
       await _pendingList.removeFirst()();
     }
 
-    //TODO: is this appropriate to do?
     await _executeInjectedActions();
   }
 

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -327,6 +327,12 @@ abstract class Simulator {
     while (_pendingList.isNotEmpty) {
       await _pendingList.removeFirst()();
     }
+
+    //TODO: is this appropriate to do? if so, make it a function!
+    while (_injectedActions.isNotEmpty) {
+      final injectedFunction = _injectedActions.removeFirst();
+      await injectedFunction();
+    }
   }
 
   /// Executes the clkStable phase

--- a/lib/src/simulator.dart
+++ b/lib/src/simulator.dart
@@ -328,11 +328,8 @@ abstract class Simulator {
       await _pendingList.removeFirst()();
     }
 
-    //TODO: is this appropriate to do? if so, make it a function!
-    while (_injectedActions.isNotEmpty) {
-      final injectedFunction = _injectedActions.removeFirst();
-      await injectedFunction();
-    }
+    //TODO: is this appropriate to do?
+    await _executeInjectedActions();
   }
 
   /// Executes the clkStable phase
@@ -343,15 +340,20 @@ abstract class Simulator {
     _clkStableController.add(null);
   }
 
+  /// Executes all the injected actions.
+  static Future<void> _executeInjectedActions() async {
+    while (_injectedActions.isNotEmpty) {
+      final injectedFunction = _injectedActions.removeFirst();
+      await injectedFunction();
+    }
+  }
+
   /// Executes the outOfTick phase
   ////
   /// Just before we end the current tick, we execute the injected actions,
   /// removing them from [_injectedActions] as we go.
   static Future<void> _outOfTick() async {
-    while (_injectedActions.isNotEmpty) {
-      final injectedFunction = _injectedActions.removeFirst();
-      await injectedFunction();
-    }
+    await _executeInjectedActions();
 
     _phase = SimulatorPhase.outOfTick;
 
@@ -386,6 +388,9 @@ abstract class Simulator {
       throw Exception('Simulation has already been run and ended.'
           '  To run a new simulation, use Simulator.reset().');
     }
+
+    // Yield execution to the event loop before beginning the simulation.
+    await Future(() {});
 
     while (hasStepsRemaining() &&
         _simExceptions.isEmpty &&

--- a/lib/src/utilities/naming.dart
+++ b/lib/src/utilities/naming.dart
@@ -41,7 +41,7 @@ enum Naming {
       } else if (name.isEmpty) {
         throw EmptyReservedNameException();
       } else if (!Sanitizer.isSanitary(name)) {
-        throw InvalidReservedNameException();
+        throw InvalidReservedNameException(name);
       }
     }
 

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -293,6 +293,7 @@ abstract class SimCompare {
         // ignore: parameter_assignments, prefer_interpolation_to_compose_strings
         return signalType +
             ' ' +
+            // ignore: prefer_interpolation_to_compose_strings
             packedDims.map((d) => '[${d - 1}:0]').join() +
             ' [${signal.elementWidth - 1}:0] $signalName' +
             unpackedDims.map((d) => '[${d - 1}:0]').join();

--- a/lib/src/utilities/vcd_parser.dart
+++ b/lib/src/utilities/vcd_parser.dart
@@ -69,6 +69,11 @@ abstract class VcdParser {
         }
       }
     }
+
+    if (state == _VcdParseState.findSig) {
+      throw Exception('Signal $signalName not found in VCD file');
+    }
+
     return currentValue == value;
   }
 }

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -109,9 +109,6 @@ void main() {
       },
     };
 
-    //TODO: what if there's another (connected) version of that signal that's the trigger?? but not exactly the same logic?
-    //TODO: how to deal with injects that trigger edges??
-
     //TODO: doc clearly the behavior of sampling async triggersl
 
     for (final mechanism in seqMechanism.entries) {
@@ -273,8 +270,6 @@ void main() {
 
           await mod.build();
 
-          WaveDumper(mod);
-
           final vectors = [
             Vector({'trigger1': 0, 'trigger2': 0}, {}),
             Vector({'trigger1': 1, 'trigger2': 1}, {}),
@@ -343,5 +338,29 @@ void main() {
       expect(seenValues[0].toInt(), 0xa);
       expect(seenValues[1].toInt(), 0xb);
     });
+  });
+
+  test('put before trigger changed does not cause race x generation', () async {
+    final d = Logic();
+    final clk = SimpleClockGenerator(10).clk;
+
+    final q = flop(clk, d);
+
+    unawaited(Simulator.run());
+
+    d.put(1);
+
+    await clk.nextPosedge;
+
+    expect(q.value.isValid, isTrue);
+    expect(q.value.toInt(), 1);
+
+    d.put(0);
+
+    await clk.nextPosedge;
+
+    expect(q.value.toInt(), 0);
+
+    await Simulator.endSimulation();
   });
 }

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -1,0 +1,36 @@
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('async reset samples correct reset value', () async {
+    final clk = Logic();
+    final reset = Logic();
+    final val = Logic();
+
+    reset.inject(0);
+    clk.inject(0);
+
+    //TODO: try different ways to define the reset as async
+    Sequential.multi(
+      [clk, reset],
+      reset: reset,
+      [
+        val < 1,
+      ],
+    );
+
+    Simulator.registerAction(10, () {
+      clk.inject(1);
+    });
+
+    Simulator.registerAction(14, () {
+      reset.inject(1);
+    });
+
+    Simulator.registerAction(15, () {
+      expect(val.value.toInt(), 0);
+    });
+
+    await Simulator.run();
+  });
+}

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -1,3 +1,12 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// async_reset_test.dart
+// Tests for asynchronous resets and triggers
+//
+// 2024 December 16
+// Author: Max Korbel <max.korbel@intel.com>
+
 import 'dart:async';
 
 import 'package:rohd/rohd.dart';

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -14,7 +14,7 @@ class NonIdenticalTriggerSeq extends Module {
     bool invert = false,
     bool triggerAfterSampledUpdate = true,
   }) {
-    final clk = Logic(name: 'clk');
+    final clk = Logic(name: 'clk')..gets(Const(0));
     trigger = addInput('trigger', trigger);
 
     final innerTrigger = Logic(name: 'innerTrigger', naming: Naming.reserved);
@@ -189,7 +189,7 @@ void main() {
         Vector({'trigger': 0}, {'result': 0}),
       ];
 
-      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
       SimCompare.checkIverilogVector(mod, vectors);
     });
 
@@ -205,7 +205,7 @@ void main() {
         Vector({'trigger': 1}, {'result': 1}),
       ];
 
-      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
       SimCompare.checkIverilogVector(mod, vectors);
     });
 
@@ -221,7 +221,7 @@ void main() {
         Vector({'trigger': 1}, {'result': 1}),
       ];
 
-      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
       SimCompare.checkIverilogVector(mod, vectors);
     });
   });

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -3,9 +3,11 @@ import 'package:test/test.dart';
 
 void main() {
   test('async reset samples correct reset value', () async {
-    final clk = Logic();
-    final reset = Logic();
-    final val = Logic();
+    final clk = Logic(name: 'clk');
+    final reset = Logic(name: 'reset');
+    final val = Logic(name: 'val');
+
+    reset.glitch.listen((x) => print('reset: $x'));
 
     reset.inject(0);
     clk.inject(0);
@@ -20,11 +22,11 @@ void main() {
     );
 
     Simulator.registerAction(10, () {
-      clk.inject(1);
+      clk.put(1);
     });
 
     Simulator.registerAction(14, () {
-      reset.inject(1);
+      reset.put(1);
     });
 
     Simulator.registerAction(15, () {

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -1,22 +1,56 @@
+import 'dart:async';
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
 class NonIdenticalTriggerSeq extends Module {
-  NonIdenticalTriggerSeq(Logic trigger) {
+  /// If [triggerAfterSampledUpdate] is `true`, then the trigger for the
+  /// sequential block happens *afer* the signal being sampled updates.  If
+  /// [triggerAfterSampledUpdate] is `false`, then the trigger for the
+  /// sequential block happens *before* the signal being sampled updates.
+  NonIdenticalTriggerSeq(
+    Logic trigger, {
+    bool invert = false,
+    bool triggerAfterSampledUpdate = true,
+  }) {
     final clk = Logic(name: 'clk');
     trigger = addInput('trigger', trigger);
 
     final innerTrigger = Logic(name: 'innerTrigger', naming: Naming.reserved);
-    innerTrigger <= trigger;
+    innerTrigger <= (invert ? ~trigger : trigger);
 
     final result = addOutput('result');
 
     Sequential.multi([
       clk,
-      innerTrigger
+      if (triggerAfterSampledUpdate) innerTrigger else trigger,
     ], [
-      result < trigger,
+      result < (triggerAfterSampledUpdate ? trigger : innerTrigger),
+    ]);
+  }
+}
+
+class MultipleTriggerSeq extends Module {
+  MultipleTriggerSeq(Logic trigger1, Logic trigger2) {
+    final clk = Logic(); //SimpleClockGenerator(10).clk;
+    trigger1 = addInput('trigger1', trigger1);
+    trigger2 = addInput('trigger2', trigger2);
+
+    final result = addOutput('result', width: 8);
+
+    Sequential.multi([
+      clk,
+      trigger1,
+      trigger2
+    ], [
+      If.block([
+        Iff(trigger1 & ~trigger2, [result < 0xa]),
+        ElseIf(~trigger1 & trigger2, [result < 0xb]),
+        // ElseIf(trigger1 & trigger2, [result < 0xc]),
+        ElseIf(~trigger1 & ~trigger2, [result < 0xd]),
+      ]),
+      // result < (trigger1 & trigger2),
     ]);
   }
 }
@@ -98,20 +132,165 @@ void main() {
     }
   });
 
-  test('non-identical signal trigger', () async {
-    final mod = NonIdenticalTriggerSeq(Logic());
+  test('async reset triggered via injection after clk edge still triggers',
+      () async {
+    final clk = SimpleClockGenerator(10).clk;
+    final reset = Logic(name: 'reset')..inject(0);
+    final val = Logic(name: 'val');
 
-    await mod.build();
+    Sequential(clk, reset: reset, asyncReset: true, [
+      val < 1,
+    ]);
 
-    final vectors = [
-      Vector({'trigger': 0}, {}),
-      Vector({'trigger': 1}, {'result': 1}),
-    ];
+    Simulator.setMaxSimTime(1000);
+    unawaited(Simulator.run());
 
-    // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
-    SimCompare.checkIverilogVector(mod, vectors,
-        dontDeleteTmpFiles: true, dumpWaves: true);
+    await clk.nextPosedge;
+    await clk.nextPosedge;
+    // reset.inject(1); //TODO
+    Simulator.injectAction(() {
+      // print('asdf1');
+      reset.put(1);
+    });
+
+    Simulator.registerAction(Simulator.time + 1, () {
+      // print('asdf');
+      expect(val.value.toInt(), 0);
+    });
+
+    // one more edge so sim doesnt end immediately
+    await clk.nextPosedge;
+
+    await Simulator.endSimulation();
+  });
+
+  group('non-identical signal trigger', () {
+    test('normal', () async {
+      final mod = NonIdenticalTriggerSeq(Logic());
+
+      await mod.build();
+
+      final vectors = [
+        Vector({'trigger': 0}, {}),
+        Vector({'trigger': 1}, {'result': 1}),
+      ];
+
+      await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
+
+    test('inverted', () async {
+      final mod = NonIdenticalTriggerSeq(Logic(), invert: true);
+
+      await mod.build();
+
+      final vectors = [
+        Vector({'trigger': 1}, {}),
+        Vector({'trigger': 0}, {'result': 0}),
+      ];
+
+      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
+
+    test('trigger earlier inverted', () async {
+      final mod = NonIdenticalTriggerSeq(Logic(),
+          invert: true, triggerAfterSampledUpdate: false);
+
+      await mod.build();
+
+      final vectors = [
+        Vector({'trigger': 0}, {}),
+        // in this case, the trigger happened before the sampled value updated
+        Vector({'trigger': 1}, {'result': 1}),
+      ];
+
+      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
+
+    test('trigger earlier normal', () async {
+      final mod =
+          NonIdenticalTriggerSeq(Logic(), triggerAfterSampledUpdate: false);
+
+      await mod.build();
+
+      final vectors = [
+        Vector({'trigger': 0}, {}),
+        // in this case, the two signals are "identical", so there is no "later"
+        Vector({'trigger': 1}, {'result': 1}),
+      ];
+
+      // await SimCompare.checkFunctionalVector(mod, vectors); //TODO fix
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
   });
 
   //TODO: test async reset with clocks too
+
+  //TODO: test if registerAction (same tick) with clk and reset both edges at the same time
+  // what should that even do?? error?? what if two signals other than clk (like different resets)
+  // that need to be mutually exclusive happen?
+  // always@(clk, r1, r2) if(r1 & ~r2) ... if(r2 & ~r1) ... if(r1 & r2) ... if(~r1 & ~r2) ...
+
+  group('multiple trigger races', () {
+    test('two resets simulatenously', () async {
+      final mod = MultipleTriggerSeq(Logic(), Logic());
+
+      await mod.build();
+
+      final vectors = [
+        Vector({'trigger1': 0, 'trigger2': 0}, {}),
+        // Vector({'trigger1': 0, 'trigger2': 0}, {'result': 0xd}),
+        Vector({'trigger1': 1, 'trigger2': 1}, {}),
+        Vector({'trigger1': 1, 'trigger2': 1}, {'result': 0xd}),
+      ];
+
+      //TODO fix, should this fail?
+      // await SimCompare.checkFunctionalVector(mod, vectors);
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
+
+    test('one then another trigger post-changed', () async {
+      final a = Logic()..put(0);
+      final b = Logic()..put(0);
+
+      final result = Logic(width: 8);
+
+      Sequential.multi([
+        a,
+        b
+      ], [
+        If.block([
+          Iff(a & ~b, [result < 0xa]),
+          ElseIf(~a & b, [result < 0xb]),
+          Else([result < 0xc]),
+        ]),
+      ]);
+
+      Simulator.registerAction(10, () {
+        a.put(1);
+      });
+
+      a.changed.listen((_) {
+        Simulator.injectAction(() {
+          a.put(0);
+          b.put(1);
+        });
+      });
+
+      final seenValues = <LogicValue>[];
+
+      result.changed.listen((_) {
+        expect(Simulator.time, 10);
+        seenValues.add(result.value);
+      });
+
+      await Simulator.run();
+
+      expect(seenValues.length, 2);
+      expect(seenValues[0].toInt(), 0xa);
+      expect(seenValues[1].toInt(), 0xb);
+    });
+  });
 }

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -295,11 +295,21 @@ void main() {
         a,
         b
       ], [
-        If.block([
-          Iff(a & ~b, [result < 0xa]),
-          ElseIf(~a & b, [result < 0xb]),
-          Else([result < 0xc]),
-        ]),
+        // this is bad style and possibly won't synthesize properly, but helps
+        // test some of the checking in `Sequential`s
+        If.s(
+          a,
+          If.s(
+            b,
+            result < 0xc,
+            result < 0xa,
+          ),
+          If.s(
+            b,
+            result < 0xb,
+            result < 0xc,
+          ),
+        ),
       ]);
 
       Simulator.registerAction(10, () {

--- a/test/async_reset_test.dart
+++ b/test/async_reset_test.dart
@@ -2,37 +2,76 @@ import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('async reset samples correct reset value', () async {
-    final clk = Logic(name: 'clk');
-    final reset = Logic(name: 'reset');
-    final val = Logic(name: 'val');
-
-    reset.glitch.listen((x) => print('reset: $x'));
-
-    reset.inject(0);
-    clk.inject(0);
-
-    //TODO: try different ways to define the reset as async
-    Sequential.multi(
-      [clk, reset],
-      reset: reset,
-      [
-        val < 1,
-      ],
-    );
-
-    Simulator.registerAction(10, () {
-      clk.put(1);
-    });
-
-    Simulator.registerAction(14, () {
-      reset.put(1);
-    });
-
-    Simulator.registerAction(15, () {
-      expect(val.value.toInt(), 0);
-    });
-
-    await Simulator.run();
+  tearDown(() async {
+    await Simulator.reset();
   });
+
+  group('async reset samples correct reset value', () {
+    final seqMechanism = {
+      'Sequential.multi': (Logic clk, Logic reset, Logic val) =>
+          Sequential.multi(
+            [clk, reset],
+            reset: reset,
+            [
+              val < 1,
+            ],
+          ),
+      'Sequential with asyncReset': (Logic clk, Logic reset, Logic val) =>
+          Sequential(
+            clk,
+            reset: reset,
+            [
+              val < 1,
+            ],
+            asyncReset: true,
+          ),
+      'FlipFlop with asyncReset': (Logic clk, Logic reset, Logic val) {
+        val <=
+            FlipFlop(
+              clk,
+              reset: reset,
+              val,
+              asyncReset: true,
+            ).q;
+      },
+      'flop with asyncReset': (Logic clk, Logic reset, Logic val) {
+        val <=
+            flop(
+              clk,
+              reset: reset,
+              val,
+              asyncReset: true,
+            );
+      },
+    };
+
+    for (final mechanism in seqMechanism.entries) {
+      test('using ${mechanism.key}', () async {
+        final clk = Logic(name: 'clk');
+        final reset = Logic(name: 'reset');
+        final val = Logic(name: 'val');
+
+        reset.inject(0);
+        clk.inject(0);
+
+        mechanism.value(clk, reset, val);
+
+        Simulator.registerAction(10, () {
+          clk.put(1);
+        });
+
+        Simulator.registerAction(14, () {
+          reset.put(1);
+        });
+
+        Simulator.registerAction(15, () {
+          expect(val.value.toInt(), 0);
+        });
+
+        await Simulator.run();
+      });
+    }
+  });
+
+  //TODO: test async reset with clocks too
 }

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -150,6 +150,32 @@ void main() {
     expect(numPosedges, equals(1));
   });
 
+  test('injection can trigger multiple changed events if post tick', () async {
+    final a = Logic(width: 8)..put(0);
+
+    Simulator.registerAction(10, () {
+      a
+        ..put(1)
+        ..inject(2);
+    });
+
+    a.changed.listen((_) {
+      a.inject(a.value.toInt() | (1 << 4));
+    });
+
+    final seenValues = <LogicValue>[];
+
+    a.changed.listen((_) {
+      seenValues.add(a.value);
+    });
+
+    await Simulator.run();
+
+    expect(seenValues.length, 2);
+    expect(seenValues[0].toInt(), 2);
+    expect(seenValues[1].toInt(), 2 | (1 << 4));
+  });
+
   group('injection triggers flop', () {
     Future<void> injectionTriggersFlop({required bool useArrays}) async {
       final baseClk = SimpleClockGenerator(10).clk;

--- a/test/changed_test.dart
+++ b/test/changed_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // changed_test.dart

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // example_test.dart

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -23,9 +23,11 @@ void main() {
   test('counter example', () async {
     await counter.main(noPrint: true);
   });
+
   test('tree example', () async {
     await tree.main(noPrint: true);
   });
+
   test('fir filter example', () async {
     await fir_filter.main(noPrint: true);
   });

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -21,11 +21,11 @@ const _simpleFSMPath = '$_tmpDir/simple_fsm.md';
 const _trafficFSMPath = '$_tmpDir/traffic_light_fsm.md';
 
 class TestModule extends Module {
-  TestModule(Logic a, Logic c, Logic reset) {
+  TestModule(Logic a, Logic c, Logic reset, {bool testingAsyncReset = false}) {
     a = addInput('a', a);
     c = addInput('c', c, width: c.width);
     final b = addOutput('b', width: c.width);
-    final clk = SimpleClockGenerator(10).clk;
+    final clk = testingAsyncReset ? Const(0) : SimpleClockGenerator(10).clk;
     reset = addInput('reset', reset);
     final states = [
       State<MyStates>(MyStates.state1, events: {
@@ -45,8 +45,9 @@ class TestModule extends Module {
       ]),
     ];
 
-    final fsm =
-        FiniteStateMachine<MyStates>(clk, reset, MyStates.state1, states);
+    final fsm = FiniteStateMachine<MyStates>(
+        clk, reset, MyStates.state1, states,
+        asyncReset: testingAsyncReset);
 
     if (!kIsWeb) {
       fsm.generateDiagram(outputPath: _simpleFSMPath);
@@ -241,11 +242,23 @@ void main() {
         Vector({'c': 1}, {'b': 0}),
       ];
       await SimCompare.checkFunctionalVector(pipem, vectors);
-      final simResult = SimCompare.iverilogVector(pipem, vectors);
-
-      expect(simResult, equals(true));
+      SimCompare.checkIverilogVector(pipem, vectors);
 
       verifyMermaidStateDiagram(_simpleFSMPath);
+    });
+
+    test('simple fsm async reset', () async {
+      final pipem =
+          TestModule(Logic(), Logic(), Logic(), testingAsyncReset: true);
+
+      await pipem.build();
+
+      final vectors = [
+        Vector({'reset': 0, 'a': 0, 'c': 0}, {}),
+        Vector({'reset': 1}, {'b': 0}),
+      ];
+      await SimCompare.checkFunctionalVector(pipem, vectors);
+      SimCompare.checkIverilogVector(pipem, vectors);
     });
 
     test('default next state fsm', () async {

--- a/test/fsm_test.dart
+++ b/test/fsm_test.dart
@@ -259,6 +259,8 @@ void main() {
       ];
       await SimCompare.checkFunctionalVector(pipem, vectors);
       SimCompare.checkIverilogVector(pipem, vectors);
+
+      verifyMermaidStateDiagram(_simpleFSMPath);
     });
 
     test('default next state fsm', () async {

--- a/test/net_bus_test.dart
+++ b/test/net_bus_test.dart
@@ -293,6 +293,21 @@ void main() {
     expect(a.value, LogicValue.zero);
   });
 
+  test('circular blasted connection', () {
+    final a = LogicNet(width: 8);
+
+    final b = a.getRange(0, 4);
+
+    final c = [b, b].swizzle();
+
+    a <= c;
+    c <= a;
+
+    a.put(0x33);
+
+    expect(c.value.toInt(), 0x33);
+  });
+
   group('simple', () {
     test('double passthrough', () async {
       final dut = DoubleNetPassthrough(LogicNet(width: 8), LogicNet(width: 8));

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pipeline_test.dart

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -203,6 +203,7 @@ void main() {
       await pipem.build();
 
       //TODO: test that reset works!
+      //TODO: test that async reset works!
       //TODO: test that reset value works!
       final vectors = [
         Vector({'a': 1}, {}),

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -202,6 +202,8 @@ void main() {
       final pipem = SimplePipelineModule(Logic(width: 8));
       await pipem.build();
 
+      //TODO: test that reset works!
+      //TODO: test that reset value works!
       final vectors = [
         Vector({'a': 1}, {}),
         Vector({'a': 2}, {}),

--- a/test/wave_dumper_test.dart
+++ b/test/wave_dumper_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // wave_dumper_test.dart


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There were a handful of bugs and issues related to asynchronous reset, reset values, simulator injections, waveform dumping, etc.  This PR addresses a variety of those issues.

- Updated examples to be better and compatible with changes
- Improved `InvalidReservedNameException` messages
- Improved error messages when a port does not exist on an interface
- Added `asyncReset` to `Sequential`, `FiniteStateMachine`, `Pipeline`, `FlipFlop`, `flop`
- Make sequentials drive `x` if a trigger and non-trigger happen at the "same time" in a tick to help catch non-synthesizable behavior in designs around flops
- Fixed a bug where a multi-triggered Sequential may not generate X's if one trigger is valid and another (later specified) trigger is invalid.
- Added support for both posedge and negedge triggers on Sequentials
- Fixed and clarified `resetValues` behavior for `Pipeline`s
- Fixed reset handling in `Pipeline` to use `Sequential`'s automation instead of its own
- Change the `Simulator` so that it executes injected actions within main tick if possible.
- Yield execution for event loop before starting the simulation
- Added some error checking for vcd parsing in wavedumper tests (not API visible, just for dev)

It also encompasses and supersedes https://github.com/intel/rohd/pull/483

> Adds support for negative edge-triggered Sequentials. In some cases, downstream tools may treat an inverted clock fed into a sequential differently than a negative edge triggered sequential. Functionally, in simulation, the behavior is the same for either option. Generators may choose to generate these differently (e.g. using negedge vs. posedge in SystemVerilog generation).
> 
> Additionally fixed a bug where a multi-triggered Sequential may not generate X's if one trigger is valid and another (later specified) trigger is invalid.
> 
> The changes also motivated some refactoring of trigger handling in Sequential, as well as renaming of the first positional argument in Sequential.multi.

## Related Issue(s)

Fix #531
Fix #528
Fix #338
Supersedes #483

## Testing

Added extensive testing for applicable areas

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes!

- Breaking: injected actions in the `Simulator` can now occur in either the `mainTick` or `clkStable` phases. This API will generally continue to work as expected and as it always has, but in some scenarios could slightly change the behavior of existing testbenches.
- Breaking: `Simulator.run` now yields execution of the Dart event loop prior to beginning the simulation. This makes actions taken before starting the simulation more predictable, but may slightly change behavior in existing testbenches that relied on a potential delay.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Generally no, but API docs were updated.  This is mostly fixing behavior, not adding/changing.
