### PR TITLE
Fix memory leak in combinational guarding

### DIFF
--- a/benchmark/iterable_removable_queue_benchmark.dart
+++ b/benchmark/iterable_removable_queue_benchmark.dart
@@ -40,7 +40,7 @@ class IterableRemovableQueueBenchmark extends BenchmarkBase {
         queue
           ..iterate(
             action: (item) => item.value + 1,
-            removeWhere: (item) => item.value == i,
+            // removeWhere: (item) => item.value == i, //TODO
           )
           ..add(DummyElement(i));
       }

--- a/benchmark/iterable_removable_queue_benchmark.dart
+++ b/benchmark/iterable_removable_queue_benchmark.dart
@@ -1,0 +1,68 @@
+// import 'dart:io';
+
+import 'dart:io';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:rohd/src/collections/iterable_removable_queue.dart';
+import "dart:developer";
+
+class DummyElement {
+  final Set<String> someSet = {};
+  int value;
+  DummyElement(this.value) {
+    for (var i = 0; i < 100; i++) {
+      someSet.add('item_${value}_$i');
+    }
+  }
+}
+
+class IterableRemovableQueueBenchmark extends BenchmarkBase {
+  IterableRemovableQueueBenchmark() : super('IterableRemovableQueue');
+
+  late final IterableRemovableQueue<DummyElement> queue;
+
+  static const numElements = 100;
+  static const numIterations = 10001;
+  static const checkFrequency = 2000;
+
+  @override
+  void setup() {
+    queue = IterableRemovableQueue<DummyElement>();
+    for (var i = 0; i < numElements; i++) {
+      queue.add(DummyElement(i));
+    }
+  }
+
+  @override
+  void run() {
+    for (var iter = 0; iter < numIterations; iter++) {
+      for (var i = 0; i < numElements; i++) {
+        queue
+          ..iterate(
+            action: (item) => item.value + 1,
+            removeWhere: (item) => item.value == i,
+          )
+          ..add(DummyElement(i));
+      }
+
+      if (iter > 0 && iter % checkFrequency == 0) {
+        final fileName = "iter$iter.heapsnapshot";
+        NativeRuntime.writeHeapSnapshotToFile(fileName);
+        final size = File(fileName).lengthSync();
+
+        print('@$iter: Heap size is $size bytes.');
+        if (size > 100 * 1000000) {
+          print('***Very large heap!');
+          break;
+        }
+      }
+    }
+    // NativeRuntime.writeHeapSnapshotToFile("newbuild.heapsnapshot");
+    // exit(0);
+  }
+}
+
+void main() {
+  IterableRemovableQueueBenchmark().report();
+  print("asdf");
+}

