### PR TITLE
Cloning and matching

### DIFF
--- a/benchmark/many_seq_and_comb_benchmark.dart
+++ b/benchmark/many_seq_and_comb_benchmark.dart
@@ -44,6 +44,10 @@ class _MCUInterface extends Interface<_MCUInterfaceTag> {
   Logic get outputData => port('outputData');
 
   final int? memorySizeOverride;
+
+  @override
+  _MCUInterface clone() =>
+      _MCUInterface(memorySizeOverride: memorySizeOverride);
 }
 
 class _MemoryControllerUnit extends Module {

--- a/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
+++ b/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
@@ -33,6 +33,9 @@ class SPIInterface extends Interface<SPIDirection> {
       SPIDirection.peripheralOutput
     ]);
   }
+
+  @override
+  SPIInterface clone() => SPIInterface();
 }
 
 class Controller extends Module {

--- a/doc/tutorials/chapter_8/counter_interface.dart
+++ b/doc/tutorials/chapter_8/counter_interface.dart
@@ -31,6 +31,9 @@ class CounterInterface extends Interface<CounterDirection> {
       CounterDirection.misc
     ]);
   }
+
+  @override
+  CounterInterface clone() => CounterInterface(width: width);
 }
 
 class Counter extends Module {

--- a/doc/tutorials/chapter_9/rohd_vf_example/lib/counter.dart
+++ b/doc/tutorials/chapter_9/rohd_vf_example/lib/counter.dart
@@ -22,6 +22,9 @@ class MyCounterInterface extends Interface<CounterDirection> {
 
     setPorts([Logic.port('clk')], [CounterDirection.misc]);
   }
+
+  @override
+  MyCounterInterface clone() => MyCounterInterface(width: width);
 }
 
 /// A simple counter which increments once per [clk] edge whenever

--- a/doc/user_guide/_docs/A11-interfaces.md
+++ b/doc/user_guide/_docs/A11-interfaces.md
@@ -39,6 +39,8 @@ class CounterInterface extends Interface<CounterDirection> {
     ], [CounterDirection.OUT]); // outputs from the counter
   }
 
