### PR TITLE
Improve exceptions for SSA checks with improper reuse

### DIFF
--- a/lib/src/modules/conditionals/conditional.dart
+++ b/lib/src/modules/conditionals/conditional.dart
@@ -160,6 +160,12 @@ abstract class Conditional {
         continue;
       }
 
+      // if at this point there's still a srcConnection, then something is wrong
+      // and someone probably reused a signal when they shouldn't have
+      if (ssaDriver.srcConnection != null) {
+        throw MappedSignalAlreadyAssignedException(ssaDriver.ref.name);
+      }
+
       ssaDriver <= mappings[ssaDriver.ref]!;
     }
   }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a version of illegal SSA signal reuse that, instead of providing a useful error message, would give a confusing error about some "phi" signal already connected.  This PR introduces a check and better exception in those cases to aid in debug.

## Related Issue(s)

N/A

## Testing

Added new test to ensure the exception is triggered appropriately.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
