### PR TITLE
Fix bug in cross-stage accesses in `Pipeline`

### DIFF
--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -32,10 +32,8 @@ class PipelineStageInfo {
   /// stage, you can access it relatively using [stageAdjustment].  For example,
   /// `p.get(x, -1)` will access the value of `x` at the output of one stage
   /// prior.
-  Logic get(Logic identifier, [int stageAdjustment = 0]) {
-    final l = _pipeline.get(identifier, stage + stageAdjustment);
-    return stageAdjustment == 0 ? _ssa(l) : l;
-  }
+  Logic get(Logic identifier, [int stageAdjustment = 0]) =>
+      getAbs(identifier, stage + stageAdjustment);
 
   /// Returns the output of [identifier] at the specified absolute [stageIndex]
   /// stage, if other than the current [stage].  Otherwise, returns the same

--- a/lib/src/modules/pipeline.dart
+++ b/lib/src/modules/pipeline.dart
@@ -24,20 +24,26 @@ class PipelineStageInfo {
   /// Constructs a new instance of information for this stage.
   PipelineStageInfo._(this._pipeline, this.stage, this._ssa);
 
-  /// Returns a staged version of [identifier] at the current stage, adjusted
-  /// by the amount of [stageAdjustment].
+  /// Returns a staged version of [identifier] at the current stage, adjusted by
+  /// the amount of [stageAdjustment].
   ///
   /// Typically, your pipeline will consist of a lot of `p.get(x)` type calls,
   /// but if you want to combinationally access a value of a signal from another
-  /// stage, you can access it relatively using [stageAdjustment].  For
-  /// example, `p.get(x, -1)` will access the value of `x` one stage prior.
-  Logic get(Logic identifier, [int stageAdjustment = 0]) =>
-      _ssa(_pipeline.get(identifier, stage + stageAdjustment));
+  /// stage, you can access it relatively using [stageAdjustment].  For example,
+  /// `p.get(x, -1)` will access the value of `x` at the output of one stage
+  /// prior.
+  Logic get(Logic identifier, [int stageAdjustment = 0]) {
+    final l = _pipeline.get(identifier, stage + stageAdjustment);
+    return stageAdjustment == 0 ? _ssa(l) : l;
+  }
 
-  /// Returns a staged version of [identifier] at the specified
-  /// absolute [stageIndex].
-  Logic getAbs(Logic identifier, int stageIndex) =>
-      _ssa(_pipeline.get(identifier, stageIndex));
+  /// Returns the output of [identifier] at the specified absolute [stageIndex]
+  /// stage, if other than the current [stage].  Otherwise, returns the same
+  /// thing as [get], for the current [stage].
+  Logic getAbs(Logic identifier, int stageIndex) {
+    final l = _pipeline.get(identifier, stageIndex);
+    return stageIndex == stage ? _ssa(l) : l;
+  }
 }
 
 /// A container for signals and combinational content generation for a stage.


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a bug in ROHD `Pipeline` abstractions where when you access signals across stages (relatively or absolutely), the SSA resolution would be incorrect, causing some confusing errors.  In the end, the bug was that the abstraction was asking the `Combinational.ssa` to access signals using the `s` function even when they were actually outputs of other stages.

This PR fixes the bug in both `get` and `getAbs` and adds tests to cover the scenarios.

## Related Issue(s)

N/A

## Testing

Added new tests to cover the issue.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

The API description in `getAbs` was wrong, and the docs have been updated, so from that perspective things have changed a bit, but that's more of a documentation bug.  There's no reason you'd want to access the "output" of the "current" stage before the end, as you'd construct a combinational loop and get an error, and the existing API never did that anyways.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