--- a/lib/src/collections/iterable_removable_queue.dart
+++ b/lib/src/collections/iterable_removable_queue.dart
@@ -70,19 +70,27 @@ class IterableRemovableQueue<T> {
       if (removeWhere!(_patrol!.item)) {
         assert(size > 0, 'Should not be removing if size is already 0.');
 
+        if (_patrol == _first && _first == _last) {
+          // if size is 1, then we clear the queue and be done with it
+          clear();
+          break;
+        }
+
         previous?.next = _patrol!.next;
 
         if (_patrol == _first) {
           _first = _patrol!.next;
           _patrol = _first;
+        } else if (_patrol == _last) {
+          _last = previous;
+          _patrol = null;
         }
 
-        if (_patrol == _last) {
-          _last = previous;
-        }
+        assert((_first == null) == (_last == null),
+            'First and last should be both null or both non-null.');
 
         // Move the patrol pointer to the next element.
-        _patrol = _patrol!.next;
+        _patrol = _patrol?.next;
 
         _size--;
       } else {
@@ -144,6 +152,9 @@ class IterableRemovableQueue<T> {
     _size += other.size;
 
     other.clear();
+
+    // Reset patrol to be safe, so we don't have a stale pointer.
+    _patrol = null;
   }
 
   /// Iterates through all items in the queue, removing any which are indicated
@@ -164,13 +175,23 @@ class IterableRemovableQueue<T> {
 
         previous?.next = element.next;
 
-        if (element == _first) {
-          _first = element.next;
+        if (element == _first && _first == _last) {
+          // if size is 1, then we clear the queue and be done with it
+          clear();
+          break;
         }
 
-        if (element == _last) {
+        if (element == _first) {
+          _first = element.next;
+        } else if (element == _last) {
           _last = previous;
         }
+
+        assert((_first == null) == (_last == null),
+            'First and last should be both null or both non-null.');
+
+        // Reset patrol to be safe, so we don't have a stale pointer.
+        _patrol = null;
 
         _size--;
       } else {

--- a/lib/src/collections/iterable_removable_queue.dart
+++ b/lib/src/collections/iterable_removable_queue.dart
@@ -80,6 +80,7 @@ class IterableRemovableQueue<T> {
   /// by [removeWhere], and performing [action] on the rest.
   void iterate(
       {void Function(T item)? action, bool Function(T item)? removeWhere}) {
+    print('initial size: $size');
     if (isEmpty) {
       return;
     }
@@ -106,6 +107,8 @@ class IterableRemovableQueue<T> {
 
       element = element.next;
     }
+
+    print('final size: $size');
   }
 }
 

--- a/lib/src/collections/iterable_removable_queue.dart
+++ b/lib/src/collections/iterable_removable_queue.dart
@@ -8,6 +8,8 @@
 // 2023 April 21
 // Author: Max Korbel <max.korbel@intel.com>
 
+int _biggestSize = 0;
+
 /// A queue that can be easily iterated through and remove items during
 /// iteration.
 class IterableRemovableQueue<T> {
@@ -21,6 +23,15 @@ class IterableRemovableQueue<T> {
   /// Null if the queue is empty.
   _IterableRemovableElement<T>? _last;
 
+  int size = 0;
+
+  void _checkSize() {
+    if (size > _biggestSize) {
+      _biggestSize = size;
+      print('New biggest size: $_biggestSize');
+    }
+  }
+
   /// Adds a new item to the end of the queue.
   void add(T item) {
     final newElement = _IterableRemovableElement<T>(item);
@@ -31,6 +42,8 @@ class IterableRemovableQueue<T> {
       _last!.next = newElement;
       _last = newElement;
     }
+    size++;
+    _checkSize();
   }
 
   /// Indicates whether there are no items in the queue.
@@ -40,6 +53,7 @@ class IterableRemovableQueue<T> {
   void clear() {
     _first = null;
     _last = null;
+    size = 0;
   }
 
   /// Appends [other] to this without copying any elements and [clear]s [other].
@@ -55,6 +69,9 @@ class IterableRemovableQueue<T> {
       _last!.next = other._first;
       _last = other._last;
     }
+
+    size += other.size;
+    _checkSize();
 
     other.clear();
   }
@@ -78,6 +95,7 @@ class IterableRemovableQueue<T> {
         } else if (element == _last) {
           _last = previous;
         }
+        size--;
       } else {
         if (action != null) {
           action(element.item);

--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -196,6 +196,7 @@ class Combinational extends Always {
   /// are consuming.
   void _guard(Logic toGuard) {
     if (_guarded.add(toGuard)) {
+      print('guarding $toGuard');
       _guardListeners.add(toGuard.glitch.listen(_writeAfterRead));
     }
   }
@@ -234,6 +235,7 @@ class Combinational extends Always {
     }
 
     // clean up after execution
+    print('cancelling ${_guardListeners.length}');
     for (final guardListener in _guardListeners) {
       guardListener.cancel();
     }

--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -196,7 +196,6 @@ class Combinational extends Always {
   /// are consuming.
   void _guard(Logic toGuard) {
     if (_guarded.add(toGuard)) {
-      print('guarding $toGuard');
       _guardListeners.add(toGuard.glitch.listen(_writeAfterRead));
     }
   }
@@ -235,7 +234,6 @@ class Combinational extends Always {
     }
 
     // clean up after execution
-    print('cancelling ${_guardListeners.length}');
     for (final guardListener in _guardListeners) {
       guardListener.cancel();
     }

--- a/lib/src/utilities/synchronous_propagator.dart
+++ b/lib/src/utilities/synchronous_propagator.dart
@@ -44,7 +44,8 @@ class SynchronousEmitter<T> {
 
   /// A [List] of actions to perform for each event.
   final IterableRemovableQueue<SynchronousSubscription<T>> _subscriptions =
-      IterableRemovableQueue<SynchronousSubscription<T>>();
+      IterableRemovableQueue<SynchronousSubscription<T>>(
+          removeWhere: _doRemove);
 
   /// Returns `true` iff this is currently emitting.
   ///
@@ -63,7 +64,6 @@ class SynchronousEmitter<T> {
 
     _subscriptions.iterate(
       action: (subscription) => subscription.func(t),
-      removeWhere: _doRemove,
     );
 
     _isEmitting = false;

--- a/test/guard_loop_test.dart
+++ b/test/guard_loop_test.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:rohd/rohd.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  test('guard loop', () async {
+    final clk = SimpleClockGenerator(10).clk;
+
+    final x = Logic(name: 'x');
+    final y = Logic(name: 'y');
+
+    Combinational([
+      Case(Logic(name: 'expression'), [
+        CaseItem(Logic(name: 'caseItem'), [
+          y < x,
+        ])
+      ])
+    ]);
+
+    Simulator.setMaxSimTime(100000 * 10);
+
+    //TODO: bug, signals that never change but are guarded grow forever!!
+
+    unawaited(Simulator.run());
+
+    for (var i = 0; i < 20; i++) {
+      await clk.nextPosedge;
+      x.put(i.isEven);
+    }
+
+    await Simulator.endSimulation();
+  });
+}

--- a/test/iterable_removable_queue_test.dart
+++ b/test/iterable_removable_queue_test.dart
@@ -127,7 +127,7 @@ void main() {
         q.iterate();
 
         expect(q.isEmpty, false);
-        expect(q.size, numItems + numItems ~/ 3);
+        expect(q.size, numItems + 2 * numItems ~/ 3);
       });
     });
   });

--- a/test/iterable_removable_queue_test.dart
+++ b/test/iterable_removable_queue_test.dart
@@ -10,18 +10,25 @@
 import 'package:rohd/src/collections/iterable_removable_queue.dart';
 import 'package:test/test.dart';
 
+class LateRemovable {
+  bool doRemove = false;
+  final int i;
+  LateRemovable(this.i);
+}
+
 void main() {
   group('iterable removable queue', () {
     const numItems = 100;
-    IterableRemovableQueue<int> buildQueue() {
-      final q = IterableRemovableQueue<int>();
+    IterableRemovableQueue<int> buildQueue(
+        {bool Function(int item)? removeWhere}) {
+      final q = IterableRemovableQueue<int>(removeWhere: removeWhere);
       for (var i = 0; i < numItems; i++) {
         q.add(i);
       }
       return q;
     }
 
-    int getCount(IterableRemovableQueue<int> q) {
+    int getCount<T>(IterableRemovableQueue<T> q) {
       var count = 0;
       q.iterate(action: (item) {
         count++;
@@ -37,19 +44,19 @@ void main() {
       });
 
       test('remove even', () {
-        final q = buildQueue()..iterate(removeWhere: (i) => i.isEven);
+        final q = buildQueue(removeWhere: (i) => i.isEven)..iterate();
         expect(getCount(q), numItems / 2);
         expect(q.isEmpty, false);
       });
 
       test('remove odd', () {
-        final q = buildQueue()..iterate(removeWhere: (i) => i.isOdd);
+        final q = buildQueue(removeWhere: (i) => i.isOdd)..iterate();
         expect(getCount(q), numItems / 2);
         expect(q.isEmpty, false);
       });
 
       test('remove all', () {
-        final q = buildQueue()..iterate(removeWhere: (i) => true);
+        final q = buildQueue(removeWhere: (i) => true)..iterate();
         expect(getCount(q), 0);
         expect(q.isEmpty, true);
       });
@@ -69,6 +76,59 @@ void main() {
       q1.takeAll(q2);
       expect(getCount(q1), numItems * 2);
       expect(q2.isEmpty, true);
+    });
+
+    test('size', () {
+      final q = buildQueue();
+      expect(getCount(q), numItems);
+      expect(q.size, numItems);
+    });
+
+    group('patrol', () {
+      test('patrol removes even when added', () {
+        final q = buildQueue(removeWhere: (i) => i.isEven);
+        expect(q.size, numItems / 2);
+        expect(q.isEmpty, false);
+      });
+
+      test('patrol removes later when status changes', () {
+        final q = IterableRemovableQueue<LateRemovable>(
+          removeWhere: (item) => item.doRemove,
+        );
+        final items = <LateRemovable>[];
+        for (var i = 0; i < numItems; i++) {
+          final item = LateRemovable(i);
+          items.add(item);
+          q.add(item);
+        }
+
+        q.iterate();
+
+        expect(getCount(q), numItems);
+        expect(q.isEmpty, false);
+        expect(q.size, numItems);
+
+        // Now change the status of all items to be removed.
+        for (final item in items) {
+          if (item.i % 3 == 0) {
+            item.doRemove = true;
+          }
+        }
+
+        // now add more, and make sure patrol is removing things too
+        for (var i = numItems; i < numItems * 2; i++) {
+          final item = LateRemovable(i);
+          items.add(item);
+          q.add(item);
+        }
+
+        expect(q.size, lessThan(numItems + numItems * 0.75));
+
+        q.iterate();
+
+        expect(q.isEmpty, false);
+        expect(q.size, numItems + numItems ~/ 3);
+      });
     });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A long-running simulation revealed a memory leak.  At first, we thought it was a bug in Dart (https://github.com/dart-lang/sdk/issues/61036), but we were distracted by a bug in the Dart debugger stack which showed similar symptoms to the actual memory leak that existed in ROHD.  The Dart bugs are tracked separately (see linked issue).

The bug has to do with `guard`ing in `Combinational` to detect "write after read" errors.  Each time we execute a `Combinational`, we add "guards" after a signal has been "read" (to see if it is later written) and then clear the guards at the end of the execution.  The implementation used a custom collection called `IterableRemovableQueue` designed to get good performance for adding and cancelling subscriptions to signal glitches during simulation.  One of the optimizations was to lazily remove items from the list only when it was being already iterated upon for other reasons (i.e. notifying listeners of a glitch).  The bug was that some signals did not change (or at least changed very infrequently), which means the list grew unboundedly and never had the iterate so that it could lazily delete the old items.

It's important to have approximately O(1) addition, O(1) removal, and O(n) iteration on this collection.  It's implemented as a linked list, so removing non-lazily would cost O(n).  This PR introduces a fix called "patrolling" so that each time a new item is added to the queue, a pointer moves forwards once, then removes all contiguous elements marked for lazy removal.  With the "guarding" usage model, this means you pay roughly the O(n) removal penalty roughly once per `Combinational` execution rather than per-element removal, which is a big win on performance.

This PR also includes some additional testing to make sure things don't break.

Measurement on the original long-running program shows an improvement in performance and memory consumption, and tests and inspection reveal that the patrol feature is working properly.

## Related Issue(s)

https://github.com/dart-lang/sdk/issues/61036

## Testing

Added new tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, this is internal changes only.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No, though some explanations are included in doc comments.
