### PR TITLE
Fix bug where `Module.build` didn't follow through structs containing ports properly, plus improved debug messaging.

### DIFF
--- a/lib/src/exceptions/module/port_rules_violation_exception.dart
+++ b/lib/src/exceptions/module/port_rules_violation_exception.dart
@@ -7,31 +7,44 @@
 // 2024 April 12
 // Author: Max Korbel <max.korbel@intel.com>
 
+import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 
 /// An [Exception] thrown when a port is not following the input/output rules.
 class PortRulesViolationException extends RohdException {
+  final Module module;
+
   /// Constructs a new [Exception] for when port rules are not present on
   /// [module] for [signal].
-  PortRulesViolationException(Module module, String signal,
+  PortRulesViolationException(this.module, String signal,
       [String additionalMessage = ''])
-      : super('Violation of input/output rules in $module on $signal.'
+      : super('Violation of input/output rules'
+            ' in module $module on signal $signal.'
             ' Logic within a Module should only communicate outside of itself'
             ' by consuming inputs/inouts and'
             ' driving outputs/inouts of that itself.'
             ' See https://intel.github.io/rohd-website/docs/modules/'
             ' for more information. $additionalMessage');
 
+  //TODO doc
+  @internal
   PortRulesViolationException.trace({
-    required Module module,
+    required this.module,
     required Logic signal,
     required PortRulesViolationException lowerException,
-  }) : super('''
-$lowerException
-@ Module $module
-  on ${_getSignalDescription(signal)} \t $signal
-  of ${signal.parentModule == null ? 'undetermined sub-module' : 'sub-module\t${signal.parentModule!}'}''');
+    required String traceDirection,
+  }) : super([
+          '$lowerException',
+          if (module != lowerException.module)
+            '@ Module $module \t [tracing $traceDirection]'
+          else
+            '= Module "${module.name}" \t [tracing $traceDirection]',
+          '  on ${_getSignalDescription(signal)} \t $signal',
+          if (signal.parentModule != module)
+            '  of ${signal.parentModule == null ? 'undetermined sub-module' : 'sub-module\t${signal.parentModule!}'}',
+        ].join('\n'));
 
+  //TODO doc
   static String _getSignalDescription(Logic signal) {
     if (signal.isPort) {
       if (signal.isInput) {

--- a/lib/src/exceptions/module/port_rules_violation_exception.dart
+++ b/lib/src/exceptions/module/port_rules_violation_exception.dart
@@ -12,6 +12,7 @@ import 'package:rohd/rohd.dart';
 
 /// An [Exception] thrown when a port is not following the input/output rules.
 class PortRulesViolationException extends RohdException {
+  /// The [module] where the violation occurred during build.
   final Module module;
 
   /// Constructs a new [Exception] for when port rules are not present on
@@ -26,7 +27,8 @@ class PortRulesViolationException extends RohdException {
             ' See https://intel.github.io/rohd-website/docs/modules/'
             ' for more information. $additionalMessage');
 
-  //TODO doc
+  /// Generates a traceable stack of messages from an previous [lowerException]
+  /// to help debug the issue.
   @internal
   PortRulesViolationException.trace({
     required this.module,
@@ -36,15 +38,25 @@ class PortRulesViolationException extends RohdException {
   }) : super([
           '$lowerException',
           if (module != lowerException.module)
+            // only update with the full `toString` of the module when its new
             '@ Module $module \t [tracing $traceDirection]'
           else
             '= Module "${module.name}" \t [tracing $traceDirection]',
           '  on ${_getSignalDescription(signal)} \t $signal',
           if (signal.parentModule != module)
-            '  of ${signal.parentModule == null ? 'undetermined sub-module' : 'sub-module\t${signal.parentModule!}'}',
+            // only call it a sub-module if it's not itself
+            '  of ${_getSubModuleDescription(signal.parentModule)}',
         ].join('\n'));
 
-  //TODO doc
+  /// A helper function to convert a [signalParentModule] into a helpful message
+  /// for [PortRulesViolationException.trace] errors.
+  static String _getSubModuleDescription(Module? signalParentModule) =>
+      signalParentModule == null
+          ? 'undetermined sub-module'
+          : 'sub-module\t$signalParentModule';
+
+  /// A helper function to convert [signal] into a helpful message for
+  /// [PortRulesViolationException.trace] errors.
   static String _getSignalDescription(Logic signal) {
     if (signal.isPort) {
       if (signal.isInput) {

--- a/lib/src/exceptions/module/port_rules_violation_exception.dart
+++ b/lib/src/exceptions/module/port_rules_violation_exception.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // port_rules_violation_exception.dart
@@ -16,8 +16,33 @@ class PortRulesViolationException extends RohdException {
   PortRulesViolationException(Module module, String signal,
       [String additionalMessage = ''])
       : super('Violation of input/output rules in $module on $signal.'
-            ' Logic within a Module should only consume inputs/inouts and'
-            ' drive outputs/inouts of that Module.'
+            ' Logic within a Module should only communicate outside of itself'
+            ' by consuming inputs/inouts and'
+            ' driving outputs/inouts of that itself.'
             ' See https://intel.github.io/rohd-website/docs/modules/'
             ' for more information. $additionalMessage');
+
+  PortRulesViolationException.trace({
+    required Module module,
+    required Logic signal,
+    required PortRulesViolationException lowerException,
+  }) : super('''
+$lowerException
+@ Module $module
+  on ${_getSignalDescription(signal)} \t $signal
+  of ${signal.parentModule == null ? 'undetermined sub-module' : 'sub-module\t${signal.parentModule!}'}''');
+
+  static String _getSignalDescription(Logic signal) {
+    if (signal.isPort) {
+      if (signal.isInput) {
+        return 'input  port';
+      } else if (signal.isOutput) {
+        return 'output port';
+      } else {
+        return 'inout  port';
+      }
+    } else {
+      return 'internal signal';
+    }
+  }
 }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -502,8 +502,10 @@ abstract class Module {
         }
       }
     } on PortRulesViolationException catch (e) {
+      //TODO: cleanup these
       // print('Trace: $this $signal (${signal.parentModule})');
       // rethrow;
+
       throw PortRulesViolationException.trace(
           module: this,
           signal: signal,
@@ -608,11 +610,19 @@ abstract class Module {
           }
         }
 
-        for (final srcConnection in signal.srcConnections) {
-          await _traceOutputForModuleContents(srcConnection);
+        if (signal is LogicStructure) {
+          for (final elem in signal.elements) {
+            await _traceOutputForModuleContents(elem,
+                dontAddSignal: elem.isPort);
+          }
+        } else {
+          for (final srcConnection in signal.srcConnections) {
+            await _traceOutputForModuleContents(srcConnection);
+          }
         }
       }
     } on PortRulesViolationException catch (e) {
+      //TODO cleanup
       // print('Trace: $this $signal (${signal.parentModule})');
       // rethrow;
       throw PortRulesViolationException.trace(

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -880,8 +880,7 @@ abstract class Module {
   String toString() => [
         '"$name" ($definitionName)  : ',
         if (_inputs.isNotEmpty) '${_inputs.keys}',
-        if (_inputs.isNotEmpty && _outputs.isNotEmpty) '=>',
-        if (_outputs.isNotEmpty) '${_outputs.keys}',
+        if (_outputs.isNotEmpty) '=> ${_outputs.keys}',
         if (_inOuts.isNotEmpty) '; ${_inOuts.keys}'
       ].join(' ');
 

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -164,18 +164,27 @@ abstract class Module {
 
   /// Returns true iff [signal] is the same [Logic] as the [input] port of this
   /// [Module] with the same name.
+  ///
+  /// Note that if signal is a [LogicStructure] which contains an [input] port,
+  /// but is not itself a port, this will return false.
   bool isInput(Logic signal) =>
       _inputs[signal.name] == signal ||
       (signal.isArrayMember && isInput(signal.parentStructure!));
 
   /// Returns true iff [signal] is the same [Logic] as the [output] port of this
   /// [Module] with the same name.
+  ///
+  /// Note that if signal is a [LogicStructure] which contains an [output] port,
+  /// but is not itself a port, this will return false.
   bool isOutput(Logic signal) =>
       _outputs[signal.name] == signal ||
       (signal.isArrayMember && isOutput(signal.parentStructure!));
 
   /// Returns true iff [signal] is the same [Logic] as the [inOut] port of this
   /// [Module] with the same name.
+  ///
+  /// Note that if signal is a [LogicStructure] which contains an [inOut] port,
+  /// but is not itself a port, this will return false.
   bool isInOut(Logic signal) =>
       _inOuts[signal.name] == signal ||
       (signal.isArrayMember && isInOut(signal.parentStructure!));
@@ -502,10 +511,6 @@ abstract class Module {
         }
       }
     } on PortRulesViolationException catch (e) {
-      //TODO: cleanup these
-      // print('Trace: $this $signal (${signal.parentModule})');
-      // rethrow;
-
       throw PortRulesViolationException.trace(
           module: this,
           signal: signal,
@@ -622,9 +627,6 @@ abstract class Module {
         }
       }
     } on PortRulesViolationException catch (e) {
-      //TODO cleanup
-      // print('Trace: $this $signal (${signal.parentModule})');
-      // rethrow;
       throw PortRulesViolationException.trace(
           module: this,
           signal: signal,

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -448,16 +448,16 @@ abstract class Module {
           // handle expanding the search for arrays
           if (signal.parentStructure != null) {
             await _traceInputForModuleContents(signal.parentStructure!,
-                dontAddSignal: dontAddSignal);
+                dontAddSignal: signal.isPort);
             await _traceOutputForModuleContents(signal.parentStructure!,
                 dontAddSignal: signal.isPort);
           }
           if (signal is LogicStructure) {
             for (final elem in signal.elements) {
               await _traceInputForModuleContents(elem,
-                  dontAddSignal: dontAddSignal);
+                  dontAddSignal: elem.isPort);
               await _traceOutputForModuleContents(elem,
-                  dontAddSignal: signal.isPort);
+                  dontAddSignal: elem.isPort);
             }
           }
 
@@ -507,7 +507,10 @@ abstract class Module {
       // print('Trace: $this $signal (${signal.parentModule})');
       // rethrow;
       throw PortRulesViolationException.trace(
-          module: this, signal: signal, lowerException: e);
+          module: this,
+          signal: signal,
+          lowerException: e,
+          traceDirection: 'from inputs');
     }
   }
 
@@ -530,8 +533,8 @@ abstract class Module {
       final subModuleParent = subModule?.parent;
 
       if (!dontAddSignal && signal.isInput) {
-        // somehow we have reached the input of a module which is not a submodule
-        // nor this module, bad!
+        // somehow we have reached the input of a module which is not a
+        // submodule nor this module, bad!
         throw PortRulesViolationException(this, signal.toString());
       }
 
@@ -574,16 +577,16 @@ abstract class Module {
           // handle expanding the search for arrays
           if (signal.parentStructure != null) {
             await _traceOutputForModuleContents(signal.parentStructure!,
-                dontAddSignal: dontAddSignal);
+                dontAddSignal: signal.isPort);
             await _traceInputForModuleContents(signal.parentStructure!,
                 dontAddSignal: signal.isPort);
           }
           if (signal is LogicStructure) {
             for (final elem in signal.elements) {
               await _traceOutputForModuleContents(elem,
-                  dontAddSignal: dontAddSignal);
+                  dontAddSignal: elem.isPort);
               await _traceInputForModuleContents(elem,
-                  dontAddSignal: signal.isPort);
+                  dontAddSignal: elem.isPort);
             }
           }
 
@@ -615,7 +618,10 @@ abstract class Module {
       // print('Trace: $this $signal (${signal.parentModule})');
       // rethrow;
       throw PortRulesViolationException.trace(
-          module: this, signal: signal, lowerException: e);
+          module: this,
+          signal: signal,
+          lowerException: e,
+          traceDirection: 'from outputs');
     }
   }
 

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -20,8 +20,6 @@ import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/timestamper.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
 
-//TODO: BUG! an *output* of a module (e.g. mux) which is an ELEMENT of a LogicStructure
-
 /// Represents a synthesizable hardware entity with clearly defined interface
 /// boundaries.
 ///
@@ -404,8 +402,8 @@ abstract class Module {
       final subModuleParent = subModule?.parent;
 
       if (!dontAddSignal && signal.isOutput) {
-        // somehow we have reached the output of a module which is not a submodule
-        // nor this module, bad!
+        // somehow we have reached the output of a module which is not a
+        // submodule nor this module, bad!
         throw PortRulesViolationException(this, signal.toString());
       }
 
@@ -866,7 +864,6 @@ abstract class Module {
     return inOutArr;
   }
 
-  //TODO: test the print looks good in different scenarios
   @override
   String toString() => [
         '"$name" ($definitionName)  : ',

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -282,6 +282,7 @@ class LogicStructure implements Logic {
   @override
   LogicStructure? _parentStructure;
 
+  //TODO: should structs which contain part of a port indicate they are ports?
   @override
   late final bool isInput = parentModule?.isInput(this) ?? false;
 

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -282,7 +282,6 @@ class LogicStructure implements Logic {
   @override
   LogicStructure? _parentStructure;
 
-  //TODO: should structs which contain part of a port indicate they are ports?
   @override
   late final bool isInput = parentModule?.isInput(this) ?? false;
 

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // module_test.dart

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -162,6 +162,34 @@ class TopStructInputWrap extends Module {
   }
 }
 
+class StructWithInoutAsElementMod extends Module {
+  Logic get o => SimpleLogicStructure()..gets(output('o'));
+  StructWithInoutAsElementMod(LogicNet a, LogicNet b, LogicNet o)
+      : super(name: 'structwportaselem_inout') {
+    a = addInOut('a', a);
+    b = addInOut('b', b);
+
+    final s = SimpleLogicStructure(
+      a,
+      LogicNet(name: 'floaty_mc_float_face'), // floating net
+    );
+
+    addInOut('o', o, width: s.width) <= s;
+  }
+}
+
+class TopStructInoutWrap extends Module {
+  TopStructInoutWrap(LogicNet a, LogicNet b, LogicNet o)
+      : super(name: 'top_struct_wrap_inout') {
+    a = addInOut('a', a);
+    b = addInOut('b', b);
+
+    o = addInOut('o', o, width: 2);
+
+    StructWithInoutAsElementMod(a, b, o);
+  }
+}
+
 class MissingInputRegistrationModule extends Module {
   Logic get b => output('b');
   MissingInputRegistrationModule(Logic a) : super(name: 'missing_input_mod') {
@@ -267,6 +295,16 @@ void main() {
       final sv = mod.generateSynth();
 
       expect(sv, contains("assign o = {1'h1,a}"));
+    });
+
+    test('inout port as struct element trace', () async {
+      final mod =
+          TopStructInoutWrap(LogicNet(), LogicNet(), LogicNet(width: 2));
+      await mod.build();
+
+      final sv = mod.generateSynth();
+
+      expect(sv, contains('net_connect (o, ({floaty_mc_float_face,a}));'));
     });
   });
 

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -289,11 +289,6 @@ void main() {
     expect(mod.build, throwsA(isA<InvalidHierarchyException>()));
   });
 
-  test('multiple location hierarchy', () async {
-    final mod = MultipleLocation();
-    expect(mod.build, throwsA(isA<PortRulesViolationException>()));
-  });
-
   group('logic structure with ports', () {
     for (final disconnectOutputs in [false, true]) {
       test(
@@ -363,6 +358,11 @@ void main() {
   });
 
   group('trace errors', () {
+    test('multiple location hierarchy', () async {
+      final mod = MultipleLocation();
+      expect(mod.build, throwsA(isA<PortRulesViolationException>()));
+    });
+
     test('correct description of path', () async {
       final mod = MissingInputRegistrationTopModule(Logic());
 

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -211,11 +211,8 @@ void main() {
     await mod.build();
 
     final sv = mod.generateSynth();
-    print(sv);
-    //TODO: add some checking!
 
-    // expect(sv, contains('assign o1 = mux_out;'));
-    // expect(sv, contains('assign o2 = b;'));
+    expect(sv, contains("assign o = {1'h1,(a ? 1'h0 : 1'h1)}"));
   });
 
   test('array concat per element builds and finds sigs', () async {

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -114,7 +114,8 @@ class SimpleLogicStructure extends LogicStructure {
 
 class StructWithPortAsElementMod extends Module {
   Logic get o => SimpleLogicStructure()..gets(output('o'));
-  StructWithPortAsElementMod(Logic a, Logic b) {
+  StructWithPortAsElementMod(Logic a, Logic b)
+      : super(name: 'structwportaselem') {
     a = addInput('a', a);
     b = addInput('b', b);
 
@@ -127,8 +128,8 @@ class StructWithPortAsElementMod extends Module {
   }
 }
 
-class TopStructyWrap extends Module {
-  TopStructyWrap(Logic a, Logic b) {
+class TopStructWrap extends Module {
+  TopStructWrap(Logic a, Logic b) : super(name: 'top_struct_wrap') {
     a = addInput('a', a);
     b = addInput('b', b);
 
@@ -206,11 +207,13 @@ void main() {
   });
 
   test('logic structure with output port as element trace', () async {
-    final mod = TopStructyWrap(Logic(), Logic());
+    final mod = TopStructWrap(Logic(), Logic());
     await mod.build();
 
     final sv = mod.generateSynth();
     print(sv);
+    //TODO: add some checking!
+
     // expect(sv, contains('assign o1 = mux_out;'));
     // expect(sv, contains('assign o2 = b;'));
   });


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR has 2 main components:
- A fix for a bug which causes "trace errors" (`PortRulesViolationException`) when a `LogicStructure` contains a port of a `Module`.
- A greatly improved error message for `PortRulesViolationException`s which shows the full stack of signals that led to the exception, which should make it *much* easier to debug these types of issues.

Thank you to @desmonddak for finding this issue during development of https://github.com/intel/rohd-hcl/pull/152

An example of the new format for a tracing error (in this case, a missing `addInput`):
```
Violation of input/output rules in module "missing_input_mod" (MissingInputRegistrationModule)  :  (b) on signal Logic(1): a. Logic within a Module should only communicate outside of itself by consuming inputs/inouts and driving outputs/inouts of that itself. See https://intel.github.io/rohd-website/docs/modules/ for more information. 
= Module "missing_input_mod" 	 [tracing from outputs]
  on input  port 	 Logic(1): a
  of sub-module	"top" (MissingInputRegistrationTopModule)  :  (a) => (b)
= Module "missing_input_mod" 	 [tracing from outputs]
  on input  port 	 Logic(1): _a
  of sub-module	"not" (NotGate)  :  (_a) => (_a_b)
= Module "missing_input_mod" 	 [tracing from outputs]
  on output port 	 Logic(1): _a_b
  of sub-module	"not" (NotGate)  :  (_a) => (_a_b)
= Module "missing_input_mod" 	 [tracing from outputs]
  on output port 	 Logic(1): b
@ Module "top" (MissingInputRegistrationTopModule)  :  (a) => (b) 	 [tracing from outputs]
  on output port 	 Logic(1): b
  of sub-module	"missing_input_mod" (MissingInputRegistrationModule)  :  (b)
= Module "top" 	 [tracing from outputs]
  on output port 	 Logic(1): b
```

There's also some doc updates and improvements in `toString`s and messages.

## Related Issue(s)

N/A

## Testing

Added tests to cover the scenarios

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, though messages from the exception have changed

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No