### PR TITLE
bug fix for zero value toRadixString()

### DIFF
--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -729,9 +729,11 @@ abstract class LogicValue implements Comparable<LogicValue> {
             (match) => '${match.group(0)}$sepChar')
         .replaceAll('$sepChar<', '<'));
 
-    final fullString = spaceString[0] == sepChar
-        ? spaceString.substring(1, spaceString.length)
-        : spaceString;
+    final fullString = (spaceString.isNotEmpty)
+        ? (spaceString[0] == sepChar)
+            ? spaceString.substring(1, spaceString.length)
+            : spaceString
+        : '0';
     return '$width$radixStr$fullString';
   }
 

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2066,6 +2066,17 @@ void main() {
             equals(lv));
       }
     });
+    test('radixString roundTrip zero corner case', () {
+      final lv = LogicValue.ofBigInt(BigInt.from(0), 61);
+      for (final i in [2, 4, 8, 10, 16]) {
+        expect(
+            LogicValue.ofRadixString(lv.toRadixString(radix: i)), equals(lv));
+        expect(
+            LogicValue.ofRadixString(
+                lv.toRadixString(radix: i, leadingZeros: true)),
+            equals(lv));
+      }
+    });
     test('radixString binary expansion', () {
       final lv = LogicValue.ofRadixString("12'b10z111011z00");
       expect(lv.toRadixString(radix: 16), equals("12'h<10z1>d<1z00>"));


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Make sure to check if computed radixString is of zero length and add back a single leading zero.

## Related Issue(s)

Fixes #605 

## Testing

Added a test for converting zero with and without leading zeros flag using different radices.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

None needed.
