### PR TITLE
Adding mechanisms to avoid unnecessary swizzle conversions.

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -19,6 +19,7 @@ import 'package:rohd/src/utilities/config.dart';
 import 'package:rohd/src/utilities/sanitizer.dart';
 import 'package:rohd/src/utilities/timestamper.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
+import 'package:rohd/src/utilities/swizzle_opt.dart';
 
 /// Represents a synthesizable hardware entity with clearly defined interface
 /// boundaries.
@@ -913,9 +914,10 @@ abstract class Module {
  */
 
 ''';
-    return synthHeader +
+    // return synthHeader +
+    return SystemVerilogSwizzleOptimizer.optimizeAssignments(synthHeader +
         SynthBuilder(this, SystemVerilogSynthesizer())
             .getFileContents()
-            .join('\n\n////////////////////\n\n');
+            .join('\n\n/////////////////////\n\n'));
   }
 }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -17,9 +17,9 @@ import 'package:rohd/src/collections/traverseable_collection.dart';
 import 'package:rohd/src/diagnostics/inspector_service.dart';
 import 'package:rohd/src/utilities/config.dart';
 import 'package:rohd/src/utilities/sanitizer.dart';
+import 'package:rohd/src/utilities/swizzle_opt.dart';
 import 'package:rohd/src/utilities/timestamper.dart';
 import 'package:rohd/src/utilities/uniquifier.dart';
-import 'package:rohd/src/utilities/swizzle_opt.dart';
 
 /// Represents a synthesizable hardware entity with clearly defined interface
 /// boundaries.

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -914,7 +914,6 @@ abstract class Module {
  */
 
 ''';
-    // return synthHeader +
     return SystemVerilogSwizzleOptimizer.optimizeAssignments(synthHeader +
         SynthBuilder(this, SystemVerilogSynthesizer())
             .getFileContents()

--- a/lib/src/utilities/swizzle_opt.dart
+++ b/lib/src/utilities/swizzle_opt.dart
@@ -1,31 +1,45 @@
+// Copyright (C) 2021-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// swizzle_opt.dart
+// Repalces unnecessary swizzle operations from SystemVerilog code strings.
+//
+// 2025 March 6
+// Author: Gustavo A. Bonilla Gonzalez <gustavo.bonilla.gonzalez@intel.com>
+//         Adan Baltazar Ortiz         <adan.baltazar.ortiz@intel.com>
 
-// ignore: public_member_api_docs
+/// A utility for ensuring code doesn't contain unnecessary swizzle operations.
+///
+/// "Unnecessary swizzle operations" refer to all direct assignments between 1
+/// dimension (packed) LogicArray and Logic of the same width, the optimized
+/// code will contain simple assignments instead of swizzle conversions.
 class SystemVerilogSwizzleOptimizer {
-  // Method to optimize assignments in SystemVerilog code
-  // ignore: public_member_api_docs
+  /// Method to optimize assignments in SystemVerilog code present in [svCode],
+  /// returning an optimized SystemVerilog code string.
   static String optimizeAssignments(String svCode) {
     // Split the code into lines for processing
-    List<String> lines = svCode.split('\n');
-    List<String> optimizedLines = [];
+    final lines = svCode.split('\n');
+    final optimizedLines = <String>[];
 
     // A map to store variable widths
-    Map<String, int> variableWidths = {};
+    final variableWidths = <String, int>{};
 
-    for (var line in lines) {
+    for (final line in lines) {
       // Check for logic declarations to capture variable widths
-      var declarationMatch = RegExp(r'logic\s*\[(\d+):(\d+)\]\s*(\w+);').firstMatch(line);
+      final declarationMatch =
+          RegExp(r'logic\s*\[(\d+):(\d+)\]\s*(\w+);').firstMatch(line);
       if (declarationMatch != null) {
-        int upperBound = int.parse(declarationMatch.group(1)!);
-        int lowerBound = int.parse(declarationMatch.group(2)!);
-        String varName = declarationMatch.group(3)!;
-        int width = (upperBound - lowerBound).abs() + 1;
+        final upperBound = int.parse(declarationMatch.group(1)!);
+        final lowerBound = int.parse(declarationMatch.group(2)!);
+        final varName = declarationMatch.group(3)!;
+        final width = (upperBound - lowerBound).abs() + 1;
         variableWidths[varName] = width;
       }
 
       // Check if the line contains a swizzle conversion
       if (line.contains('= {') && line.contains('};')) {
-        // Perform optimization logic here
-        String optimizedLine = optimizeLine(line, variableWidths);
+        // Checking and optimizing line
+        final optimizedLine = _optimizeLine(line, variableWidths);
         optimizedLines.add(optimizedLine);
       } else {
         optimizedLines.add(line);
@@ -36,13 +50,14 @@ class SystemVerilogSwizzleOptimizer {
     return optimizedLines.join('\n');
   }
 
-  // Method to optimize a single line of SystemVerilog code
-  static String optimizeLine(String line, Map<String, int> variableWidths) {
+  /// Method to optimize a single line of SystemVerilog code
+  static String _optimizeLine(String line, Map<String, int> variableWidths) {
+    final optimizedLine = line;
     // Example logic to identify and optimize swizzle conversions
-    return line.replaceAllMapped(
-        RegExp(r'(\w+)\s*=\s*{\s*(\w+)\s*};'), (match) {
-      String lhs = match.group(1)!;
-      String rhs = match.group(2)!;
+    return optimizedLine.replaceAllMapped(RegExp(r'(\w+)\s*=\s*{\s*(\w+)\s*};'),
+        (match) {
+      final lhs = match.group(1)!;
+      final rhs = match.group(2)!;
 
       // Check if the widths match for direct assignment
       if (variableWidths.containsKey(lhs) &&
@@ -53,7 +68,7 @@ class SystemVerilogSwizzleOptimizer {
       }
 
       // Return the original line if widths do not match
-      return line;
+      return line.trimLeft();
     });
   }
 }

--- a/lib/src/utilities/swizzle_opt.dart
+++ b/lib/src/utilities/swizzle_opt.dart
@@ -52,10 +52,12 @@ class SystemVerilogSwizzleOptimizer {
 
   /// Method to optimize a single line of SystemVerilog code
   static String _optimizeLine(String line, Map<String, int> variableWidths) {
-    final optimizedLine = line;
+    var optimizedLine = line;
+    var unnecesarySwizzleDetected = false;
+
     // Example logic to identify and optimize swizzle conversions
-    return optimizedLine.replaceAllMapped(RegExp(r'(\w+)\s*=\s*{\s*(\w+)\s*};'),
-        (match) {
+    optimizedLine = optimizedLine
+        .replaceAllMapped(RegExp(r'(\w+)\s*=\s*{\s*(\w+)\s*};'), (match) {
       final lhs = match.group(1)!;
       final rhs = match.group(2)!;
 
@@ -63,12 +65,17 @@ class SystemVerilogSwizzleOptimizer {
       if (variableWidths.containsKey(lhs) &&
           variableWidths.containsKey(rhs) &&
           variableWidths[lhs] == variableWidths[rhs]) {
-        // Transform swizzle conversion to direct assignment
-        return '$lhs = $rhs;';
+        unnecesarySwizzleDetected = true;
       }
 
-      // Return the original line if widths do not match
-      return line.trimLeft();
+      // Transform swizzle conversion to direct assignment
+      return '$lhs = $rhs;';
     });
+
+    if (unnecesarySwizzleDetected) {
+      return optimizedLine;
+    } else {
+      return line;
+    }
   }
 }

--- a/lib/src/utilities/swizzle_opt.dart
+++ b/lib/src/utilities/swizzle_opt.dart
@@ -1,0 +1,59 @@
+
+// ignore: public_member_api_docs
+class SystemVerilogSwizzleOptimizer {
+  // Method to optimize assignments in SystemVerilog code
+  // ignore: public_member_api_docs
+  static String optimizeAssignments(String svCode) {
+    // Split the code into lines for processing
+    List<String> lines = svCode.split('\n');
+    List<String> optimizedLines = [];
+
+    // A map to store variable widths
+    Map<String, int> variableWidths = {};
+
+    for (var line in lines) {
+      // Check for logic declarations to capture variable widths
+      var declarationMatch = RegExp(r'logic\s*\[(\d+):(\d+)\]\s*(\w+);').firstMatch(line);
+      if (declarationMatch != null) {
+        int upperBound = int.parse(declarationMatch.group(1)!);
+        int lowerBound = int.parse(declarationMatch.group(2)!);
+        String varName = declarationMatch.group(3)!;
+        int width = (upperBound - lowerBound).abs() + 1;
+        variableWidths[varName] = width;
+      }
+
+      // Check if the line contains a swizzle conversion
+      if (line.contains('= {') && line.contains('};')) {
+        // Perform optimization logic here
+        String optimizedLine = optimizeLine(line, variableWidths);
+        optimizedLines.add(optimizedLine);
+      } else {
+        optimizedLines.add(line);
+      }
+    }
+
+    // Join the optimized lines back into a single string
+    return optimizedLines.join('\n');
+  }
+
+  // Method to optimize a single line of SystemVerilog code
+  static String optimizeLine(String line, Map<String, int> variableWidths) {
+    // Example logic to identify and optimize swizzle conversions
+    return line.replaceAllMapped(
+        RegExp(r'(\w+)\s*=\s*{\s*(\w+)\s*};'), (match) {
+      String lhs = match.group(1)!;
+      String rhs = match.group(2)!;
+
+      // Check if the widths match for direct assignment
+      if (variableWidths.containsKey(lhs) &&
+          variableWidths.containsKey(rhs) &&
+          variableWidths[lhs] == variableWidths[rhs]) {
+        // Transform swizzle conversion to direct assignment
+        return '$lhs = $rhs;';
+      }
+
+      // Return the original line if widths do not match
+      return line;
+    });
+  }
+}

--- a/test/swizzle_opt_test.dart
+++ b/test/swizzle_opt_test.dart
@@ -1,0 +1,97 @@
+import 'package:rohd/src/utilities/swizzle_opt.dart'; // Adjust the import path as necessary
+import 'package:test/test.dart';
+
+void main() {
+  group('SystemVerilogOptimizer', () {
+
+    test('optimizes simple swizzle conversion', () {
+      const input = '''
+module example1;
+  logic [7:0] myArray;
+  logic [7:0] myValue;
+
+  initial begin
+    myArray = {myValue};
+  end
+endmodule
+''';
+
+      const expectedOutput = '''
+module example1;
+  logic [7:0] myArray;
+  logic [7:0] myValue;
+
+  initial begin
+    myArray = myValue;
+  end
+endmodule
+''';
+
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(expectedOutput));
+    });
+
+    test('does not optimize when widths do not match', () {
+      const input = '''
+module example2;
+  logic [7:0] myArray;
+  logic [3:0] myValue;
+
+  initial begin
+    myArray = {myValue};
+  end
+endmodule
+''';
+
+      // Expect no change since widths do not match
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(input));
+    });
+
+    test('handles complex expressions without change', () {
+      const input = '''
+module example3;
+  logic [7:0] myArray;
+  logic [3:0] myValue1, myValue2;
+
+  initial begin
+    myArray = {myValue1, myValue2};
+  end
+endmodule
+''';
+
+      // Expect no change for complex expressions
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(input));
+    });
+
+    test('optimizes multiple assignments', () {
+      const input = '''
+module example4;
+  logic [7:0] myArray1;
+  logic [7:0] myArray2;
+  logic [7:0] myValue1;
+  logic [7:0] myValue2;
+
+  initial begin
+    myArray1 = {myValue1};
+    myArray2 = {myValue2};
+  end
+endmodule
+''';
+
+      const expectedOutput = '''
+module example4;
+  logic [7:0] myArray1;
+  logic [7:0] myArray2;
+  logic [7:0] myValue1;
+  logic [7:0] myValue2;
+
+  initial begin
+    myArray1 = myValue1;
+    myArray2 = myValue2;
+  end
+endmodule
+''';
+
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(expectedOutput));
+    });
+  });
+}

--- a/test/swizzle_opt_test.dart
+++ b/test/swizzle_opt_test.dart
@@ -1,9 +1,18 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// swizzle_opt_test.dart
+// Unit tests for swizzle optimization.
+//
+// 2025 March 6
+// Author: Gustavo A. Bonilla Gonzalez <gustavo.bonilla.gonzalez@intel.com>
+//         Adan Baltazar Ortiz         <adan.baltazar.ortiz@intel.com>
+
 import 'package:rohd/src/utilities/swizzle_opt.dart'; // Adjust the import path as necessary
 import 'package:test/test.dart';
 
 void main() {
   group('SystemVerilogOptimizer', () {
-
     test('optimizes simple swizzle conversion', () {
       const input = '''
 module example1;
@@ -27,7 +36,8 @@ module example1;
 endmodule
 ''';
 
-      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(expectedOutput));
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input),
+          equals(expectedOutput));
     });
 
     test('does not optimize when widths do not match', () {
@@ -43,7 +53,8 @@ endmodule
 ''';
 
       // Expect no change since widths do not match
-      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(input));
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input),
+          equals(input));
     });
 
     test('handles complex expressions without change', () {
@@ -59,7 +70,8 @@ endmodule
 ''';
 
       // Expect no change for complex expressions
-      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(input));
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input),
+          equals(input));
     });
 
     test('optimizes multiple assignments', () {
@@ -91,7 +103,8 @@ module example4;
 endmodule
 ''';
 
-      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input), equals(expectedOutput));
+      expect(SystemVerilogSwizzleOptimizer.optimizeAssignments(input),
+          equals(expectedOutput));
     });
   });
 }

--- a/test/swizzle_opt_test.dart
+++ b/test/swizzle_opt_test.dart
@@ -8,7 +8,7 @@
 // Author: Gustavo A. Bonilla Gonzalez <gustavo.bonilla.gonzalez@intel.com>
 //         Adan Baltazar Ortiz         <adan.baltazar.ortiz@intel.com>
 
-import 'package:rohd/src/utilities/swizzle_opt.dart'; // Adjust the import path as necessary
+import 'package:rohd/src/utilities/swizzle_opt.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## Description & Motivation

The use of swizzle conversions could be unnecessary in the generated SystemVerilog code when there are assignments between a LogicArray with 1 dimension (packed), and a Logic of the same width. This changes add mechanisms to identify those cases and replace the swizzle conversions with simple assignments.

## Related Issue(s)

#559 

## Testing

A unit testing script was created to validate the [SystemVerilogSwizzleOptimizer] functionality.
rohd/test/swizzle_opt_test.dart

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

The [SystemVerilogSwizzleOptimizer] class was added with its code documentation, no need to add more.
rohd/lib/src/utilities/swizzle_opt.dart
