### PR TITLE
Deprecate `Port` and move to `Logic.port` for API consistency

### DIFF
--- a/benchmark/many_seq_and_comb_benchmark.dart
+++ b/benchmark/many_seq_and_comb_benchmark.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // many_seq_and_comb_benchmark.dart

--- a/benchmark/many_seq_and_comb_benchmark.dart
+++ b/benchmark/many_seq_and_comb_benchmark.dart
@@ -17,18 +17,18 @@ enum _MCUInterfaceTag { input, output }
 class _MCUInterface extends Interface<_MCUInterfaceTag> {
   _MCUInterface({this.memorySizeOverride}) {
     setPorts([
-      Port('clock'),
-      Port('enable'),
-      Port('write'),
-      Port('selectByte'),
-      Port('address', 16),
-      Port('inputData', 16),
+      Logic.port('clock'),
+      Logic.port('enable'),
+      Logic.port('write'),
+      Logic.port('selectByte'),
+      Logic.port('address', 16),
+      Logic.port('inputData', 16),
     ], [
       _MCUInterfaceTag.input
     ]);
 
     setPorts([
-      Port('outputData', 16),
+      Logic.port('outputData', 16),
     ], [
       _MCUInterfaceTag.output
     ]);

--- a/doc/tutorials/chapter_8/01_interface.md
+++ b/doc/tutorials/chapter_8/01_interface.md
@@ -17,7 +17,7 @@ Interfaces make it easier to define port connections of a module in a reusable w
 
 `Interface` takes a generic parameter for direction type. This enables you to group signals so make adding them as inputs/outputs easier for different modules sharing this interface.
 
-The `Port` class extends `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
+The `Logic.port` factory returns a `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
 
 When connecting an `Interface` to a `Module`, you should always create a new instance of the `Interface` so you don't modify the one being passed in through the constructor. Modifying the same `Interface` as was passed would have negative consequences if multiple `Modules` were consuming the same `Interface`, and also breaks the rules for `Module` input and output connectivity.
 
@@ -97,15 +97,15 @@ class CounterInterface extends Interface<CounterDirection> {
 
   final int width;
   CounterInterface({this.width = 8}) {
-    setPorts([Port('en'), Port('reset')], [CounterDirection.inward]);
+    setPorts([Logic.port('en'), Logic.port('reset')], [CounterDirection.inward]);
 
     setPorts([
-      Port('val', width),
+      Logic.port('val', width),
     ], [
       CounterDirection.outward
     ]);
 
-    setPorts([Port('clk')], [CounterDirection.misc]);
+    setPorts([Logic.port('clk')], [CounterDirection.misc]);
   }
 }
 ```

--- a/doc/tutorials/chapter_8/01_interface.md
+++ b/doc/tutorials/chapter_8/01_interface.md
@@ -17,7 +17,7 @@ Interfaces make it easier to define port connections of a module in a reusable w
 
 `Interface` takes a generic parameter for direction type. This enables you to group signals so make adding them as inputs/outputs easier for different modules sharing this interface.
 
-The `Logic.port` factory returns a `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
+The `Logic.port` constructor makes interface port definitions a little cleaner by taking the width as a positional argument.
 
 When connecting an `Interface` to a `Module`, you should always create a new instance of the `Interface` so you don't modify the one being passed in through the constructor. Modifying the same `Interface` as was passed would have negative consequences if multiple `Modules` were consuming the same `Interface`, and also breaks the rules for `Module` input and output connectivity.
 

--- a/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
+++ b/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
@@ -19,16 +19,16 @@ class SPIInterface extends Interface<SPIDirection> {
   SPIInterface() {
     // Output from Controller, Input to Peripheral
     setPorts([
-      Port('sck'),
-      Port('sdi'),
-      Port('cs'),
+      Logic.port('sck'),
+      Logic.port('sdi'),
+      Logic.port('cs'),
     ], [
       SPIDirection.controllerOutput
     ]);
 
     // Output from Peripheral, Input to Controller
     setPorts([
-      Port('sdo'),
+      Logic.port('sdo'),
     ], [
       SPIDirection.peripheralOutput
     ]);

--- a/doc/tutorials/chapter_8/counter_interface.dart
+++ b/doc/tutorials/chapter_8/counter_interface.dart
@@ -13,20 +13,20 @@ class CounterInterface extends Interface<CounterDirection> {
   final int width;
   CounterInterface({this.width = 8}) {
     setPorts([
-      Port('en'),
-      Port('reset'),
+      Logic.port('en'),
+      Logic.port('reset'),
     ], [
       CounterDirection.inward
     ]);
 
     setPorts([
-      Port('val', width),
+      Logic.port('val', width),
     ], [
       CounterDirection.outward
     ]);
 
     setPorts([
-      Port('clk'),
+      Logic.port('clk'),
     ], [
       CounterDirection.misc
     ]);

--- a/doc/tutorials/chapter_9/rohd_vf_example/lib/counter.dart
+++ b/doc/tutorials/chapter_9/rohd_vf_example/lib/counter.dart
@@ -11,15 +11,16 @@ class MyCounterInterface extends Interface<CounterDirection> {
 
   final int width;
   MyCounterInterface({this.width = 8}) {
-    setPorts([Port('en'), Port('reset')], [CounterDirection.inward]);
+    setPorts(
+        [Logic.port('en'), Logic.port('reset')], [CounterDirection.inward]);
 
     setPorts([
-      Port('val', width),
+      Logic.port('val', width),
     ], [
       CounterDirection.outward
     ]);
 
-    setPorts([Port('clk')], [CounterDirection.misc]);
+    setPorts([Logic.port('clk')], [CounterDirection.misc]);
   }
 }
 

--- a/doc/user_guide/_docs/A11-interfaces.md
+++ b/doc/user_guide/_docs/A11-interfaces.md
@@ -10,7 +10,7 @@ Interfaces make it easier to define port connections of a module in a reusable w
 
 [`Interface`](https://intel.github.io/rohd/rohd/Interface-class.html) takes a generic parameter for direction type.  This enables you to group signals so make adding them as inputs/outputs easier for different modules sharing this interface.
 
-The [`Logic.port`](https://intel.github.io/rohd/rohd/Logic/Logic.port.html) facory returns `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
+The [`Logic.port`](https://intel.github.io/rohd/rohd/Logic-class.html) constructor makes interface port definitions a little cleaner by taking the width as a positional argument.
 
 When connecting an `Interface` to a `Module`, you should always create a new instance of the `Interface` so you don't modify the one being passed in through the constructor.  Modifying the same `Interface` as was passed would have negative consequences if multiple `Module`s were consuming the same `Interface`, and also breaks the rules for `Module` input and output connectivity.
 

--- a/doc/user_guide/_docs/A11-interfaces.md
+++ b/doc/user_guide/_docs/A11-interfaces.md
@@ -10,7 +10,7 @@ Interfaces make it easier to define port connections of a module in a reusable w
 
 [`Interface`](https://intel.github.io/rohd/rohd/Interface-class.html) takes a generic parameter for direction type.  This enables you to group signals so make adding them as inputs/outputs easier for different modules sharing this interface.
 
-The [`Port`](https://intel.github.io/rohd/rohd/Port-class.html) class extends `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
+The [`Logic.port`](https://intel.github.io/rohd/rohd/Logic/Logic.port.html) facory returns `Logic`, but has a constructor that takes width as a positional argument to make interface port definitions a little cleaner.
 
 When connecting an `Interface` to a `Module`, you should always create a new instance of the `Interface` so you don't modify the one being passed in through the constructor.  Modifying the same `Interface` as was passed would have negative consequences if multiple `Module`s were consuming the same `Interface`, and also breaks the rules for `Module` input and output connectivity.
 
@@ -30,12 +30,12 @@ class CounterInterface extends Interface<CounterDirection> {
   CounterInterface(this.width) {
     // register ports to a specific direction
     setPorts([
-      Port('en'), // Port extends Logic
-      Port('reset')
+      Logic.port('en'), // Logic.port factory returns Logic
+      Logic.port('reset')
     ], [CounterDirection.IN]);  // inputs to the counter
 
     setPorts([
-      Port('val', width),
+      Logic.port('val', width),
     ], [CounterDirection.OUT]); // outputs from the counter
   }
 
@@ -87,9 +87,9 @@ class SimpleInterface extends PairInterface {
 
   SimpleInterface()
       : super(
-          portsFromConsumer: [Port('rsp')],
-          portsFromProvider: [Port('req')],
-          sharedInputPorts: [Port('clk')],
+          portsFromConsumer: [Logic.port('rsp')],
+          portsFromProvider: [Logic.port('req')],
+          sharedInputPorts: [Logic.port('clk')],
         );
 
   SimpleInterface.clone(SimpleInterface super.otherInterface) : super.clone();
@@ -145,8 +145,8 @@ class SubInterface extends PairInterface {
 
   SubInterface()
       : super(
-          portsFromConsumer: [Port('rsp')],
-          portsFromProvider: [Port('req')],
+          portsFromConsumer: [Logic.port('rsp')],
+          portsFromProvider: [Logic.port('req')],
         );
   SubInterface.clone(SubInterface super.otherInterface) : super.clone();
 }
@@ -160,7 +160,7 @@ class TopLevelInterface extends PairInterface {
 
   TopLevelInterface(this.numSubInterfaces)
       : super(
-          sharedInputPorts: [Port('clk')],
+          sharedInputPorts: [Logic.port('clk')],
         ) {
     for (var i = 0; i < numSubInterfaces; i++) {
       subIntfs.add(addSubInterface('sub$i', SubInterface()));

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -25,13 +25,14 @@ import 'package:rohd/rohd.dart';
 /// [Module] input and output connectivity.
 class Interface<TagType> {
   /// Internal map from the [Interface]'s defined port name to an instance
-  /// of a [Port].
+  /// of a [Logic.port].
   ///
   /// Note that each port's name (`port.name`) does not necessarily match the
   /// keys of [_ports] if they have been uniquified.
   final Map<String, Logic> _ports = {};
 
-  /// Maps from the [Interface]'s defined port name to an instance of a [Port].
+  /// Maps from the [Interface]'s defined port name to an instance
+  /// of a [Logic.port].
   ///
   /// Note that each port's name (`port.name`) does not necessarily match the
   /// keys of [_ports] if they have been uniquified.

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -25,14 +25,14 @@ import 'package:rohd/rohd.dart';
 /// [Module] input and output connectivity.
 class Interface<TagType> {
   /// Internal map from the [Interface]'s defined port name to an instance
-  /// of a [Logic.port].
+  /// of a [Logic].
   ///
   /// Note that each port's name (`port.name`) does not necessarily match the
   /// keys of [_ports] if they have been uniquified.
   final Map<String, Logic> _ports = {};
 
   /// Maps from the [Interface]'s defined port name to an instance
-  /// of a [Logic.port].
+  /// of a [Logic].
   ///
   /// Note that each port's name (`port.name`) does not necessarily match the
   /// keys of [_ports] if they have been uniquified.

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface.dart

--- a/lib/src/interfaces/pair_interface.dart
+++ b/lib/src/interfaces/pair_interface.dart
@@ -91,7 +91,7 @@ class PairInterface extends Interface<PairDirection> {
               case LogicNet():
                 return LogicNet.port(name, p.width);
               default:
-                return Port(name, p.width);
+                return Logic.port(name, p.width);
             }
           })
           .toList(growable: false);

--- a/lib/src/interfaces/pair_interface.dart
+++ b/lib/src/interfaces/pair_interface.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface.dart

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -300,6 +300,25 @@ class Logic {
     }
   }
 
+  /// Constructs a [Logic] with some additional validation for ports of
+  /// [Module]s.
+  ///
+  /// Useful for [Interface] definitions.
+  factory Logic.port(String name, [int width = 1]) {
+    if (!Sanitizer.isSanitary(name)) {
+      throw InvalidPortNameException(name);
+    }
+
+    return Logic(
+      name: name,
+      width: width,
+
+      // make port names mergeable so we don't duplicate the ports
+      // when calling connectIO
+      naming: Naming.mergeable,
+    );
+  }
+
   @override
   String toString() => [
         'Logic($width): $name',

--- a/lib/src/signals/port.dart
+++ b/lib/src/signals/port.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // port.dart

--- a/lib/src/signals/port.dart
+++ b/lib/src/signals/port.dart
@@ -14,9 +14,11 @@ import 'package:rohd/src/utilities/sanitizer.dart';
 /// inputs and outputs of [Module]s.
 ///
 /// Useful for [Interface] definitions.
+@Deprecated('Use `Logic.port` instead.')
 class Port extends Logic {
   /// Constructs a [Logic] intended to be used for ports of a [Module] or
   /// in an [Interface].
+  @Deprecated('Use `Logic.port` instead.')
   Port(String name, [int width = 1])
       : super(
           name: name,

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // counter_wintf_test.dart

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -21,10 +21,11 @@ class CounterInterface extends Interface<CounterDirection> {
 
   final int width;
   CounterInterface(this.width) {
-    setPorts([Port('en'), Port('reset')], [CounterDirection.inward]);
+    setPorts(
+        [Logic.port('en'), Logic.port('reset')], [CounterDirection.inward]);
 
     setPorts([
-      Port('val', width),
+      Logic.port('val', width),
     ], [
       CounterDirection.outward
     ]);

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -14,7 +14,7 @@ enum MyDirection { dir1, dir2 }
 
 class MyModuleInterface extends Interface<MyDirection> {
   MyModuleInterface() {
-    setPorts([Port('p1'), LogicArray.port('p1arr')], [MyDirection.dir1]);
+    setPorts([Logic.port('p1'), LogicArray.port('p1arr')], [MyDirection.dir1]);
     setPorts(
         [LogicNet.port('p2'), LogicArray.netPort('p2arr')], [MyDirection.dir2]);
   }
@@ -35,7 +35,7 @@ class MyModule extends Module {
 
 class UncleanPortInterface extends Interface<MyDirection> {
   UncleanPortInterface() {
-    setPorts([Port('end')], [MyDirection.dir1]);
+    setPorts([Logic.port('end')], [MyDirection.dir1]);
   }
 }
 
@@ -44,14 +44,14 @@ class MaybePortInterface extends Interface<MyDirection> {
 
   MaybePortInterface({required bool includePort}) {
     if (includePort) {
-      setPorts([Port('p')], {MyDirection.dir1});
+      setPorts([Logic.port('p')], {MyDirection.dir1});
     }
   }
 }
 
 class BadNetInterface extends Interface<MyDirection> {
   BadNetInterface() {
-    setPorts([Port('p')], [MyDirection.dir1]);
+    setPorts([Logic.port('p')], [MyDirection.dir1]);
     setPorts([LogicArray.port('a')], [MyDirection.dir2]);
   }
 }

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface_test.dart

--- a/test/pair_interface_hier_test.dart
+++ b/test/pair_interface_hier_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface_hier_test.dart

--- a/test/pair_interface_hier_test.dart
+++ b/test/pair_interface_hier_test.dart
@@ -18,7 +18,7 @@ class SubInterface extends PairInterface {
 
   SubInterface({super.modify})
       : super(
-          portsFromConsumer: [Port('rsp')],
+          portsFromConsumer: [Logic.port('rsp')],
           portsFromProvider: [LogicArray.port('req')],
           commonInOutPorts: [
             LogicNet.port('io'),
@@ -38,7 +38,7 @@ class TopLevelInterface extends PairInterface {
 
   TopLevelInterface(this.numSubInterfaces)
       : super(
-          sharedInputPorts: [Port('clk')],
+          sharedInputPorts: [Logic.port('clk')],
         ) {
     for (var i = 0; i < numSubInterfaces; i++) {
       subIntfs.add(addSubInterface(

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -20,9 +20,9 @@ class SimpleInterface extends PairInterface {
 
   SimpleInterface()
       : super(
-          portsFromConsumer: [Port('rsp')],
+          portsFromConsumer: [Logic.port('rsp')],
           portsFromProvider: [LogicArray.port('req')],
-          sharedInputPorts: [Port('clk')],
+          sharedInputPorts: [Logic.port('clk')],
           commonInOutPorts: [
             LogicNet.port('io'),
             LogicArray.netPort('io_arr', [3])

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface_test.dart

--- a/test/provider_consumer_test.dart
+++ b/test/provider_consumer_test.dart
@@ -18,8 +18,8 @@ class DataInterface extends PairInterface {
 
   DataInterface({String? prefix})
       : super(
-            portsFromProvider: [Port('data', 32), Port('valid')],
-            portsFromConsumer: [Port('ready')],
+            portsFromProvider: [Logic.port('data', 32), Logic.port('valid')],
+            portsFromConsumer: [Logic.port('ready')],
             modify: (original) => [
                   if (prefix != null) prefix,
                   original,

--- a/test/provider_consumer_test.dart
+++ b/test/provider_consumer_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // provider_consumer_test.dart


### PR DESCRIPTION
## Description & Motivation

Deprecate `Port` and replace it with a new `Logic.port` constructor with the same functionality to make the API more consistent. Other classes such as `LogicArray` and `LogicNet` already have this style of port constructor.

## Related Issue(s)

#506 

## Testing

Updated existing tests to use `Logic.port`

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No. The `Port` class is deprecated but still present.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Updated documentation to use the new `Logic.port` constructor instead of `Port`
