### PR TITLE
Fix bug in `LogicStructure.previousValue`

### DIFF
--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -328,8 +328,12 @@ class LogicStructure implements Logic {
       elements.map((e) => e.value).toList(growable: false).rswizzle();
 
   @override
-  LogicValue? get previousValue =>
-      elements.map((e) => e.value).toList(growable: false).rswizzle();
+  LogicValue? get previousValue => elements.any((e) => e.previousValue == null)
+      ? null
+      : elements
+          .map((e) => e.previousValue!)
+          .toList(growable: false)
+          .rswizzle();
 
   @override
   late final int width = elements.map((e) => e.width).sum;

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -261,4 +261,29 @@ void main() {
       SimCompare.checkIverilogVector(mod, vectors);
     });
   });
+
+  test('logicstructure value and previous value', () async {
+    final s = MyStruct();
+
+    final val1 = LogicValue.ofInt(1, 2);
+    final val2 = LogicValue.ofInt(2, 2);
+
+    s.put(val1);
+
+    expect(s.value, val1);
+    expect(s.previousValue, isNull);
+
+    var checkRan = false;
+
+    Simulator.registerAction(10, () {
+      s.put(val2);
+      expect(s.value, val2);
+      expect(s.previousValue, val1);
+      checkRan = true;
+    });
+
+    await Simulator.run();
+
+    expect(checkRan, isTrue);
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A typo in `LogicStructure.previousValue` caused it to actually return the *current* `value`.  This was also undertested.

This PR fixes the bug and adds a test.

## Related Issue(s)

N/A

## Testing

Added a new test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, bug fix

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
