### PR TITLE
Fix bug where non-async flop generates async flop

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v11
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.6.2 # downgrade pending https://github.com/dart-lang/dartdoc/issues/3996
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -81,6 +83,8 @@ jobs:
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.6.2 # downgrade pending https://github.com/dart-lang/dartdoc/issues/3996
 
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -122,7 +122,6 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - parameter_assignments
@@ -211,7 +210,6 @@ linter:
     - unnecessary_to_list_in_spreads
     # - unreachable_from_main
     - unrelated_type_equality_checks
-    - unsafe_html
     - use_build_context_synchronously
     - use_colored_box
     - use_decorated_box

--- a/lib/src/modules/conditionals/flop.dart
+++ b/lib/src/modules/conditionals/flop.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // flop.dart
@@ -184,7 +184,7 @@ class FlipFlop extends Module with SystemVerilog {
 
     final triggerString = [
       clk,
-      if (reset != null) reset,
+      if (reset != null && asyncReset) reset,
     ].map((e) => 'posedge $e').join(' or ');
 
     final svBuffer = StringBuffer('always_ff @($triggerString) ');

--- a/lib/src/signals/wire_net.dart
+++ b/lib/src/signals/wire_net.dart
@@ -215,6 +215,9 @@ class _WireNetBlasted extends _Wire implements _WireNet {
   LogicValue get value => LogicValue.ofIterable(_wires.map((e) => e.value));
 
   @override
+  LogicValue get _currentValue => throw UnsupportedError('Unnecessary');
+
+  @override
   set _currentValue(LogicValue newValue) =>
       // this is delegated away via calling `value` getter
       throw UnsupportedError('Unnecessary');


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

In #533 a bug was included along with implementation of the feature allowing the `asyncReset` flag to be added to `flop` and `FlipFlop` which caused generated SystemVerilog to include an asynchronous reset, regardless of whether `asyncReset` was set to true or false.

This PR fixes the bug and adds tests which check the functionality of non-async flops to ensure they are not asynchronously triggered in either ROHD or SystemVerilog simulation.  This testing was missing in the original PR, which led to the escape.

## Related Issue(s)

Related to #533

## Testing

Added new tests which failed without the fix

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
