### PR TITLE
LogicValue radixString uses underscore separators by default

### DIFF
--- a/lib/src/exceptions/logic_value/logic_value_construction_exception.dart
+++ b/lib/src/exceptions/logic_value/logic_value_construction_exception.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_value_construction_exception.dart
-// An exception that thrown when a signal failes to `put`.
+// An exception that is thrown when a signal fails to `put`.
 //
 // 2023 May 1
 // Author: Max Korbel <max.korbel@intel.com>

--- a/lib/src/exceptions/logic_value/logic_value_conversion_exception.dart
+++ b/lib/src/exceptions/logic_value/logic_value_conversion_exception.dart
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// logic_value_conversion_exception.dart
+// An exception that is thrown when a conversion from a [LogicValue] fails
+// (such as to a [String]).
+//
+// 2024 December 26
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+
+import 'package:rohd/rohd.dart';
+
+/// An exception that is thrown when a [LogicValue] cannot be
+/// properly converted.
+class LogicValueConversionException extends RohdException {
+  /// Creates an exception for when conversion of a `LogicValue` fails.
+  LogicValueConversionException(String message)
+      : super('Failed to convert `LogicValue`: $message');
+}

--- a/lib/src/exceptions/logic_value/logic_value_conversion_exception.dart
+++ b/lib/src/exceptions/logic_value/logic_value_conversion_exception.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_value_conversion_exception.dart

--- a/lib/src/exceptions/logic_value/logic_value_exceptions.dart
+++ b/lib/src/exceptions/logic_value/logic_value_exceptions.dart
@@ -4,4 +4,5 @@
 export 'invalid_truncation_exception.dart';
 export 'invalid_value_operation_exception.dart';
 export 'logic_value_construction_exception.dart';
+export 'logic_value_conversion_exception.dart';
 export 'value_width_mismatch_exception.dart';

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -1097,7 +1097,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
 
   /// Converts a valid logical value to a boolean.
   ///