+  @override
+  CounterInterface clone() => CounterInterface(width: width);
 }
 
 class Counter extends Module {

--- a/doc/user_guide/_docs/A19-logic-structures.md
+++ b/doc/user_guide/_docs/A19-logic-structures.md
@@ -1,7 +1,7 @@
 ---
 title: "Logic Structures"
 permalink: /docs/logic-structures/
-last_modified_at: 2022-6-5
+last_modified_at: 2025-7-23
 toc: true
 ---
 
@@ -11,7 +11,7 @@ A [`LogicStructure`](https://intel.github.io/rohd/rohd/LogicStructure-class.html
 
 **`LogicStructure`s can be used anywhere a `Logic` can be**. This means you can assign one structure to another structure, or inter-assign between normal signals and structures.  As long as the overall width matches, the assignment will work. The order of assignment of bits is based on the order of the `elements` in the structure.
 
-**Elements within a `LogicStructure` can be individually assigned.** This is a notable difference from individual bits of a plain `Logic` where you'd have to use something like `withSet` to effectively modify bits within a signal.
+**Elements within a `LogicStructure` can be individually assigned.** This is a notable difference from individual bits of a plain `Logic` where you'd have to use something like `withSet` or `assignSubset` to effectively modify bits within a signal.
 
 `LogicArray`s are a type of `LogicStructure` and thus inherit these behavioral traits.
 
@@ -48,16 +48,18 @@ class ReadyValidStruct extends LogicStructure {
   final Logic ready;
   final Logic valid;
 
-  factory ReadyValidStruct() => MyStruct._(
+  factory ReadyValidStruct({String name = 'readyValid'}) => ReadyValidStruct._(
         Logic(name: 'ready'),
         Logic(name: 'valid'),
+        name: name,
       );
 
-  ReadyValidStruct._(this.ready, this.valid)
-      : super([ready, valid], name: 'readyValid');
+  ReadyValidStruct._(this.ready, this.valid, {required String name})
+      : super([ready, valid], name: name);
 
   @override
-  LogicStructure clone({String? name}) => ReadyValidStruct();
+  ReadyValidStruct clone({String? name}) =>
+      ReadyValidStruct(name: name ?? this.name);
 }
 ```
 

--- a/lib/src/exceptions/module/port_type_exception.dart
+++ b/lib/src/exceptions/module/port_type_exception.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // port_type_exception.dart
@@ -13,6 +13,14 @@ import 'package:rohd/rohd.dart';
 class PortTypeException extends RohdException {
   /// Constructs a new [Exception] for when a port has the wrong type.
   PortTypeException(Logic port, [String additionalMessage = ''])
-      : super('Port ${port.name} has the wrong type.'
+      : this.forIntendedName(port.name, additionalMessage);
+
+  /// Constructs a new [Exception] for when a port with the [intendedName] has
+  /// the wrong type.
+  ///
+  /// This constructor is in case the port didn't even get the right name.
+  PortTypeException.forIntendedName(String intendedName,
+      [String additionalMessage = ''])
+      : super('Port $intendedName has an incompatible type.'
             ' $additionalMessage');
 }

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -23,7 +23,7 @@ import 'package:rohd/rohd.dart';
 /// was passed would have negative consequences if multiple [Module]s
 /// were consuming the same [Interface], and also breaks the rules for
 /// [Module] input and output connectivity.
-class Interface<TagType> {
+class Interface<TagType extends Enum> {
   /// Internal map from the [Interface]'s defined port name to an instance
   /// of a [Logic].
   ///
@@ -232,4 +232,17 @@ class Interface<TagType> {
               MapEntry(portName, thisPort < other.port(portName)))
           .values
           .toList(growable: false));
+
+  /// Creates a new [Interface] with the same ports as `this`.
+  ///
+  /// It is expected that any implementation will override this in a way that
+  /// returns the same type as itself.
+  @mustBeOverridden
+  Interface<TagType> clone() {
+    final newIntf = Interface<TagType>();
+    _portToTagMap.forEach((portName, tags) {
+      newIntf.setPorts([port(portName).clone()], tags);
+    });
+    return newIntf;
+  }
 }

--- a/lib/src/interfaces/pair_interface.dart
+++ b/lib/src/interfaces/pair_interface.dart
@@ -98,6 +98,7 @@ class PairInterface extends Interface<PairDirection> {
 
   /// Creates a new instance of a [PairInterface] with the same ports and other
   /// characteristics.
+  @Deprecated('Use `clone()` on an instance instead')
   PairInterface.clone(PairInterface otherInterface)
       : this(
           portsFromConsumer:
@@ -268,6 +269,11 @@ class PairInterface extends Interface<PairDirection> {
     _subInterfaces[name] = _SubPairInterface(subInterface, reverse: reverse);
     return subInterface;
   }
+
+  @override
+  @mustBeOverridden
+  // ignore: deprecated_member_use_from_same_package
+  PairInterface clone() => PairInterface.clone(this);
 }
 
 /// An internal tracking object for sub-interfaces and characteristics useful

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -684,14 +684,15 @@ abstract class Module {
     // TODO: confirm that no matched input/output structure has ANY nets in it
     //  or we will violate all kinds of assumptions
     if (source.isNet || (source is LogicStructure && source.hasNets)) {
-      //TODO
-      throw Exception('Matched inputs cannot have nets in them.');
+      throw PortTypeException(
+          source, 'Matched inputs cannot have nets in them.');
     }
 
     final inPort = (source.clone(name: name) as LogicType)..gets(source);
 
     if (inPort.name != name) {
-      throw Exception('clone name failed'); // TODO
+      throw PortTypeException.forIntendedName(name,
+          'The `clone` method for $source failed to update the signal name.');
     }
 
     if (inPort is LogicStructure) {
@@ -768,7 +769,7 @@ abstract class Module {
     _checkForSafePortName(name);
 
     if (!source.isNet) {
-      throw Exception('Matched inOuts must be nets.');
+      throw PortTypeException(source, 'Matched inOuts must be nets.');
     }
 
     _inOutDrivers.add(source);
@@ -793,7 +794,8 @@ abstract class Module {
     final inOutPort = (source.clone(name: name) as LogicType)..gets(source);
 
     if (inOutPort.name != name) {
-      throw Exception('clone name failed'); // TODO
+      throw PortTypeException.forIntendedName(name,
+          'The `clone` method for $source failed to update the signal name.');
     }
 
     if (inOutPort is LogicStructure) {
@@ -865,15 +867,16 @@ abstract class Module {
     _checkForSafePortName(name);
 
     if (toMatch.isNet || (toMatch is LogicStructure && toMatch.hasNets)) {
-      //TODO
-      throw Exception('Matched outputs cannot have nets in them.');
+      throw PortTypeException(
+          toMatch, 'Matched outputs cannot have nets in them.');
     }
 
     // must make a new clone of it, to avoid people using ports of other modules
     final outPort = toMatch.clone(name: name) as LogicType;
 
     if (outPort.name != name) {
-      throw Exception('clone name failed'); // TODO
+      throw PortTypeException.forIntendedName(name,
+          'The `clone` method for $toMatch failed to update the signal name.');
     }
 
     if (outPort is LogicStructure) {

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -698,6 +698,9 @@ abstract class Module {
       String name, LogicType source) {
     _checkForSafePortName(name);
 
+    // TODO: confirm that no matched input/output structure has ANY nets in it
+    //  or we will violate all kinds of assumptions
+
     final inPort = (source.clone(name: name) as LogicType)..gets(source);
 
     if (inPort.name != name) {

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -55,13 +55,6 @@ abstract class Module {
   /// An internal mapping of inOut names to their sources to this [Module].
   late final Map<String, Logic> _inOutSources = {};
 
-  // late final Map<String, LogicStructure> _inputStructures = {};
-  // late final Map<String, LogicStructure> _inputStructureSources = {};
-  // late final Map<String, LogicStructure> _inOutStructures = {};
-  // late final Map<String, LogicStructure> _inOutStructureSources = {};
-  // late final Map<String, LogicStructure> _outputStructures = {};
-  // late final Map<String, LogicStructure> _outputStructureSources = {};
-
   /// The parent [Module] of this [Module].
   ///
   /// This only gets populated after its parent [Module], if it exists, has
@@ -131,16 +124,6 @@ abstract class Module {
       _inputSources[name] ??
       (throw PortDoesNotExistException(
           '$name is not an input of this Module.'));
-
-  // LogicStructure inputStructure(String name) =>
-  //     _inputStructures[name] ??
-  //     (throw PortDoesNotExistException(
-  //         '$name is not an input structure of this Module.'));
-
-  // LogicStructure inputStructureSource(String name) =>
-  //     _inputStructureSources[name] ??
-  //     (throw PortDoesNotExistException(
-  //         '$name is not an input structure of this Module.'));
 
   /// Provides the [input] named [name] if it exists, otherwise `null`.
   ///
@@ -700,6 +683,10 @@ abstract class Module {
 
     // TODO: confirm that no matched input/output structure has ANY nets in it
     //  or we will violate all kinds of assumptions
+    if (source.isNet || (source is LogicStructure && source.hasNets)) {
+      //TODO
+      throw Exception('Matched inputs cannot have nets in them.');
+    }
 
     final inPort = (source.clone(name: name) as LogicType)..gets(source);
 
@@ -776,6 +763,18 @@ abstract class Module {
     return inOutPort;
   }
 
+  LogicType addMatchedInOut<LogicType extends Logic>(
+      String name, LogicType source) {
+    _checkForSafePortName(name);
+
+    if (!source.isNet) {
+      throw Exception('Matched inOuts must be fully nets.');
+    }
+
+    // TODO finish implementation!
+    return source;
+  }
+
   /// Registers and returns an input [LogicArray] port to this [Module] with
   /// the specified [dimensions], [elementWidth], and [numUnpackedDimensions]
   /// named [name].
@@ -828,6 +827,11 @@ abstract class Module {
   LogicType addMatchedOutput<LogicType extends Logic>(
       String name, LogicType toMatch) {
     _checkForSafePortName(name);
+
+    if (toMatch.isNet || (toMatch is LogicStructure && toMatch.hasNets)) {
+      //TODO
+      throw Exception('Matched outputs cannot have nets in them.');
+    }
 
     // must make a new clone of it, to avoid people using ports of other modules
     final outPort = toMatch.clone(name: name) as LogicType;
@@ -925,33 +929,6 @@ abstract class Module {
 
     return inOutArr;
   }
-
-  // StructType addInputStructure<StructType extends LogicStructure>(
-  //     String name, StructType source) {
-  //   final inputStruct = (source.clone(name: name) as StructType)
-  //     ..gets(addInput(name, source, width: source.width));
-
-  //   _inputStructures[name] = inputStruct;
-  //   _inputStructureSources[name] = source;
-
-  //   return inputStruct;
-  // }
-
-  // StructType addOutputStructure<StructType extends LogicStructure>(
-  //     String name, StructType internalSource) {
-  //   final externalStruct = internalSource.clone(name: name);
-  //   final outputPort = addOutput(name, width: externalStruct.width);
-
-  //   outputPort <= internalSource;
-  //   externalStruct <= outputPort;
-
-  //   return externalStruct as StructType;
-  // }
-
-  // StructType addInOutStructure<StructType extends LogicStructure>(
-  //         String name, StructType source) =>
-  //     (source.clone(name: name) as StructType)
-  //       ..gets(addInOut(name, source, width: source.width));
 
   InterfaceType connectInterface<InterfaceType extends Interface<TagType>,
               TagType extends Enum>(InterfaceType source,

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -677,12 +677,19 @@ abstract class Module {
     return inPort;
   }
 
+  /// Registers a signal as an [input] to this [Module] and returns an input
+  /// port that can be consumed. The type of the port will be [LogicType] and
+  /// constructed via [Logic.clone], so it is required that the [source]
+  /// implements clone functionality that matches the type and properly updates
+  /// the [Logic.name] as well.
+  ///
+  /// The return value is the same as what is returned by [input] and should
+  /// only be used within this [Module]. The provided [source] is accessible via
+  /// [inputSource].
   LogicType addMatchedInput<LogicType extends Logic>(
       String name, LogicType source) {
     _checkForSafePortName(name);
 
-    // TODO: confirm that no matched input/output structure has ANY nets in it
-    //  or we will violate all kinds of assumptions
     if (source.isNet || (source is LogicStructure && source.hasNets)) {
       throw PortTypeException(
           source, 'Matched inputs cannot have nets in them.');

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -722,7 +722,7 @@ abstract class Module {
   final Set<Logic> _inOutDrivers = {};
 
   /// Registers a signal as an [inOut] to this [Module] and returns an inOut
-  /// port that can be consumed.
+  /// port that can be consumed inside this [Module].
   ///
   /// The return value is the same as what is returned by [inOut] and should
   /// only be used within this [Module]. The provided [source] is accessible via
@@ -771,6 +771,15 @@ abstract class Module {
     return inOutPort;
   }
 
+  /// Registers a signal as an [inOut] to this [Module] and returns an inOut
+  /// port that can be consumed inside this [Module]. The type of the port will
+  /// be [LogicType] and constructed via [Logic.clone], so it is required that
+  /// the [source] implements clone functionality that matches the type and
+  /// properly updates the [Logic.name] as well.
+  ///
+  /// The return value is the same as what is returned by [inOut] and should
+  /// only be used within this [Module]. The provided [source] is accessible via
+  /// [inOutSource].
   LogicType addMatchedInOut<LogicType extends Logic>(
       String name, LogicType source) {
     _checkForSafePortName(name);
@@ -855,7 +864,7 @@ abstract class Module {
   }
 
   /// Registers an [output] to this [Module] and returns an output port that can
-  /// be driven.
+  /// be driven by this [Module] or consumed outside of it.
   ///
   /// The return value is the same as what is returned by [output].
   Logic addOutput(String name, {int width = 1}) {
@@ -869,6 +878,16 @@ abstract class Module {
     return outPort;
   }
 
+  /// Registers an [output] to this [Module] and returns an output port that can
+  /// be driven by this [Module] or consumed outside of it. The type of the port
+  /// will be [LogicType] and constructed via [Logic.clone] on [toMatch], so it
+  /// is required that the [toMatch] implements clone functionality that matches
+  /// the type and properly updates the [Logic.name] as well.
+  ///
+  /// This function does not set the [toMatch] argument to drive or be driven by
+  /// the [output] port.
+  ///
+  /// The return value is the same as what is returned by [output].
   LogicType addMatchedOutput<LogicType extends Logic>(
       String name, LogicType toMatch) {
     _checkForSafePortName(name);

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -995,6 +995,8 @@ abstract class Module {
     return inOutArr;
   }
 
+  /// Connects the [source] to this [Module] using [Interface.connectIO] and
+  /// returns a copy of the [source] that can be used within this module.
   InterfaceType connectInterface<InterfaceType extends Interface<TagType>,
               TagType extends Enum>(InterfaceType source,
           {Iterable<TagType>? inputTags,
@@ -1008,6 +1010,8 @@ abstract class Module {
             inOutTags: inOutTags,
             uniquify: uniquify);
 
+  /// Connects the [source] to this [Module] using [PairInterface.pairConnectIO]
+  /// and returns a copy of the [source] that can be used within this module.
   InterfaceType connectPairInterface<InterfaceType extends PairInterface>(
           InterfaceType source, PairRole role,
           {String Function(String original)? uniquify}) =>

--- a/lib/src/modules/conditionals/ssa.dart
+++ b/lib/src/modules/conditionals/ssa.dart
@@ -22,4 +22,8 @@ class SsaLogic extends Logic {
   /// Constructs a new SSA node referring to a signal in a specific context.
   SsaLogic(this.ref, this.context)
       : super(width: ref.width, name: ref.name, naming: Naming.mergeable);
+
+  @override
+  SsaLogic clone({String? name}) =>
+      throw UnimplementedError('Should not clone an SsaLogic');
 }

--- a/lib/src/signals/const.dart
+++ b/lib/src/signals/const.dart
@@ -29,4 +29,7 @@ class Const extends Logic {
 
     makeUnassignable(reason: '`Const` signals are unassignable.');
   }
+
+  @override
+  Logic clone({String? name}) => Const(value, width: width);
 }

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -269,10 +269,9 @@ class Logic {
   /// Makes a copy of `this`, optionally with the specified [name], but the same
   /// [width].
   @mustBeOverridden
-  //TODO: does this need to expose naming too?
   Logic clone({String? name}) => _clone(name: name);
 
-  /// Makes a [clone] with the provided [name] and optionally [naming], then
+  /// Makes a new [Logic] with the provided [name] and optionally [naming], then
   /// assigns it to be driven by `this`.
   ///
   /// This is a useful utility for naming the result of some hardware
@@ -284,7 +283,6 @@ class Logic {
   /// final myImportantNode = (a ^ b).named('myImportantNode');
   /// ```
   Logic named(String name, {Naming? naming}) =>
-      //TODO: ths should call `clone` instead of _clone so it gets renamed properly
       _clone(name: name, naming: naming)..gets(this);
 
   /// An internal constructor for [Logic] which additional provides access to

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -192,7 +192,7 @@ class Logic {
   ///
   /// This should *only* be called by [Module.build].  It is used to
   /// optimize search.
-  @protected
+  @internal
   set parentModule(Module? newParentModule) {
     assert(_parentModule == null || _parentModule == newParentModule,
         'Should only set parent module once.');
@@ -268,6 +268,8 @@ class Logic {
 
   /// Makes a copy of `this`, optionally with the specified [name], but the same
   /// [width].
+  @mustBeOverridden
+  //TODO: does this need to expose naming too?
   Logic clone({String? name}) => _clone(name: name);
 
   /// Makes a [clone] with the provided [name] and optionally [naming], then
@@ -282,6 +284,7 @@ class Logic {
   /// final myImportantNode = (a ^ b).named('myImportantNode');
   /// ```
   Logic named(String name, {Naming? naming}) =>
+      //TODO: ths should call `clone` instead of _clone so it gets renamed properly
       _clone(name: name, naming: naming)..gets(this);
 
   /// An internal constructor for [Logic] which additional provides access to

--- a/lib/src/signals/logic_array.dart
+++ b/lib/src/signals/logic_array.dart
@@ -197,6 +197,7 @@ class LogicArray extends LogicStructure {
   ///
   /// If no new [name] is specified, then it will also have the same name.
   @override
+  @mustBeOverridden
   LogicArray clone({String? name}) => _clone(name: name);
 
   /// Makes a [clone] with the provided [name] and optionally [naming], then

--- a/lib/src/signals/logic_net.dart
+++ b/lib/src/signals/logic_net.dart
@@ -97,4 +97,8 @@ class LogicNet extends Logic {
   void _blastWire() {
     _updateWire((_wire as _WireNet).toBlasted());
   }
+
+  @override
+  @mustBeOverridden
+  Logic clone({String? name}) => super.clone(name: name) as LogicNet;
 }

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -49,6 +49,7 @@ class LogicStructure implements Logic {
               ' ${element.parentStructure}.');
         }
 
+        // TODO: this check is ONLY applicable if we're making it a port? or just never?
         if (element.parentModule != null &&
             element.parentModule!.isPort(element)) {
           // Note we do not use `element.isPort` since that will set the lazy

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -49,17 +49,6 @@ class LogicStructure implements Logic {
               ' ${element.parentStructure}.');
         }
 
-        // TODO: this check is ONLY applicable if we're making it a port? or just never?
-        if (element.parentModule != null &&
-            element.parentModule!.isPort(element)) {
-          // Note we do not use `element.isPort` since that will set the lazy
-          // variable, which would break assumptions when we create the port,
-          // which may be in progress
-          throw LogicConstructionException(
-              '`Module` ports cannot be set as elements of a `LogicStructure`,'
-              ' but $element is a port of ${element.parentModule}.');
-        }
-
         element._parentStructure = this;
       });
   }

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -629,7 +629,12 @@ class LogicStructure implements Logic {
       packed.selectFrom(busList, defaultValue: defaultValue);
 
   @override
-  bool get isNet => false;
+  bool get isNet => elements.every((e) => e.isNet);
+
+  /// Indicates whether this structure or any of its elements [isNet].
+  bool get hasNets =>
+      elements.any((e) => e.isNet || (e is LogicStructure && e.hasNets)) ||
+      isNet;
 
   @override
   Iterable<Logic> get srcConnections => {

--- a/lib/src/signals/port.dart
+++ b/lib/src/signals/port.dart
@@ -32,4 +32,7 @@ class Port extends Logic {
       throw InvalidPortNameException(name);
     }
   }
+
+  @override
+  Logic clone({String? name}) => Port(name ?? this.name, width);
 }

--- a/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
@@ -31,6 +31,8 @@ class SystemVerilogSynthModuleDefinition extends SynthModuleDefinition {
   /// [LogicNet]s.
   SystemVerilogSynthSubModuleInstantiation _addNetConnect(
       SynthLogic dst, SynthLogic src) {
+    //TODO: this needs to suport partial assignments!
+
     // make an (unconnected) module representing the assignment
     final netConnect =
         _NetConnect(LogicNet(width: dst.width), LogicNet(width: src.width));

--- a/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
@@ -31,8 +31,6 @@ class SystemVerilogSynthModuleDefinition extends SynthModuleDefinition {
   /// [LogicNet]s.
   SystemVerilogSynthSubModuleInstantiation _addNetConnect(
       SynthLogic dst, SynthLogic src) {
-    //TODO: this needs to suport partial assignments!
-
     // make an (unconnected) module representing the assignment
     final netConnect =
         _NetConnect(LogicNet(width: dst.width), LogicNet(width: src.width));
@@ -57,10 +55,10 @@ class SystemVerilogSynthModuleDefinition extends SynthModuleDefinition {
     final reducedAssignments = <SynthAssignment>[];
 
     for (final assignment in assignments) {
-      // if (assignment is PartialSynthAssignment) { //TODO?
-      //   subsetReceiveStructPort(assignment.dst);
-      // } else
       if (assignment.src.isNet && assignment.dst.isNet) {
+        assert(assignment is! PartialSynthAssignment,
+            'Net connections should not be partial assignments.');
+
         _addNetConnect(assignment.dst, assignment.src);
       } else {
         reducedAssignments.add(assignment);

--- a/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synth_module_definition.dart
@@ -57,6 +57,9 @@ class SystemVerilogSynthModuleDefinition extends SynthModuleDefinition {
     final reducedAssignments = <SynthAssignment>[];
 
     for (final assignment in assignments) {
+      // if (assignment is PartialSynthAssignment) { //TODO?
+      //   subsetReceiveStructPort(assignment.dst);
+      // } else
       if (assignment.src.isNet && assignment.dst.isNet) {
         _addNetConnect(assignment.dst, assignment.src);
       } else {

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
@@ -152,9 +152,15 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
           'Net connections should have been implemented as'
           ' bidirectional net connections.');
 
-      // TODO: need to handle partial assignments here
-      assignmentLines
-          .add('assign ${assignment.dst.name} = ${assignment.src.name};');
+      var sliceString = '';
+      if (assignment is PartialSynthAssignment) {
+        sliceString = assignment.upperIndex == assignment.lowerIndex
+            ? '[${assignment.upperIndex}]'
+            : '[${assignment.upperIndex}:${assignment.lowerIndex}]';
+      }
+
+      assignmentLines.add('assign ${assignment.dst.name}$sliceString'
+          ' = ${assignment.src.name};');
     }
     return assignmentLines.join('\n');
   }

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
@@ -152,6 +152,7 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
           'Net connections should have been implemented as'
           ' bidirectional net connections.');
 
+      // TODO: need to handle partial assignments here
       assignmentLines
           .add('assign ${assignment.dst.name} = ${assignment.src.name};');
     }

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
@@ -154,9 +154,9 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
 
       var sliceString = '';
       if (assignment is PartialSynthAssignment) {
-        sliceString = assignment.upperIndex == assignment.lowerIndex
-            ? '[${assignment.upperIndex}]'
-            : '[${assignment.upperIndex}:${assignment.lowerIndex}]';
+        sliceString = assignment.dstUpperIndex == assignment.dstLowerIndex
+            ? '[${assignment.dstUpperIndex}]'
+            : '[${assignment.dstUpperIndex}:${assignment.dstLowerIndex}]';
       }
 
       assignmentLines.add('assign ${assignment.dst.name}$sliceString'

--- a/lib/src/synthesizers/utilities/synth_assignment.dart
+++ b/lib/src/synthesizers/utilities/synth_assignment.dart
@@ -39,26 +39,30 @@ class SynthAssignment {
     return _src;
   }
 
+  bool _checkWidths() => _src.width == _dst.width;
+
   /// Constructs a representation of an assignment.
-  SynthAssignment(this._src, this._dst)
-      : assert(
-            _src.width == _dst.width,
-            'Cannot assign signals of different widths:'
-            ' ${_src.width} vs ${_dst.width}');
+  SynthAssignment(this._src, this._dst) {
+    assert(_checkWidths(), 'Signal width mismatch');
+  }
 
   @override
   String toString() => '$dst <= $src';
 }
 
 class PartialSynthAssignment extends SynthAssignment {
-  int upperIndex;
-  int lowerIndex;
-
-  /// Constructs a representation of a partial assignment.
-  PartialSynthAssignment(SynthLogic src, SynthLogic dst,
-      {required this.upperIndex, required this.lowerIndex})
-      : super(src, dst);
+  int dstUpperIndex;
+  int dstLowerIndex;
 
   @override
-  String toString() => '$dst[$upperIndex:$lowerIndex] <= $src';
+  bool _checkWidths() => _src.width == (dstUpperIndex - dstLowerIndex + 1);
+
+  /// Constructs a representation of a partial assignment.
+  PartialSynthAssignment(super._src, super._dst,
+      {required this.dstUpperIndex, required this.dstLowerIndex})
+      : assert(dstLowerIndex >= 0, 'Invalid lower index'),
+        assert(dstUpperIndex < _dst.width, 'Invalid upper index');
+
+  @override
+  String toString() => '$dst[$dstUpperIndex:$dstLowerIndex] <= $src';
 }

--- a/lib/src/synthesizers/utilities/synth_assignment.dart
+++ b/lib/src/synthesizers/utilities/synth_assignment.dart
@@ -40,7 +40,11 @@ class SynthAssignment {
   }
 
   /// Constructs a representation of an assignment.
-  SynthAssignment(this._src, this._dst);
+  SynthAssignment(this._src, this._dst)
+      : assert(
+            _src.width == _dst.width,
+            'Cannot assign signals of different widths:'
+            ' ${_src.width} vs ${_dst.width}');
 
   @override
   String toString() => '$dst <= $src';

--- a/lib/src/synthesizers/utilities/synth_assignment.dart
+++ b/lib/src/synthesizers/utilities/synth_assignment.dart
@@ -45,3 +45,16 @@ class SynthAssignment {
   @override
   String toString() => '$dst <= $src';
 }
+
+class PartialSynthAssignment extends SynthAssignment {
+  int upperIndex;
+  int lowerIndex;
+
+  /// Constructs a representation of a partial assignment.
+  PartialSynthAssignment(SynthLogic src, SynthLogic dst,
+      {required this.upperIndex, required this.lowerIndex})
+      : super(src, dst);
+
+  @override
+  String toString() => '$dst[$upperIndex:$lowerIndex] <= $src';
+}

--- a/lib/src/synthesizers/utilities/synth_assignment.dart
+++ b/lib/src/synthesizers/utilities/synth_assignment.dart
@@ -39,6 +39,7 @@ class SynthAssignment {
     return _src;
   }
 
+  /// Used for assertions, checks if the widths meet proper expectations.
   bool _checkWidths() => _src.width == _dst.width;
 
   /// Constructs a representation of an assignment.
@@ -50,8 +51,12 @@ class SynthAssignment {
   String toString() => '$dst <= $src';
 }
 
+/// Represents an assignment from a full source to a partial destination.
 class PartialSynthAssignment extends SynthAssignment {
+  /// The upper index of the destination.
   int dstUpperIndex;
+
+  /// The lower index of the destination.
   int dstLowerIndex;
 
   @override

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -31,9 +31,15 @@ class SynthLogic {
     _replacement = newReplacement;
   }
 
+  /// Indicates if this signal is an element of a [LogicStructure] that is a
+  /// port.
+  ///
+  /// Note that this is distinct from a port that is an element of a
+  /// [LogicStructure] that is not a port.
   bool get isStructPortElement =>
       (this is! SynthLogicArrayElement) &&
-      logics.any((e) => e.isPort && e.parentStructure != null);
+      logics.any((e) =>
+          e.isPort && e.parentStructure != null && e.parentStructure!.isPort);
 
   // bool get isMainPort =>
   //     logics.any((e) => e.isPort && e.parentStructure == null); // TODO?

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -31,6 +31,10 @@ class SynthLogic {
     _replacement = newReplacement;
   }
 
+  bool get isStructPortElement =>
+      (this is! SynthLogicArrayElement) &&
+      logics.any((e) => e.isPort && e.parentStructure != null);
+
   /// The direct replacement of this [SynthLogic].
   SynthLogic? _replacement;
 
@@ -79,7 +83,10 @@ class SynthLogic {
   /// other. If onlyt one of them is not [mergeable], it can adopt the elements
   /// from the other.
   bool get mergeable =>
-      _reservedLogic == null && _constLogic == null && _renameableLogic == null;
+      _reservedLogic == null &&
+      _constLogic == null &&
+      _renameableLogic == null &&
+      !isStructPortElement;
 
   /// True only if this represents a [LogicArray].
   final bool isArray;

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -83,10 +83,8 @@ class SynthLogic {
   /// other. If onlyt one of them is not [mergeable], it can adopt the elements
   /// from the other.
   bool get mergeable =>
-      _reservedLogic == null &&
-      _constLogic == null &&
-      _renameableLogic == null &&
-      !isStructPortElement;
+      _reservedLogic == null && _constLogic == null && _renameableLogic == null;
+  // && !isStructPortElement; // TODO: need this?
 
   /// True only if this represents a [LogicArray].
   final bool isArray;

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -35,6 +35,9 @@ class SynthLogic {
       (this is! SynthLogicArrayElement) &&
       logics.any((e) => e.isPort && e.parentStructure != null);
 
+  // bool get isMainPort =>
+  //     logics.any((e) => e.isPort && e.parentStructure == null); // TODO?
+
   /// The direct replacement of this [SynthLogic].
   SynthLogic? _replacement;
 
@@ -204,6 +207,12 @@ class SynthLogic {
       return null;
     }
 
+    //TODO?
+    // if ((a.isMainPort && b.isStructPortElement) ||
+    //     (b.isMainPort && a.isStructPortElement)) {
+    //   return null;
+    // }
+
     if (b.mergeable) {
       a.adopt(b);
       return b;
@@ -227,6 +236,8 @@ class SynthLogic {
     assert(other.mergeable || _constantsMergeable(this, other),
         'Cannot merge a non-mergeable into this.');
     assert(other.isArray == isArray, 'Cannot merge arrays and non-arrays');
+    assert(other.width == width,
+        'Cannot merge logics of different widths: $width vs ${other.width}');
 
     _constNameDisallowed |= other._constNameDisallowed;
 

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -41,9 +41,6 @@ class SynthLogic {
       logics.any((e) =>
           e.isPort && e.parentStructure != null && e.parentStructure!.isPort);
 
-  // bool get isMainPort =>
-  //     logics.any((e) => e.isPort && e.parentStructure == null); // TODO?
-
   /// The direct replacement of this [SynthLogic].
   SynthLogic? _replacement;
 
@@ -93,7 +90,6 @@ class SynthLogic {
   /// from the other.
   bool get mergeable =>
       _reservedLogic == null && _constLogic == null && _renameableLogic == null;
-  // && !isStructPortElement; // TODO: need this?
 
   /// True only if this represents a [LogicArray].
   final bool isArray;
@@ -212,12 +208,6 @@ class SynthLogic {
       // do not merge nets with non-nets
       return null;
     }
-
-    //TODO?
-    // if ((a.isMainPort && b.isStructPortElement) ||
-    //     (b.isMainPort && a.isStructPortElement)) {
-    //   return null;
-    // }
 
     if (b.mergeable) {
       a.adopt(b);

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -130,6 +130,12 @@ class SynthModuleDefinition {
   /// definition.
   final List<Module> supportingModules = [];
 
+  //TODO: plan for mapping to struct ports
+  // - when driving an output struct (not array) from inside a module, just do `assign myOut[5:3] = ...`
+  // - when receiving an input struct (not array) from inside a module, just do `... = myIn[5:3]`
+  // - when receiving from a submodule output struct (not array), just do `... = mySubmodule.myOut[5:3]`
+  // - when driving a submodule input struct (not array), just do `myIn[5:3] = ...` but force a new intermediate signal to be driven
+
   /// Creates a new definition representation for this [module].
   SynthModuleDefinition(this.module)
       : _synthInstantiationNameUniquifier = Uniquifier(
@@ -197,11 +203,11 @@ class SynthModuleDefinition {
         continue;
       }
 
-      if (receiver is LogicArray) {
+      if (receiver is LogicStructure) {
         logicsToTraverse.addAll(receiver.elements);
       }
 
-      if (receiver.isArrayMember) {
+      if (receiver.parentStructure != null) {
         logicsToTraverse.add(receiver.parentStructure!);
       }
 
@@ -232,11 +238,11 @@ class SynthModuleDefinition {
       final receiverIsConstant = driver == null && receiver is Const;
 
       final receiverIsModuleInput =
-          module.isInput(receiver) && !receiver.isArrayMember;
+          module.isInput(receiver) && receiver.parentStructure == null;
       final receiverIsModuleOutput =
-          module.isOutput(receiver) && !receiver.isArrayMember;
+          module.isOutput(receiver) && receiver.parentStructure == null;
       final receiverIsModuleInOut =
-          module.isInOut(receiver) && !receiver.isArrayMember;
+          module.isInOut(receiver) && receiver.parentStructure == null;
 
       final synthDriver = _getSynthLogic(driver);
 

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -166,7 +166,6 @@ class SynthModuleDefinition {
 
     var idx = 0;
     for (final leafElement in port.leafElements) {
-      //TODO: test hiearchical structs
       final leafSynth = _getSynthLogic(leafElement)!;
       internalSignals.add(leafSynth);
       assignments.add(PartialSynthAssignment(leafSynth, portSynth,

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -269,6 +269,16 @@ class SynthModuleDefinition {
         ..addAll(subModule.inputs.values)
         ..addAll(subModule.outputs.values)
         ..addAll(subModule.inOuts.values);
+
+      subModule.inputs.values
+          .whereType<LogicStructure>()
+          .where((e) => e is! LogicArray)
+          .forEach(_partialAssignStructPort);
+
+      subModule.outputs.values
+          .whereType<LogicStructure>()
+          .where((e) => e is! LogicArray)
+          .forEach(_subsetReceiveStructPort);
     }
 
     // search for other modules contained within this module

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -170,7 +170,7 @@ class SynthModuleDefinition {
       final leafSynth = _getSynthLogic(leafElement)!;
       internalSignals.add(leafSynth);
       assignments.add(PartialSynthAssignment(leafSynth, portSynth,
-          upperIndex: idx + leafElement.width - 1, lowerIndex: idx));
+          dstUpperIndex: idx + leafElement.width - 1, dstLowerIndex: idx));
       idx += leafElement.width;
     }
   }

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -551,10 +551,18 @@ class SynthModuleDefinition {
     // there might be more assign statements than necessary, so let's ditch them
     var prevAssignmentCount = 0;
 
+    // grapb the partial assignments since they can't be merged
+    final partialAssignments =
+        assignments.whereType<PartialSynthAssignment>().toList();
+    assignments.removeWhere((e) => e is PartialSynthAssignment);
+
     while (prevAssignmentCount != assignments.length) {
       // keep looping until it stops shrinking
       final reducedAssignments = <SynthAssignment>[];
       for (final assignment in assignments) {
+        assert(assignment is! PartialSynthAssignment,
+            'Partial assignments should have been removed before this.');
+
         final dst = assignment.dst;
         final src = assignment.src;
 
@@ -597,6 +605,10 @@ class SynthModuleDefinition {
         ..clear()
         ..addAll(reducedAssignments);
     }
+
+    // add back all the partial assignments that were removed since they could
+    // not be merged
+    assignments.addAll(partialAssignments);
 
     // update the look-up table post-merge
     logicToSynthMap.clear();

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -153,16 +153,6 @@ class SynthModuleDefinition {
   /// definition.
   final List<Module> supportingModules = [];
 
-  //TODO: plan for mapping to struct ports
-  // - when driving an output struct (not array) from inside a module, just do `assign myOut[5:3] = ...`
-  // - when receiving an input struct (not array) from inside a module, just do `... = myIn[5:3]`
-  // - when receiving from a submodule output struct (not array), just do `... = mySubmodule.myOut[5:3]`
-  // - when driving a submodule input struct (not array), just do `myIn[5:3] = ...` but force a new intermediate signal to be driven
-  // HOWEVER: we cannot assume expressions can go anywhere, due to expressionless inputs, so we should reassign to the struct members?
-  // OK new plan:
-  // - when DRIVING a struct port (my output, sub's input), we use a "partial assignment", a new construct
-  // - when RECEIVING from a struct port (my input, sub's output), we use a BusSubset locally created to slice it off
-
   /// Takes all the leaf elements of [port] and drives [port] with them, each
   /// with a partial assignment.
   ///
@@ -332,6 +322,8 @@ class SynthModuleDefinition {
       final synthReceiver = _getSynthLogic(receiver)!;
 
       if (receiver is LogicNet) {
+        // only for the leaves, that's why only `LogicNet` and not array/struct
+
         logicsToTraverse.addAll([
           ...receiver.srcConnections,
           ...receiver.dstConnections

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -347,12 +347,15 @@ class SynthModuleDefinition {
 
       final receiverIsConstant = driver == null && receiver is Const;
 
+      final receiverParentStructureIsPort =
+          receiver.parentStructure != null && receiver.parentStructure!.isPort;
+
       final receiverIsModuleInput =
-          module.isInput(receiver) && receiver.parentStructure == null;
+          module.isInput(receiver) && !receiverParentStructureIsPort;
       final receiverIsModuleOutput =
-          module.isOutput(receiver) && receiver.parentStructure == null;
+          module.isOutput(receiver) && !receiverParentStructureIsPort;
       final receiverIsModuleInOut =
-          module.isInOut(receiver) && receiver.parentStructure == null;
+          module.isInOut(receiver) && !receiverParentStructureIsPort;
 
       final synthDriver = _getSynthLogic(driver);
 
@@ -363,6 +366,11 @@ class SynthModuleDefinition {
       } else if (receiverIsModuleInOut) {
         inOuts.add(synthReceiver);
       } else {
+        assert(
+            !inputs.contains(synthReceiver) &&
+                !outputs.contains(synthReceiver) &&
+                !inOuts.contains(synthReceiver),
+            'Internal signals should not be ports also.');
         internalSignals.add(synthReceiver);
       }
 

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -269,7 +269,8 @@ class SynthModuleDefinition {
         logicsToTraverse.addAll(receiver.elements);
       }
 
-      if (receiver.parentStructure != null) {
+      if (receiver.isArrayMember) {
+        // don't need to step up to any structure, just arrays
         logicsToTraverse.add(receiver.parentStructure!);
       }
 

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -177,7 +177,20 @@ class SynthModuleDefinition {
       ..addAll(module.inOuts.values);
 
     for (final output in module.outputs.values) {
-      outputs.add(_getSynthLogic(output)!);
+      final outputSynth = _getSynthLogic(output)!;
+      outputs.add(outputSynth);
+
+      if (output is LogicStructure && output is! LogicArray) {
+        var idx = 0;
+        for (final leafElement in output.leafElements) {
+          //TODO: test hiearchical structs
+          final leafSynth = _getSynthLogic(leafElement)!;
+          internalSignals.add(leafSynth);
+          assignments.add(PartialSynthAssignment(leafSynth, outputSynth,
+              upperIndex: idx + leafElement.width - 1, lowerIndex: idx));
+          idx += leafElement.width;
+        }
+      }
     }
 
     // make sure disconnected inputs are included

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -152,6 +152,9 @@ class SynthModuleDefinition {
   // - when receiving from a submodule output struct (not array), just do `... = mySubmodule.myOut[5:3]`
   // - when driving a submodule input struct (not array), just do `myIn[5:3] = ...` but force a new intermediate signal to be driven
   // HOWEVER: we cannot assume expressions can go anywhere, due to expressionless inputs, so we should reassign to the struct members?
+  // OK new plan:
+  // - when DRIVING a struct port (my output, sub's input), we use a "partial assignment", a new construct
+  // - when RECEIVING from a struct port (my input, sub's output), we use a BusSubset locally created to slice it off
 
   /// Creates a new definition representation for this [module].
   SynthModuleDefinition(this.module)

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -224,6 +224,7 @@ abstract class SimCompare {
     RegExp(r'sorry: constant selects in always_\* processes'
         ' are not currently supported'),
     RegExp('warning: always_comb process has no sensitivities'),
+    RegExp('finish called at'),
   ];
 
   /// Executes [vectors] against the Icarus Verilog simulator and checks

--- a/test/assignment_test.dart
+++ b/test/assignment_test.dart
@@ -38,15 +38,17 @@ class MyStruct extends LogicStructure {
   final Logic smaller;
   final Logic big;
 
-  factory MyStruct() => MyStruct._(
+  factory MyStruct({String name = 'myStruct'}) => MyStruct._(
         Logic(name: 'smaller'),
         Logic(name: 'big', width: 8),
+        name: name,
       );
 
-  MyStruct._(this.smaller, this.big) : super([smaller, big], name: 'myStruct');
+  MyStruct._(this.smaller, this.big, {required String name})
+      : super([smaller, big], name: name);
 
   @override
-  LogicStructure clone({String? name}) => MyStruct();
+  MyStruct clone({String? name}) => MyStruct(name: name ?? this.name);
 }
 
 class LogicStructSubsetModule extends Module {

--- a/test/counter_wintf_test.dart
+++ b/test/counter_wintf_test.dart
@@ -30,6 +30,9 @@ class CounterInterface extends Interface<CounterDirection> {
       CounterDirection.outward
     ]);
   }
+
+  @override
+  CounterInterface clone() => CounterInterface(width);
 }
 
 class Counter extends Module {

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -18,6 +18,9 @@ class MyModuleInterface extends Interface<MyDirection> {
     setPorts(
         [LogicNet.port('p2'), LogicArray.netPort('p2arr')], [MyDirection.dir2]);
   }
+
+  @override
+  MyModuleInterface clone() => MyModuleInterface();
 }
 
 class MyModule extends Module {
@@ -37,16 +40,23 @@ class UncleanPortInterface extends Interface<MyDirection> {
   UncleanPortInterface() {
     setPorts([Logic.port('end')], [MyDirection.dir1]);
   }
+
+  @override
+  UncleanPortInterface clone() => UncleanPortInterface();
 }
 
 class MaybePortInterface extends Interface<MyDirection> {
   Logic? get p => tryPort('p');
 
-  MaybePortInterface({required bool includePort}) {
+  final bool includePort;
+  MaybePortInterface({required this.includePort}) {
     if (includePort) {
       setPorts([Logic.port('p')], {MyDirection.dir1});
     }
   }
+
+  @override
+  MaybePortInterface clone() => MaybePortInterface(includePort: includePort);
 }
 
 class BadNetInterface extends Interface<MyDirection> {
@@ -54,6 +64,9 @@ class BadNetInterface extends Interface<MyDirection> {
     setPorts([Logic.port('p')], [MyDirection.dir1]);
     setPorts([LogicArray.port('a')], [MyDirection.dir2]);
   }
+
+  @override
+  BadNetInterface clone() => BadNetInterface();
 }
 
 class BadNetModule extends Module {

--- a/test/logic_array_test.dart
+++ b/test/logic_array_test.dart
@@ -161,6 +161,13 @@ class LAPassthroughIntf extends Interface<LADir> {
           elementWidth: other.elementWidth,
           numUnpackedDimensions: other.numUnpackedDimensions,
         );
+
+  @override
+  LAPassthroughIntf clone() => LAPassthroughIntf(
+        dimensions: dimensions,
+        elementWidth: elementWidth,
+        numUnpackedDimensions: numUnpackedDimensions,
+      );
 }
 
 class LAPassthroughWithIntf extends Module implements SimpleLAPassthrough {

--- a/test/logic_name_test.dart
+++ b/test/logic_name_test.dart
@@ -17,12 +17,17 @@ class MyStruct extends LogicStructure {
   final Logic ready;
   final Logic valid;
 
-  factory MyStruct() => MyStruct._(
+  factory MyStruct({String name = 'myStruct'}) => MyStruct._(
         Logic(name: 'ready'),
         Logic(name: 'valid'),
+        name: name,
       );
 
-  MyStruct._(this.ready, this.valid) : super([ready, valid], name: 'myStruct');
+  MyStruct._(this.ready, this.valid, {required String name})
+      : super([ready, valid], name: name);
+
+  @override
+  MyStruct clone({String? name}) => MyStruct(name: name ?? this.name);
 }
 
 class LogicTestModule extends Module {

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -17,15 +17,17 @@ class MyStruct extends LogicStructure {
   final Logic ready;
   final Logic valid;
 
-  factory MyStruct() => MyStruct._(
+  factory MyStruct({String? name}) => MyStruct._(
         Logic(name: 'ready'),
         Logic(name: 'valid'),
+        name: name,
       );
 
-  MyStruct._(this.ready, this.valid) : super([ready, valid], name: 'myStruct');
+  MyStruct._(this.ready, this.valid, {String? name})
+      : super([ready, valid], name: name ?? 'myStruct');
 
   @override
-  LogicStructure clone({String? name}) => MyStruct();
+  LogicStructure clone({String? name}) => MyStruct(name: name);
 }
 
 class MyFancyStruct extends LogicStructure {

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -13,21 +13,40 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
-class MyStruct extends LogicStructure {
+/// This is the struct used in the logic structures documentation.
+class ReadyValidStruct extends LogicStructure {
   final Logic ready;
   final Logic valid;
 
-  factory MyStruct({String? name}) => MyStruct._(
+  factory ReadyValidStruct({String name = 'readyValid'}) => ReadyValidStruct._(
         Logic(name: 'ready'),
         Logic(name: 'valid'),
         name: name,
       );
 
-  MyStruct._(this.ready, this.valid, {String? name})
-      : super([ready, valid], name: name ?? 'myStruct');
+  ReadyValidStruct._(this.ready, this.valid, {required String name})
+      : super([ready, valid], name: name);
 
   @override
-  LogicStructure clone({String? name}) => MyStruct(name: name);
+  ReadyValidStruct clone({String? name}) =>
+      ReadyValidStruct(name: name ?? this.name);
+}
+
+class MyStruct extends LogicStructure {
+  final Logic ready;
+  final Logic valid;
+
+  factory MyStruct({String name = 'myStruct'}) => MyStruct._(
+        Logic(name: 'ready'),
+        Logic(name: 'valid'),
+        name: name,
+      );
+
+  MyStruct._(this.ready, this.valid, {required super.name})
+      : super([ready, valid]);
+
+  @override
+  MyStruct clone({String? name}) => MyStruct(name: name ?? this.name);
 }
 
 class MyFancyStruct extends LogicStructure {
@@ -35,14 +54,21 @@ class MyFancyStruct extends LogicStructure {
   final Logic bus;
   final LogicStructure subStruct;
 
-  factory MyFancyStruct({int busWidth = 12}) => MyFancyStruct._(
+  factory MyFancyStruct({int busWidth = 12, String name = 'myFancyStruct'}) =>
+      MyFancyStruct._(
         LogicArray([3, 3], 8, name: 'arr'),
         Logic(name: 'bus', width: busWidth),
         MyStruct(),
+        name: name,
       );
 
-  MyFancyStruct._(this.arr, this.bus, this.subStruct)
-      : super([arr, bus, subStruct], name: 'myFancyStruct');
+  MyFancyStruct._(this.arr, this.bus, this.subStruct,
+      {super.name = 'myFancyStruct'})
+      : super([arr, bus, subStruct]);
+
+  @override
+  MyFancyStruct clone({String? name}) =>
+      MyFancyStruct(busWidth: bus.width, name: name ?? this.name);
 }
 
 class StructPortModule extends Module {
@@ -111,6 +137,11 @@ class StructModuleWithInstrumentation extends Module {
 void main() {
   tearDown(() async {
     await Simulator.reset();
+  });
+
+  test('example ready valid struct', () {
+    expect(
+        ReadyValidStruct(name: 'hello').clone(name: 'goodbye').name, 'goodbye');
   });
 
   test('late previousValue', () async {

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -1,4 +1,5 @@
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
 class MyStruct extends LogicStructure {
@@ -48,6 +49,10 @@ class SimpleStructModuleContainer extends Module {
 }
 
 void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
   test('simple struct module', () async {
     final mod = SimpleStructModuleContainer(Logic(), Logic());
     await mod.build();
@@ -55,6 +60,17 @@ void main() {
     final sv = mod.generateSynth();
     expect(sv, isNot(contains('internal_struct')));
 
+    expect(sv, contains('input logic [1:0] myIn'));
+    expect(sv, contains('output logic [1:0] myOut'));
+
+    final vectors = [
+      Vector({'a1': 0, 'a2': 1}, {'b1': 1, 'b2': 0}),
+      Vector({'a1': 1, 'a2': 0}, {'b1': 0, 'b2': 1}),
+    ];
+
     print(sv);
+
+    // await SimCompare.checkFunctionalVector(mod, vectors);
+    // SimCompare.checkIverilogVector(mod, vectors);
   });
 }

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -127,8 +127,7 @@ void main() {
         Vector({'b1': 0, 'b2': 1}, {'a1': 1, 'a2': 0}),
       ];
 
-      await SimCompare.checkFunctionalVector(mod, vectorsReversed,
-          enableChecking: false);
+      await SimCompare.checkFunctionalVector(mod, vectorsReversed);
       SimCompare.checkIverilogVector(mod, vectorsReversed);
     });
   });

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -157,6 +157,17 @@ void main() {
     SimCompare.checkIverilogVector(mod, vectors);
   });
 
+  test('matched array is an array', () async {
+    final mod = MatcherPassThrough(LogicArray([4], 2));
+    await mod.build();
+
+    final sv = mod.generateSynth();
+
+    expect(sv, contains('input logic [3:0][1:0] anyIn'));
+    expect(sv, contains('output logic [3:0][1:0] anyOut'));
+    expect(sv, contains('assign anyOut = anyIn;'));
+  });
+
   group('simple struct module with nets', () {
     Future<Module> makeMod() async {
       final mod =

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -52,8 +52,10 @@ void main() {
     final mod = SimpleStructModuleContainer(Logic(), Logic());
     await mod.build();
 
-    print(mod.generateSynth());
+    //TODO: expect that internal_struct is NOT in the output
+    final sv = mod.generateSynth();
+    // expect(sv, isNot(contains('internal_struct')));
 
-    // print(mod.generateSynth());
+    print(sv);
   });
 }

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -68,9 +68,7 @@ void main() {
       Vector({'a1': 1, 'a2': 0}, {'b1': 0, 'b2': 1}),
     ];
 
-    print(sv);
-
-    // await SimCompare.checkFunctionalVector(mod, vectors);
-    // SimCompare.checkIverilogVector(mod, vectors);
+    await SimCompare.checkFunctionalVector(mod, vectors);
+    SimCompare.checkIverilogVector(mod, vectors);
   });
 }

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -1,0 +1,44 @@
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+import 'logic_structure_test.dart';
+
+class SimpleStructModule extends Module {
+  MyStruct get myOut => output('myOut') as MyStruct;
+
+  SimpleStructModule(MyStruct myIn, {super.name = 'simple_struct_mod'}) {
+    myIn = addMatchedInput('myIn', myIn);
+
+    final internal = MyStruct(name: 'internal_struct');
+    internal.ready <= myIn.valid;
+    internal.valid <= myIn.ready;
+
+    addMatchedOutput('myOut', internal) <= internal;
+  }
+}
+
+class SimpleStructModuleContainer extends Module {
+  SimpleStructModuleContainer(Logic a1, Logic a2,
+      {super.name = 'simple_struct_mod_container'}) {
+    a1 = addInput('a1', a1);
+    a2 = addInput('a2', a2);
+    final myStruct = MyStruct(name: 'upper_struct');
+    myStruct.ready <= a1;
+    myStruct.valid <= a2;
+    final sub = SimpleStructModule(myStruct);
+
+    addOutput('b1') <= sub.myOut.ready;
+    addOutput('b2') <= sub.myOut.valid;
+  }
+}
+
+void main() {
+  test('simple struct module', () async {
+    final mod = SimpleStructModuleContainer(Logic(), Logic());
+    await mod.build();
+
+    print(mod.generateSynth());
+
+    // print(mod.generateSynth());
+  });
+}

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -52,9 +52,8 @@ void main() {
     final mod = SimpleStructModuleContainer(Logic(), Logic());
     await mod.build();
 
-    //TODO: expect that internal_struct is NOT in the output
     final sv = mod.generateSynth();
-    // expect(sv, isNot(contains('internal_struct')));
+    expect(sv, isNot(contains('internal_struct')));
 
     print(sv);
   });

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -91,33 +91,45 @@ void main() {
     SimCompare.checkIverilogVector(mod, vectors);
   });
 
-  test('simple struct module with nets', () async {
-    final mod = SimpleStructModuleContainer(Logic(), Logic(), asNet: true);
-    await mod.build();
+  group('simple struct module with nets', () {
+    Future<Module> makeMod() async {
+      final mod =
+          SimpleStructModuleContainer(LogicNet(), LogicNet(), asNet: true);
+      await mod.build();
 
-    final sv = mod.generateSynth();
-    print(sv);
-    expect(sv, isNot(contains('internal_struct')));
+      final sv = mod.generateSynth();
 
-    expect(sv, contains('inout wire [1:0] myIn'));
-    expect(sv, contains('inout wire [1:0] myOut'));
+      expect(sv, isNot(contains('internal_struct')));
 
-    final vectors = [
-      Vector({'a1': 0, 'a2': 1}, {'b1': 1, 'b2': 0}),
-      Vector({'a1': 1, 'a2': 0}, {'b1': 0, 'b2': 1}),
-    ];
+      expect(sv, contains('inout wire [1:0] myIn'));
+      expect(sv, contains('inout wire [1:0] myOut'));
 
-    await SimCompare.checkFunctionalVector(mod, vectors);
-    SimCompare.checkIverilogVector(mod, vectors);
+      return mod;
+    }
 
-    await Simulator.reset();
+    test('forward', () async {
+      final mod = await makeMod();
 
-    final vectorsReversed = [
-      Vector({'b1': 1, 'b2': 0}, {'a1': 0, 'a2': 1}),
-      Vector({'b1': 0, 'b2': 1}, {'a1': 1, 'a2': 0}),
-    ];
+      final vectors = [
+        Vector({'a1': 0, 'a2': 1}, {'b1': 1, 'b2': 0}),
+        Vector({'a1': 1, 'a2': 0}, {'b1': 0, 'b2': 1}),
+      ];
 
-    await SimCompare.checkFunctionalVector(mod, vectorsReversed);
-    SimCompare.checkIverilogVector(mod, vectorsReversed);
+      await SimCompare.checkFunctionalVector(mod, vectors);
+      SimCompare.checkIverilogVector(mod, vectors);
+    });
+
+    test('reversed', () async {
+      final mod = await makeMod();
+
+      final vectorsReversed = [
+        Vector({'b1': 1, 'b2': 0}, {'a1': 0, 'a2': 1}),
+        Vector({'b1': 0, 'b2': 1}, {'a1': 1, 'a2': 0}),
+      ];
+
+      await SimCompare.checkFunctionalVector(mod, vectorsReversed,
+          enableChecking: false);
+      SimCompare.checkIverilogVector(mod, vectorsReversed);
+    });
   });
 }

--- a/test/matched_port_test.dart
+++ b/test/matched_port_test.dart
@@ -1,7 +1,22 @@
 import 'package:rohd/rohd.dart';
 import 'package:test/test.dart';
 
-import 'logic_structure_test.dart';
+class MyStruct extends LogicStructure {
+  final Logic ready;
+  final Logic valid;
+
+  factory MyStruct({String? name}) => MyStruct._(
+        Logic(name: 'ready', naming: Naming.mergeable),
+        Logic(name: 'valid', naming: Naming.mergeable),
+        name: name,
+      );
+
+  MyStruct._(this.ready, this.valid, {String? name})
+      : super([ready, valid], name: name ?? 'myStruct');
+
+  @override
+  LogicStructure clone({String? name}) => MyStruct(name: name);
+}
 
 class SimpleStructModule extends Module {
   MyStruct get myOut => output('myOut') as MyStruct;

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -108,8 +108,12 @@ class SubModWithArray extends Module {
 }
 
 class SimpleLogicStructure extends LogicStructure {
-  SimpleLogicStructure([Logic? a, Logic? b])
-      : super([a ?? Logic(), b ?? Logic()], name: 'simple_logic_structure');
+  SimpleLogicStructure(
+      {Logic? a, Logic? b, super.name = 'simple_logic_structure'})
+      : super([a ?? Logic(), b ?? Logic()]);
+
+  @override
+  SimpleLogicStructure clone({String? name}) => SimpleLogicStructure();
 }
 
 class StructWithOutputAsElementMod extends Module {
@@ -121,8 +125,8 @@ class StructWithOutputAsElementMod extends Module {
     b = addInput('b', b);
 
     final s = SimpleLogicStructure(
-      mux(a, Const(0), Const(1)),
-      Const(1),
+      a: mux(a, Const(0), Const(1)),
+      b: Const(1),
     );
 
     final o_ = addOutput('o', width: s.width);
@@ -154,8 +158,8 @@ class StructWithInputAsElementMod extends Module {
     b = addInput('b', b);
 
     final s = SimpleLogicStructure(
-      a,
-      Const(1),
+      a: a,
+      b: Const(1),
     );
 
     final o_ = addOutput('o', width: s.width);
@@ -188,8 +192,8 @@ class StructWithInoutAsElementMod extends Module {
     b = addInOut('b', b);
 
     final s = SimpleLogicStructure(
-      a,
-      LogicNet(name: 'floaty_mc_float_face'), // floating net
+      a: a,
+      b: LogicNet(name: 'floaty_mc_float_face'), // floating net
     );
 
     addInOut('o', o, width: s.width) <= s;

--- a/test/net_test.dart
+++ b/test/net_test.dart
@@ -239,11 +239,15 @@ class NetArrayTopMod extends Module {
 }
 
 class NetfulLogicStructure extends LogicStructure {
-  NetfulLogicStructure()
+  NetfulLogicStructure({super.name})
       : super([
           LogicNet(name: 'structnet', width: 4),
           Logic(name: 'structlogic', width: 4)
         ]);
+
+  @override
+  NetfulLogicStructure clone({String? name}) =>
+      NetfulLogicStructure(name: name);
 }
 
 class NetsStructsArraysDriving extends Module {

--- a/test/net_test.dart
+++ b/test/net_test.dart
@@ -123,6 +123,9 @@ class NetIntf extends Interface<NetTag> {
     setPorts([LogicNet.port('ana', 8)], {NetTag.na});
     setPorts([LogicNet.port('anb', 8)], {NetTag.nb});
   }
+
+  @override
+  NetIntf clone() => NetIntf();
 }
 
 class NetISubMod extends Module {
@@ -176,6 +179,9 @@ class NetArrayIntf extends Interface<NetArrayTag> {
       NetArrayTag.d3
     });
   }
+
+  @override
+  NetArrayIntf clone() => NetArrayIntf();
 }
 
 class NetArraySubMod extends Module {

--- a/test/pair_interface_hier_test.dart
+++ b/test/pair_interface_hier_test.dart
@@ -26,7 +26,8 @@ class SubInterface extends PairInterface {
           ],
         );
 
-  SubInterface.clone(SubInterface super.otherInterface) : super.clone();
+  @override
+  SubInterface clone() => SubInterface(modify: modify);
 }
 
 class TopLevelInterface extends PairInterface {
@@ -49,15 +50,14 @@ class TopLevelInterface extends PairInterface {
     }
   }
 
-  TopLevelInterface.clone(TopLevelInterface otherInterface)
-      : this(otherInterface.numSubInterfaces);
+  @override
+  TopLevelInterface clone() => TopLevelInterface(numSubInterfaces);
 }
 
 class HierProducer extends Module {
   late final TopLevelInterface _intf;
   HierProducer(TopLevelInterface intf) {
-    _intf = TopLevelInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.provider);
+    _intf = intf.clone()..pairConnectIO(this, intf, PairRole.provider);
 
     _intf.subIntfs[0].req <= FlipFlop(_intf.clk, _intf.subIntfs[0].rsp).q;
   }
@@ -66,8 +66,7 @@ class HierProducer extends Module {
 class HierConsumer extends Module {
   late final TopLevelInterface _intf;
   HierConsumer(TopLevelInterface intf) {
-    _intf = TopLevelInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.consumer);
+    _intf = intf.clone()..pairConnectIO(this, intf, PairRole.consumer);
 
     _intf.subIntfs[1].rsp <= FlipFlop(_intf.clk, _intf.subIntfs[1].req).q;
   }

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -11,8 +11,6 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
-import 'multimodule_test.dart';
-
 class SimpleInterface extends PairInterface {
   Logic get clk => port('clk');
   Logic get req => port('req');

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -30,14 +30,14 @@ class SimpleInterface extends PairInterface {
           modify: (original) => 'simple_$original',
         );
 
-  SimpleInterface.clone(SimpleInterface super.otherInterface) : super.clone();
+  @override
+  SimpleInterface clone() => SimpleInterface();
 }
 
 class SimpleProvider extends Module {
   late final SimpleInterface _intf;
   SimpleProvider(SimpleInterface intf) {
-    _intf = SimpleInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.provider);
+    _intf = intf.clone()..pairConnectIO(this, intf, PairRole.provider);
 
     SimpleSubProvider(_intf);
   }
@@ -45,13 +45,13 @@ class SimpleProvider extends Module {
 
 class SimpleSubProvider extends Module {
   SimpleSubProvider(SimpleInterface intf) {
-    SimpleInterface.clone(intf).pairConnectIO(this, intf, PairRole.provider);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.provider);
   }
 }
 
 class SimpleConsumer extends Module {
   SimpleConsumer(SimpleInterface intf) {
-    SimpleInterface.clone(intf).pairConnectIO(this, intf, PairRole.consumer);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.consumer);
   }
 }
 
@@ -68,14 +68,14 @@ class SimpleTop extends Module {
 class PassthroughPairIntfModule extends Module {
   PassthroughPairIntfModule(SimpleInterface intf1, SimpleInterface intf2,
       {required bool useConditional}) {
-    intf1 = SimpleInterface.clone(intf1)
+    intf1 = intf1.clone()
       ..pairConnectIO(
         this,
         intf1,
         PairRole.consumer,
         uniquify: (original) => '${original}_1',
       );
-    intf2 = SimpleInterface.clone(intf2)
+    intf2 = intf2.clone()
       ..connectIO(
         this,
         intf2,

--- a/test/provider_consumer_test.dart
+++ b/test/provider_consumer_test.dart
@@ -16,7 +16,9 @@ class DataInterface extends PairInterface {
   Logic get valid => port('valid');
   Logic get ready => port('ready');
 
-  DataInterface({String? prefix})
+  final String? prefix;
+
+  DataInterface({this.prefix})
       : super(
             portsFromProvider: [Logic.port('data', 32), Logic.port('valid')],
             portsFromConsumer: [Logic.port('ready')],
@@ -24,6 +26,8 @@ class DataInterface extends PairInterface {
                   if (prefix != null) prefix,
                   original,
                 ].join('_'));
+  @override
+  DataInterface clone() => DataInterface(prefix: prefix);
 }
 
 class RequestInterface extends PairInterface {
@@ -40,6 +44,8 @@ class RequestInterface extends PairInterface {
 
   RequestInterface.clone(RequestInterface other)
       : this(numWd: other.numWd, name: other.name);
+  @override
+  RequestInterface clone() => RequestInterface(numWd: numWd, name: name);
 }
 
 class ResponseInterface extends PairInterface {
@@ -48,6 +54,8 @@ class ResponseInterface extends PairInterface {
     readData = addSubInterface('read_data', DataInterface(prefix: 'rd'),
         reverse: true);
   }
+  @override
+  ResponseInterface clone() => ResponseInterface();
 }
 
 class PCInterface extends PairInterface {
@@ -57,6 +65,8 @@ class PCInterface extends PairInterface {
     req = addSubInterface('req', RequestInterface());
     rsp = addSubInterface('rsp', ResponseInterface());
   }
+  @override
+  PCInterface clone() => PCInterface();
 }
 
 class Provider extends Module {

--- a/test/ssa_test.dart
+++ b/test/ssa_test.dart
@@ -22,8 +22,13 @@ abstract class SsaTestModule extends Module {
 }
 
 class SimpleStruct extends LogicStructure {
-  SimpleStruct()
-      : super([Logic(width: 4), Logic(width: 4)], name: 'simple_struct');
+  SimpleStruct({super.name = 'simple_struct'})
+      : super(
+          [Logic(width: 4), Logic(width: 4)],
+        );
+
+  @override
+  SimpleStruct clone({String? name}) => SimpleStruct(name: name);
 }
 
 class StructOpRepack extends Module {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR introduces a couple ideas:
- Requiring a `clone` to be included on `Logic`s and `Interface`s
- Adding APIs to `Module` that take advantage of those capabilities

The `addMatched*` functions on `Module` are parameterized and return the same datatype as was received.  Additionally, `Module` now supports `LogicStructure`s of any type as ports, though the SV still packs them on the interface.  These functions are also useful for creating ports when you want the widths/dimensions to match the original argument.

There's also some `connect*` functions for `Interfaces`, which basically just wrap the more common way to create interfaces by calling `clone` and `connectIO`.  There's one for arbitrary `Interface`s and one for `PairInterface`s.

## Related Issue(s)

N/A

## Testing

Added new testing for new functionality.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, though there's new expectations for any implemented `Interface`s and `LogicStructure`s if they wish to properly handle these APIs.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, API docs included.  User guide updates WIP.
