### PR TITLE
fixes for pub.dev issues in 0.6.6

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup Pana source analysis
+        run: tool/gh_actions/install_pana.sh
+
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
 
@@ -48,6 +51,9 @@ jobs:
 
       - name: Analyze project source
         run: tool/gh_actions/analyze_source.sh
+
+      - name: Run Pana on project source
+        run: tool/gh_actions/pana_source.sh
 
       - name: Check project documentation
         run: tool/gh_actions/generate_documentation.sh

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,6 +34,7 @@ linter:
     - avoid_field_initializers_in_const_classes
     - avoid_final_parameters
     - avoid_function_literals_in_foreach_calls
+    - avoid_futureor_void
     - avoid_implementing_value_types
     - avoid_init_to_null
     - avoid_js_rounded_ints
@@ -81,6 +82,7 @@ linter:
     - directives_ordering
     - discarded_futures
     - do_not_use_environment
+    # - document_ignores
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
@@ -93,6 +95,7 @@ linter:
     - implicit_call_tearoffs
     - implicit_reopen
     - invalid_case_patterns
+    - invalid_runtime_check_with_js_interop_types
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -119,6 +122,8 @@ linter:
     - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
+    # - omit_obvious_local_variable_types
+    # - omit_obvious_property_types
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
@@ -176,6 +181,10 @@ linter:
     # - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
+    # - specify_nonobvious_local_variable_types
+    # - specify_nonobvious_property_types
+    - strict_top_level_inference
+    # - switch_on_type
     - test_types_in_equals
     - throw_in_finally
     - tighten_type_of_initializing_formals
@@ -183,6 +192,8 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     - unawaited_futures
+    - unintended_html_in_doc_comment
+    # - unnecessary_async
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks
@@ -190,6 +201,7 @@ linter:
     - unnecessary_constructor_name
     # - unnecessary_final
     - unnecessary_getters_setters
+    # - unnecessary_ignore
     - unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive
@@ -208,8 +220,11 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
+    # - unnecessary_unawaited
+    - unnecessary_underscores
     # - unreachable_from_main
     - unrelated_type_equality_checks
+    # - unsafe_variance
     - use_build_context_synchronously
     - use_colored_box
     - use_decorated_box
@@ -221,6 +236,7 @@ linter:
     - use_key_in_widget_constructors
     - use_late_for_private_fields_and_variables
     - use_named_constants
+    - use_null_aware_elements
     - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties
@@ -229,5 +245,6 @@ linter:
     - use_super_parameters
     - use_test_throws_matchers
     - use_to_and_as_if_applicable
+    - use_truncating_division
     - valid_regexps
     - void_checks

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -122,7 +122,7 @@ linter:
     - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
-    # - omit_obvious_local_variable_types
+    - omit_obvious_local_variable_types
     # - omit_obvious_property_types
     - one_member_abstracts
     - only_throw_errors
@@ -181,6 +181,7 @@ linter:
     # - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
+    # conflicts with omit_obvious_local_variable_types
     # - specify_nonobvious_local_variable_types
     # - specify_nonobvious_property_types
     - strict_top_level_inference
@@ -201,7 +202,7 @@ linter:
     - unnecessary_constructor_name
     # - unnecessary_final
     - unnecessary_getters_setters
-    # - unnecessary_ignore
+    - unnecessary_ignore
     - unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive

--- a/doc/tutorials/chapter_2/a_logic.dart
+++ b/doc/tutorials/chapter_2/a_logic.dart
@@ -7,19 +7,19 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, omit_local_variable_types
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';
 
 void main() async {
   // Create a logic
-  final Logic unnamedSignal = Logic();
+  final unnamedSignal = Logic();
 
   print(unnamedSignal);
 
   // 8-bit bus named 'b'.
-  final Logic bus = Logic(name: 'b', width: 8);
+  final bus = Logic(name: 'b', width: 8);
 
   // Instantiate Module and display system verilog
   final basicLogic = LogicInitialization(unnamedSignal, bus);

--- a/doc/tutorials/chapter_2/answers/exercise_1.dart
+++ b/doc/tutorials/chapter_2/answers/exercise_1.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // exercise_1.dart

--- a/doc/tutorials/chapter_2/answers/exercise_1.dart
+++ b/doc/tutorials/chapter_2/answers/exercise_1.dart
@@ -7,7 +7,7 @@
 // 2023 February 14
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 

--- a/doc/tutorials/chapter_2/answers/exercise_2.dart
+++ b/doc/tutorials/chapter_2/answers/exercise_2.dart
@@ -7,7 +7,7 @@
 // 2023 February 14
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unnecessary_this
+// ignore_for_file: avoid_print
 import 'package:rohd/rohd.dart';
 import '../helper.dart';
 

--- a/doc/tutorials/chapter_2/answers/exercise_2.dart
+++ b/doc/tutorials/chapter_2/answers/exercise_2.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // exercise_2.dart

--- a/doc/tutorials/chapter_2/b_logic_width.dart
+++ b/doc/tutorials/chapter_2/b_logic_width.dart
@@ -7,7 +7,7 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';

--- a/doc/tutorials/chapter_2/b_logic_width.dart
+++ b/doc/tutorials/chapter_2/b_logic_width.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // a_logic_width.dart

--- a/doc/tutorials/chapter_2/c_logic_gate_part_1.dart
+++ b/doc/tutorials/chapter_2/c_logic_gate_part_1.dart
@@ -7,8 +7,6 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
-
 import 'package:rohd/rohd.dart';
 import 'helper.dart';
 

--- a/doc/tutorials/chapter_2/c_logic_gate_part_1.dart
+++ b/doc/tutorials/chapter_2/c_logic_gate_part_1.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // c_logic_gate_part_1.dart

--- a/doc/tutorials/chapter_2/d_assignment_operator.dart
+++ b/doc/tutorials/chapter_2/d_assignment_operator.dart
@@ -7,7 +7,7 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';

--- a/doc/tutorials/chapter_2/d_assignment_operator.dart
+++ b/doc/tutorials/chapter_2/d_assignment_operator.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // d_assignment_operator.dart

--- a/doc/tutorials/chapter_2/e_logic_gate_part_2.dart
+++ b/doc/tutorials/chapter_2/e_logic_gate_part_2.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // e_logic_gate_part_2.dart

--- a/doc/tutorials/chapter_2/e_logic_gate_part_2.dart
+++ b/doc/tutorials/chapter_2/e_logic_gate_part_2.dart
@@ -7,8 +7,6 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
-
 import 'package:rohd/rohd.dart';
 import 'helper.dart';
 

--- a/doc/tutorials/chapter_2/f_logic_gate_part_3.dart
+++ b/doc/tutorials/chapter_2/f_logic_gate_part_3.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // f_logic_gate_part_3.dart

--- a/doc/tutorials/chapter_2/f_logic_gate_part_3.dart
+++ b/doc/tutorials/chapter_2/f_logic_gate_part_3.dart
@@ -7,7 +7,7 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';

--- a/doc/tutorials/chapter_2/g_constant.dart
+++ b/doc/tutorials/chapter_2/g_constant.dart
@@ -7,7 +7,7 @@
 // 2023 February 20
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';

--- a/doc/tutorials/chapter_2/h_bus_range_swizzling.dart
+++ b/doc/tutorials/chapter_2/h_bus_range_swizzling.dart
@@ -7,7 +7,7 @@
 // 2023 February 14
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 import 'helper.dart';

--- a/doc/tutorials/chapter_2/h_bus_range_swizzling.dart
+++ b/doc/tutorials/chapter_2/h_bus_range_swizzling.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // bus_range_swizzling.dart

--- a/doc/tutorials/chapter_2/helper.dart
+++ b/doc/tutorials/chapter_2/helper.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // helper.dart

--- a/doc/tutorials/chapter_2/helper.dart
+++ b/doc/tutorials/chapter_2/helper.dart
@@ -7,7 +7,7 @@
 // 2023 February 14
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-// ignore_for_file: avoid_print, unused_local_variable
+// ignore_for_file: avoid_print
 
 import 'package:rohd/rohd.dart';
 

--- a/doc/tutorials/chapter_4/answers/exercise_1.dart
+++ b/doc/tutorials/chapter_4/answers/exercise_1.dart
@@ -36,7 +36,6 @@ void recursiveFullAdder(Logic a, Logic b, Logic carry, List<Logic> sum, int i) {
   } else {
     // Recursive Case
     final res = fullAdder(a[i], b[i], carry);
-    // ignore: parameter_assignments
     recursiveFullAdder(a, b, res.cOut, sum, i + 1);
     sum.add(res.sum);
   }

--- a/doc/tutorials/chapter_4/answers/exercise_1_sv.dart
+++ b/doc/tutorials/chapter_4/answers/exercise_1_sv.dart
@@ -51,7 +51,6 @@ void recursiveFullAdder(Logic a, Logic b, Logic carry, List<Logic> sum, int i) {
   } else {
     // Recursive Case
     final res = FullAdder(a[i], b[i], carry);
-    // ignore: parameter_assignments
     recursiveFullAdder(a, b, res.result.cOut, sum, i + 1);
     sum.add(res.result.sum);
   }

--- a/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
+++ b/doc/tutorials/chapter_8/answers/exercise_1_spi.dart
@@ -110,7 +110,7 @@ class TestBench extends Module {
   Logic get sout => output('sout');
 
   final spiInterface = SPIInterface();
-  final clk = SimpleClockGenerator(10).clk;
+  final Logic clk = SimpleClockGenerator(10).clk;
 
   TestBench(Logic reset, Logic sin) {
     reset = addInput('reset', reset);

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Intel Corporation
+// Copyright (C) 2022-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // finite_state_machine.dart

--- a/lib/src/finite_state_machine.dart
+++ b/lib/src/finite_state_machine.dart
@@ -281,7 +281,7 @@ class _MermaidStateDiagram {
   final File _outputFile;
 
   // An empty spaces indentation for state.
-  final _indentation = ' ' * 4;
+  final String _indentation = ' ' * 4;
 
   /// Generate a [_MermaidStateDiagram] that initialized the diagram of
   /// mermaid as `stateDiagram`.

--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -204,7 +204,7 @@ class Combinational extends Always {
   ///
   /// Declared as a separate static function so that it doesn't need to be
   /// created on each [_guard] call.
-  static void _writeAfterRead(dynamic args) {
+  static void _writeAfterRead(LogicValueChanged f) {
     throw WriteAfterReadException();
   }
 

--- a/lib/src/modules/conditionals/combinational.dart
+++ b/lib/src/modules/conditionals/combinational.dart
@@ -204,7 +204,7 @@ class Combinational extends Always {
   ///
   /// Declared as a separate static function so that it doesn't need to be
   /// created on each [_guard] call.
-  static void _writeAfterRead(args) {
+  static void _writeAfterRead(dynamic args) {
     throw WriteAfterReadException();
   }
 

--- a/lib/src/modules/conditionals/conditional_assign.dart
+++ b/lib/src/modules/conditionals/conditional_assign.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // conditional_assign.dart

--- a/lib/src/modules/conditionals/conditional_assign.dart
+++ b/lib/src/modules/conditionals/conditional_assign.dart
@@ -46,7 +46,7 @@ class ConditionalAssign extends Conditional {
   late final List<Conditional> conditionals = const [];
 
   /// A cached copy of the result of [receiverOutput] to save on lookups.
-  late final _receiverOutput = receiverOutput(receiver);
+  late final Logic _receiverOutput = receiverOutput(receiver);
 
   @override
   void execute(Set<Logic>? drivenSignals,

--- a/lib/src/modules/conditionals/sequential.dart
+++ b/lib/src/modules/conditionals/sequential.dart
@@ -327,7 +327,6 @@ class Sequential extends Always {
                 },
               ).catchError(
                 test: (error) => error is Exception,
-                // ignore: avoid_types_on_closure_parameters
                 (Object err, StackTrace stackTrace) {
                   Simulator.throwException(err as Exception, stackTrace);
                 },
@@ -355,11 +354,9 @@ class Sequential extends Always {
             _execute();
             _pendingExecute = false;
           }).catchError(test: (error) => error is Exception,
-              // ignore: avoid_types_on_closure_parameters
               (Object err, StackTrace stackTrace) {
             Simulator.throwException(err as Exception, stackTrace);
           }).catchError(test: (error) => error is StateError,
-              // ignore: avoid_types_on_closure_parameters
               (Object err, StackTrace stackTrace) {
             // This could be a result of the `Simulator` being reset, causing
             // the stream to `close` before `first` occurs.

--- a/lib/src/modules/conditionals/sequential.dart
+++ b/lib/src/modules/conditionals/sequential.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // sequential.dart

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -766,7 +766,6 @@ class Logic {
     final modifiedEndIndex = IndexUtilities.wrapIndex(endIndex, width);
 
     if (modifiedStartIndex == 0 && modifiedEndIndex == width - 1) {
-      // ignore: avoid_returning_this
       return this;
     }
 
@@ -866,7 +865,6 @@ class Logic {
         this,
       ].swizzle();
     } else if (newWidth == width) {
-      // ignore: avoid_returning_this
       return this;
     }
 

--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -475,7 +475,7 @@ class LogicStructure implements Logic {
 
   /// An internal version of [packed] for instrumentation operations on this
   /// [LogicStructure].
-  late final _internalPacked = _generateInternalPacked();
+  late final Logic _internalPacked = _generateInternalPacked();
 
   /// Generates and subscribes to be stored lazily into [_internalPacked].
   Logic _generateInternalPacked() {
@@ -651,7 +651,6 @@ class LogicStructure implements Logic {
       throw UnsupportedError('Delegated to elements');
 
   @override
-  // ignore: unused_element
   set _unassignableReason(String? _) =>
       throw UnsupportedError('Delegated to elements');
 

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simcompare.dart

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -203,7 +203,6 @@ abstract class SimCompare {
             }
           }).catchError(
             test: (error) => error is Exception,
-            // ignore: avoid_types_on_closure_parameters
             (Object err, StackTrace stackTrace) {
               Simulator.throwException(err as Exception, stackTrace);
             },
@@ -291,7 +290,7 @@ abstract class SimCompare {
             signal.dimensions.getRange(0, signal.numUnpackedDimensions);
         final packedDims = signal.dimensions
             .getRange(signal.numUnpackedDimensions, signal.dimensions.length);
-        // ignore: parameter_assignments, prefer_interpolation_to_compose_strings
+        // ignore: prefer_interpolation_to_compose_strings
         return signalType +
             ' ' +
             // ignore: prefer_interpolation_to_compose_strings

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -343,7 +343,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
   /// the width of [other].
   LogicValue _concatenate(LogicValue other) {
     if (other.width == 0) {
-      // ignore: avoid_returning_this
       return this;
     } else if (width == 0) {
       return other;
@@ -1106,7 +1105,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
   ///
   /// Throws an Exception if width is not 1.
   @Deprecated('Check `width` separately to see if single-bit.')
-  // ignore: avoid_returning_this
   LogicValue get bit {
     if (width != 1) {
       throw Exception('Width must be 1, but was $width.');
@@ -1525,7 +1523,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
   /// Performs shift operations in the specified direction
   LogicValue _shift(dynamic shamt, _ShiftType direction) {
     if (width == 0) {
-      // ignore: avoid_returning_this
       return this;
     }
 

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_values.dart

--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -54,7 +54,7 @@ class WaveDumper {
   ///
   /// When the [Simulator] time progresses beyond this, it will dump all the
   /// signals that have changed up until that point at this saved time value.
-  var _currentDumpingTimestamp = Simulator.time;
+  int _currentDumpingTimestamp = Simulator.time;
 
   /// Attaches a [WaveDumper] to record all signal changes in a simulation of
   /// [module] in a VCD file at [outputPath].

--- a/lib/src/wave_dumper.dart
+++ b/lib/src/wave_dumper.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // wave_dumper.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,12 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  collection: ^1.15.0
-  logging: ^1.0.1
-  meta: ^1.3.0
-  test: ^1.17.3
+  collection: ^1.19.1
+  logging: ^1.3.0
+  meta: ^1.17.0
+  test: ^1.26.3
 
 dev_dependencies:
-  benchmark_harness: ^2.2.0
-  yaml: ^3.1.1
+  benchmark_harness: ^2.3.1
+  lints: ^6.0.0
+  yaml: ^3.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,11 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  collection: ^1.19.1
-  logging: ^1.3.0
-  meta: ^1.17.0
-  test: ^1.26.3
+  collection: ^1.15.0
+  logging: ^1.0.1
+  meta: ^1.9.0
+  test: ^1.17.3
 
 dev_dependencies:
-  benchmark_harness: ^2.3.1
-  lints: ^6.0.0
-  yaml: ^3.1.3
+  benchmark_harness: ^2.2.0
+  yaml: ^3.1.1

--- a/test/invalid_latch_test.dart
+++ b/test/invalid_latch_test.dart
@@ -62,8 +62,8 @@ class _DLatch extends Module {
   /// The inverse output of the latch.
   Logic get outB => output(_outB.name);
 
-  late final _out = addOutput('out');
-  late final _outB = addOutput('outB');
+  late final Logic _out = addOutput('out');
+  late final Logic _outB = addOutput('outB');
 }
 
 void main() async {

--- a/test/invalid_latch_test.dart
+++ b/test/invalid_latch_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // invalid_latch_test.dart

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_value_test.dart

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -15,10 +15,15 @@ import 'package:rohd/src/utilities/web.dart';
 import 'package:test/test.dart';
 
 // All logicvalues to support trying all possiblities
-const allLv = [LogicValue.zero, LogicValue.one, LogicValue.x, LogicValue.z];
+const List<LogicValue> allLv = [
+  LogicValue.zero,
+  LogicValue.one,
+  LogicValue.x,
+  LogicValue.z
+];
 
 // shorten some names to make tests read better
-const lv = LogicValue.ofString;
+const LogicValue Function(String stringRepresentation) lv = LogicValue.ofString;
 LogicValue large(LogicValue lv) => LogicValue.filled(100, lv);
 
 int repeatedInt(int value, int width, int times) {

--- a/test/net_test.dart
+++ b/test/net_test.dart
@@ -152,7 +152,6 @@ class NetITopMod extends Module {
     final net = LogicNet(width: 8, name: 'myNet');
     final norm = LogicNet(width: 8, name: 'myNorm');
 
-    // ignore: parameter_assignments
     intf = NetIntf()..connectIO(this, intf, outputTags: NetTag.values);
 
     NetISubMod(norm, net, intf, NetTag.na);

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -65,7 +65,7 @@ class SimplePipelineModuleLateAdd extends Module {
 }
 
 class PipelineModuleWithPipelinedSub extends Module {
-  final _clk = SimpleClockGenerator(10).clk;
+  final Logic _clk = SimpleClockGenerator(10).clk;
 
   PipelineModuleWithPipelinedSub(Logic a) {
     a = addInput('a', a, width: a.width);
@@ -94,7 +94,7 @@ class PipelineModuleWithPipelinedSub extends Module {
 }
 
 class PipelineModuleWithAbsRef extends Module {
-  final _clk = SimpleClockGenerator(10).clk;
+  final Logic _clk = SimpleClockGenerator(10).clk;
 
   PipelineModuleWithAbsRef(Logic a) {
     a = addInput('a', a, width: a.width);

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -281,8 +281,7 @@ void main() {
 
   group('Rohme compatibility tests', () {
     test('simulator supports delta cycles', () async {
-      // ignore: omit_local_variable_types
-      final List<String> testLog = [];
+      final testLog = <String>[];
 
       void deltaFunc(int t, int i) {
         testLog.add('wake up $i');
@@ -311,8 +310,7 @@ void main() {
     });
 
     test('deltas occur after end of delta', () async {
-      // ignore: omit_local_variable_types
-      final List<String> testLog = [];
+      final testLog = <String>[];
 
       void deltaFunc(int t, int i) {
         testLog.add('first delta $i');

--- a/test/simulator_test.dart
+++ b/test/simulator_test.dart
@@ -294,13 +294,7 @@ void main() {
 
       await Simulator.run();
 
-      // ignore: omit_local_variable_types
-      final List<String> expectedLog = [
-        'wake up 0',
-        'wake up 1',
-        'delta 0',
-        'delta 1'
-      ];
+      final expectedLog = ['wake up 0', 'wake up 1', 'delta 0', 'delta 1'];
       expect(testLog, expectedLog);
     });
 
@@ -335,8 +329,7 @@ void main() {
 
       await Simulator.run();
 
-      // ignore: omit_local_variable_types
-      final List<String> expectedLog = [
+      final expectedLog = [
         'first delta 0',
         'first delta 1',
         'end delta 0',

--- a/tool/gh_actions/install_pana.sh
+++ b/tool/gh_actions/install_pana.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# install_pana.sh
+# GitHub Actions step: Install pana dart analysis.
+#
+# 2025 September 26
+# Author: Desmond A. Kirkpatrick
+
+dart pub global activate pana

--- a/tool/gh_actions/install_pana.sh
+++ b/tool/gh_actions/install_pana.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2022-2023 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # install_pana.sh

--- a/tool/gh_actions/pana_source.sh
+++ b/tool/gh_actions/pana_source.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# pana_source.sh
+# GitHub Actions step: execute pana analysis on project source.
+#
+# 2025 September 26
+# Author: Desmond A. Kirkpatrick
+
+PATH="$PATH":"$HOME/.pub-cache/bin"
+
+pana .

--- a/tool/gh_actions/pana_source.sh
+++ b/tool/gh_actions/pana_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2022-2023 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # pana_source.sh
@@ -11,4 +11,4 @@
 
 PATH="$PATH":"$HOME/.pub-cache/bin"
 
-pana .
+pana --exit-code-threshold 0 .


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A set of dependency issues arise as reported by 
`dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`
and
`dart pub downgrade`  followed by `dart analyze `

as used by pub.dev scoring.

## Related Issue(s)

Fixes #604 

## Testing

Ran test suites for ROHD and for ROHD-HCL pointing to modified ROHD.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.
