### PR TITLE
Bug fix for withSet in LogicStructure.

### DIFF
--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_structure.dart

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_structure.dart

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -372,7 +372,7 @@ class LogicStructure implements Logic {
                 max(startIndex - index, 0),
                 update.getRange(
                   max(index - startIndex, 0),
-                  min(index - startIndex + elementWidth, elementWidth),
+                  min(index - startIndex + elementWidth, update.width),
                 ));
       } else {
         newElement <= element;

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_structure_test.dart

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -200,6 +200,13 @@ void main() {
 
       expect(orig.clone(name: 'newName').name, 'newName');
     });
+
+    test('tricky withSet', () async {
+      // first field has width of 72 so this is the starting point
+      // second field has a width of 12
+      // try a withSet of a subset of the second field
+      MyFancyStruct().withSet(72, Logic(width: 4));
+    });
   });
 
   group('LogicStructures with modules', () {

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_structure_test.dart


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Bug in LogicStructure's withSet method where if the "update" value's width is less than the given overlapping field's width within the structure (per the start index of the set), build would crash because the out of bounds guard on the "update" value was incorrectly ignoring the "update" field's width and instead just using the overlapping field's width.

## Related Issue(s)

N/A

## Testing

Added a single unit test to logic_structure_test that exercises the bug.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Backwards compatible.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No need for doc.
