### PR TITLE
fix radix10 issue in toRadixString

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -665,11 +665,16 @@ abstract class LogicValue implements Comparable<LogicValue> {
       final radixString =
           toBigInt().toUnsigned(width).toRadixString(radix).toUpperCase();
       reversedStr = _reverse(radixString);
-    } else {
-      if (radix == 10) {
-        throw LogicValueConversionException(
-            'Cannot support decimal strings with invalid bits');
+    } else if (radix == 10) {
+      // throw LogicValueConversionException(
+      //     'Cannot support decimal strings with invalid bits');
+      final span = (width * math.log(2) / math.log(radix)).floor();
+      if (toRadixString().contains(RegExp('[xX]'))) {
+        reversedStr = 'X' * span;
+      } else {
+        reversedStr = 'Z' * span;
       }
+    } else {
       final span = (math.log(radix) / math.log(2)).ceil();
       final extendedStr =
           LogicValue.of(this, width: span * (width / span).ceil());
@@ -801,8 +806,12 @@ abstract class LogicValue implements Comparable<LogicValue> {
               shorter = span - 1;
             } else {
               if (radix == 10) {
-                shorter = binaryLength -
-                    BigInt.parse(compressedStr, radix: 10)
+                // shorter = binaryLength -
+                //     BigInt.parse(compressedStr, radix: 10)
+                //         .toRadixString(2)
+                //         .length;
+                shorter = span -
+                    BigInt.parse(leadChar, radix: radix)
                         .toRadixString(2)
                         .length;
               } else {
@@ -816,7 +825,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
             shorter = 0;
           }
         }
-        if (binaryLength - shorter > specifiedLength) {
+        if ((radix != 10) & (binaryLength - shorter > specifiedLength)) {
           throw LogicValueConstructionException(
               'ofRadixString: cannot represent '
               '$compressedStr in $specifiedLength');

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -666,8 +666,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
           toBigInt().toUnsigned(width).toRadixString(radix).toUpperCase();
       reversedStr = _reverse(radixString);
     } else if (radix == 10) {
-      // throw LogicValueConversionException(
-      //     'Cannot support decimal strings with invalid bits');
       final span = (width * math.log(2) / math.log(radix)).floor();
       if (toRadixString().contains(RegExp('[xX]'))) {
         reversedStr = 'X' * span;
@@ -805,21 +803,8 @@ abstract class LogicValue implements Comparable<LogicValue> {
             if (RegExp('[xXzZ]').hasMatch(leadChar)) {
               shorter = span - 1;
             } else {
-              if (radix == 10) {
-                // shorter = binaryLength -
-                //     BigInt.parse(compressedStr, radix: 10)
-                //         .toRadixString(2)
-                //         .length;
-                shorter = span -
-                    BigInt.parse(leadChar, radix: radix)
-                        .toRadixString(2)
-                        .length;
-              } else {
-                shorter = span -
-                    BigInt.parse(leadChar, radix: radix)
-                        .toRadixString(2)
-                        .length;
-              }
+              shorter = span -
+                  BigInt.parse(leadChar, radix: radix).toRadixString(2).length;
             }
           } else {
             shorter = 0;

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2140,6 +2140,25 @@ void main() {
             LogicValue.ofRadixString(lv.toRadixString(radix: i)), equals(lv));
       }
     });
+    test('radixString decimal case', () {
+      {
+        final lv = LogicValue.ofRadixString("12'bzz_zzz1_1011");
+        final ds = lv.toRadixString(radix: 10);
+        final dlv = LogicValue.ofRadixString(ds);
+        final ds2 = dlv.toRadixString(radix: 10);
+        expect(ds, equals(ds2));
+        expect(ds, equals("12'dZZZ"));
+      }
+      {
+        final lv = LogicValue.ofRadixString("12'bzz_zzx1_1011");
+        final ds = lv.toRadixString(radix: 10);
+        final dlv = LogicValue.ofRadixString(ds);
+        final ds2 = dlv.toRadixString(radix: 10);
+        expect(ds, equals(ds2));
+        expect(ds, equals("12'dXXX"));
+      }
+    });
+
     test('radixString small leading radix character', () {
       final lv = LogicValue.ofRadixString("10'b10_1010_0111");
       expect(lv.toRadixString(radix: 4), equals("10'q2_2213"));


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Bug fix to enable LogicValue.toRadixString(radix:10) to return a string with X or Z instead of throwing.

## Related Issue(s)

#542 

## Testing

Tests added with X and Z in their bit values, tested to ensure a string with appropriate X or Z is returned.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.  Throwing was not an expected behavior.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

we don't have documentation on toRadixString except in code.  This will have to be included as we add more extensive documentation to the user guide:  best ways of printing LogicValue for debug.