-  /// Throws an exception if the value is invalid.
+  /// Throws a LogicValueConversionException if the value is invalid.
   bool toBool() {
     if (!isValid) {
       throw LogicValueConversionException(

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -111,7 +111,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
                 ? _LogicValueEnum.x
                 : this == LogicValue.z
                     ? _LogicValueEnum.z
-                    : throw Exception('Failed to convert.');
+                    : throw LogicValueConversionException('Failed to convert.');
   }
 
   /// Creates a [LogicValue] of [val] using [of], but attempts to infer the
@@ -944,7 +944,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
 
   String _bitString() {
     if (width != 1) {
-      throw Exception(
+      throw LogicValueConversionException(
           'Cannot convert value of width $width to a single bit value.');
     }
     return this == LogicValue.x
@@ -1100,10 +1100,12 @@ abstract class LogicValue implements Comparable<LogicValue> {
   /// Throws an exception if the value is invalid.
   bool toBool() {
     if (!isValid) {
-      throw Exception('Cannot convert value "$this" to bool');
+      throw LogicValueConversionException(
+          'Cannot convert value "$this" to bool');
     }
     if (width != 1) {
-      throw Exception('Only single bit values can be converted to a bool,'
+      throw LogicValueConversionException(
+          'Only single bit values can be converted to a bool,'
           ' but found width $width in $this');
     }
     return this == LogicValue.one;

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -729,7 +729,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
   ///
   /// If the format of then length/radix-encoded string is not completely parsed
   /// an exception will be thrown.  This can be caused by illegal characters
-  /// in the string or too short or too long of a value string.
+  /// in the string or too long of a value string.
   ///
   ///  Strings created by [toRadixString] are parsed by [ofRadixString].
   ///
@@ -795,19 +795,25 @@ abstract class LogicValue implements Comparable<LogicValue> {
           while (cnt < binaryChunk.length - 1 && binaryChunk[cnt++] == '0') {}
           shorter = cnt - 1;
         } else {
-          final leadChar = compressedStr[0];
-          if (RegExp('[xXzZ]').hasMatch(leadChar)) {
-            shorter = span - 1;
-          } else {
-            if (radix == 10) {
-              shorter = binaryLength -
-                  BigInt.parse(compressedStr, radix: 10)
-                      .toRadixString(2)
-                      .length;
+          if (compressedStr.isNotEmpty) {
+            final leadChar = compressedStr[0];
+            if (RegExp('[xXzZ]').hasMatch(leadChar)) {
+              shorter = span - 1;
             } else {
-              shorter = span -
-                  BigInt.parse(leadChar, radix: radix).toRadixString(2).length;
+              if (radix == 10) {
+                shorter = binaryLength -
+                    BigInt.parse(compressedStr, radix: 10)
+                        .toRadixString(2)
+                        .length;
+              } else {
+                shorter = span -
+                    BigInt.parse(leadChar, radix: radix)
+                        .toRadixString(2)
+                        .length;
+              }
             }
+          } else {
+            shorter = 0;
           }
         }
         if (binaryLength - shorter > specifiedLength) {
@@ -827,10 +833,15 @@ abstract class LogicValue implements Comparable<LogicValue> {
             .map((m) => List.generate(span, (s) => m.$2.start * span + s))
             .expand((ze) => ze);
 
-        final intValue = BigInt.parse(
-                _reverse(noBinariesStr.replaceAll(RegExp('[xXzZ]'), '0')),
-                radix: radix)
-            .toUnsigned(specifiedLength);
+        final BigInt intValue;
+        if (noBinariesStr.isNotEmpty) {
+          intValue = BigInt.parse(
+                  _reverse(noBinariesStr.replaceAll(RegExp('[xXzZ]'), '0')),
+                  radix: radix)
+              .toUnsigned(specifiedLength);
+        } else {
+          intValue = BigInt.zero;
+        }
         final logicValList = List<LogicValue>.from(
             LogicValue.ofString(intValue.toRadixString(2))
                 .zeroExtend(specifiedLength)

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2088,6 +2088,16 @@ void main() {
                 sepChar: '.'),
             equals(lv));
       }
+      try {
+        lv.toRadixString(sepChar: 'q');
+      } on Exception catch (e) {
+        expect(e, isA<LogicValueConversionException>());
+      }
+      try {
+        lv.toRadixString(radix: 14);
+      } on Exception catch (e) {
+        expect(e, isA<LogicValueConversionException>());
+      }
     });
     test('radixString space separators', () {
       final lv = LogicValue.ofRadixString("10'b10 0010 0111", sepChar: ' ');
@@ -2097,7 +2107,7 @@ void main() {
       try {
         LogicValue.ofRadixString("10'b10 0010_0111");
       } on Exception catch (e) {
-        expect(e.runtimeType, LogicValueConstructionException);
+        expect(e, isA<LogicValueConstructionException>());
       }
     });
 
@@ -2105,7 +2115,7 @@ void main() {
       try {
         LogicValue.ofRadixString("10'b10q0010q0111", sepChar: 'q');
       } on Exception catch (e) {
-        expect(e.runtimeType, LogicValueConstructionException);
+        expect(e, isA<LogicValueConstructionException>());
       }
     });
 
@@ -2113,8 +2123,10 @@ void main() {
       try {
         LogicValue.ofRadixString("10'b10_0010_0111_0000");
       } on Exception catch (e) {
-        expect(e.runtimeType, LogicValueConstructionException);
+        expect(e, isA<LogicValueConstructionException>());
       }
+      // Try the shortest possible input
+      LogicValue.ofRadixString("10'b");
     });
 
     test('radixString leading Z', () {

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2079,6 +2079,44 @@ void main() {
       }
     });
 
+    test('radixString round trip with alternate separation character', () {
+      final lv = LogicValue.ofRadixString("10'b00.0010.0111", sepChar: '.');
+
+      for (final i in [2, 4, 8, 10, 16]) {
+        expect(
+            LogicValue.ofRadixString(lv.toRadixString(radix: i, sepChar: '.'),
+                sepChar: '.'),
+            equals(lv));
+      }
+    });
+    test('radixString space separators', () {
+      final lv = LogicValue.ofRadixString("10'b10 0010 0111", sepChar: ' ');
+      expect(lv.toInt(), equals(551));
+    });
+    test('radixString bad separator', () {
+      try {
+        LogicValue.ofRadixString("10'b10 0010_0111");
+      } on Exception catch (e) {
+        expect(e.runtimeType, LogicValueConstructionException);
+      }
+    });
+
+    test('radixString illegal separator', () {
+      try {
+        LogicValue.ofRadixString("10'b10q0010q0111", sepChar: 'q');
+      } on Exception catch (e) {
+        expect(e.runtimeType, LogicValueConstructionException);
+      }
+    });
+
+    test('radixString bad length', () {
+      try {
+        LogicValue.ofRadixString("10'b10_0010_0111_0000");
+      } on Exception catch (e) {
+        expect(e.runtimeType, LogicValueConstructionException);
+      }
+    });
+
     test('radixString leading Z', () {
       final lv = LogicValue.ofRadixString("10'bzz_zzz1_1011");
       expect(lv.toRadixString(), equals("10'bzz_zzz1_1011"));

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2067,8 +2067,8 @@ void main() {
     });
 
     test('radixString leading zero', () {
-      final lv = LogicValue.ofRadixString("10'b00 0010 0111");
-      expect(lv.toRadixString(), equals("10'b10 0111"));
+      final lv = LogicValue.ofRadixString("10'b00_0010_0111");
+      expect(lv.toRadixString(), equals("10'b10_0111"));
       expect(lv.toRadixString(radix: 4), equals("10'q213"));
       expect(lv.toRadixString(radix: 8), equals("10'o47"));
       expect(lv.toRadixString(radix: 10), equals("10'd39"));
@@ -2080,8 +2080,8 @@ void main() {
     });
 
     test('radixString leading Z', () {
-      final lv = LogicValue.ofRadixString("10'bzz zzz1 1011");
-      expect(lv.toRadixString(), equals("10'bzz zzz1 1011"));
+      final lv = LogicValue.ofRadixString("10'bzz_zzz1_1011");
+      expect(lv.toRadixString(), equals("10'bzz_zzz1_1011"));
       expect(lv.toRadixString(radix: 4), equals("10'qZZ<z1>23"));
       expect(lv.toRadixString(radix: 8), equals("10'oZZ<z11>3"));
       expect(lv.toRadixString(radix: 16), equals("10'hZ<zzz1>b"));
@@ -2091,8 +2091,8 @@ void main() {
       }
     });
     test('radixString small leading radix character', () {
-      final lv = LogicValue.ofRadixString("10'b10 1010 0111");
-      expect(lv.toRadixString(radix: 4), equals("10'q2 2213"));
+      final lv = LogicValue.ofRadixString("10'b10_1010_0111");
+      expect(lv.toRadixString(radix: 4), equals("10'q2_2213"));
       expect(lv.toRadixString(radix: 8), equals("10'o1247"));
       expect(lv.toRadixString(radix: 10), equals("10'd679"));
       expect(lv.toRadixString(radix: 16), equals("10'h2A7"));


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Added an option to LogicValue.toRadixString and .ofRadixString to use '_' as a default separator, but allow
for the user to specify a different separator.

## Related Issue(s)

#534 

## Testing

Converted tests to use _ as separator after testing with sepChar argument.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes.  Previously output radixStrings will not parse by default as they will have spaces.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Documentation in the class code is now up to date with this change.
