### PR TITLE
Fix bug in SSA discovery when `LogicStructure`s are used

### DIFF
--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -137,6 +137,16 @@ class Combinational extends Always {
       } else {
         toParse.addAll(tpi.dstConnections);
       }
+
+      //TODO: this fixes a BUG!  Need to make tests that reproduce!
+      if (tpi.parentStructure != null) {
+        toParse.add(tpi.parentStructure!);
+      }
+
+      //TODO: is this necessary to fix a similar bug?
+      if (tpi is LogicStructure) {
+        toParse.addAll(tpi.elements);
+      }
     }
   }
 

--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // combinational.dart
@@ -138,12 +138,16 @@ class Combinational extends Always {
         toParse.addAll(tpi.dstConnections);
       }
 
-      //TODO: this fixes a BUG!  Need to make tests that reproduce!
+      // This is critical to make sure we are notifying downstream SSA's even
+      // if they are driven as a result of being a part of a modified structure.
       if (tpi.parentStructure != null) {
         toParse.add(tpi.parentStructure!);
       }
 
-      //TODO: is this necessary to fix a similar bug?
+      // This is probably unnecessary, as the SSA would not allow someone to
+      // reference an element of a structure without separately SSA'ing it.
+      // However, leaving this in here just in case (probably negligible perf
+      // impact).
       if (tpi is LogicStructure) {
         toParse.addAll(tpi.elements);
       }

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pipeline_test.dart
@@ -247,7 +247,7 @@ void main() {
           throwsRangeError);
     });
 
-    test('getting unregisterd signal on pipeline is error', () {
+    test('getting unregistered signal on pipeline is error', () {
       expect(
           () => Pipeline(Logic(), signals: [
                 Logic()


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a bug in the way that the `Combinational.ssa` was discovering/notifying signals of drivers when `LogicStructure`s were split apart and rejoined.  This PR fixes that bug by expanding the search to the `parentStructure` signals being searched.  It also expands the search to elements of `LogicStructure`s just in case, even though it appears that wouldn't be a problem.

## Related Issue(s)

N/A

## Testing

Added new tests that reproduce the issue.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
