### PR TITLE
Fix bug where cached `packed` on `LogicStructure`s on output ports reused inside and out cause build trace failures

### DIFF
--- a/lib/src/signals/logic_structure.dart
+++ b/lib/src/signals/logic_structure.dart
@@ -19,7 +19,15 @@ class LogicStructure implements Logic {
 
   /// Packs all [elements] into one flattened [Logic] bus.
   @override
-  late final Logic packed = elements
+  // If this is an output port, we have to regenerate each time to avoid
+  // illegal reuse inside and outside the module. This is unique for outputs.
+  Logic get packed => isOutput ? _genPacked() : _packed;
+
+  /// A cached version of [packed] scenarios when it is legal.
+  late final Logic _packed = _genPacked();
+
+  /// Generates the packed version of this [LogicStructure].
+  Logic _genPacked() => elements
       .map((e) {
         if (e is LogicStructure) {
           return e.packed;

--- a/test/logic_array_test.dart
+++ b/test/logic_array_test.dart
@@ -506,6 +506,24 @@ class AssignSubsetModule extends Module {
   }
 }
 
+class ParentModuleWithPackingArrayOutput extends Module {
+  ParentModuleWithPackingArrayOutput(
+    Logic x,
+  ) {
+    x = addInput('x', x);
+    ChildModuleWithPackingArrayOutput(x).myOut.packed.xor() ^ x;
+  }
+}
+
+class ChildModuleWithPackingArrayOutput extends Module {
+  late final LogicArray myOut =
+      addOutputArray('myOut', dimensions: [2, 2], elementWidth: 4);
+  ChildModuleWithPackingArrayOutput(Logic x) {
+    x = addInput('x', x);
+    x ^ myOut.packed.xor();
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -1083,6 +1101,13 @@ void main() {
       await SimCompare.checkFunctionalVector(mod, vectors);
       SimCompare.checkIverilogVector(mod, vectors);
     });
+  });
+
+  test('packed array output inside and outside of module', () async {
+    final mod = ParentModuleWithPackingArrayOutput(Logic());
+
+    // just building will detect if there was a bad reuse of packed
+    await mod.build();
   });
 
   group('array clone', () {

--- a/test/typed_port_test.dart
+++ b/test/typed_port_test.dart
@@ -158,6 +158,23 @@ class ModuleWithPartialAssignInlineAndOutReuseModule extends Module {
   }
 }
 
+class ParentModuleWithPackingSubModuleOutput extends Module {
+  ParentModuleWithPackingSubModuleOutput(
+    Logic x,
+  ) {
+    x = addInput('x', x);
+    ChildModuleWithPackingOutput(x).myOut.packed.xor() ^ x;
+  }
+}
+
+class ChildModuleWithPackingOutput extends Module {
+  late final MyStruct myOut = addTypedOutput('myOut', MyStruct().clone);
+  ChildModuleWithPackingOutput(Logic x) {
+    x = addInput('x', x);
+    x ^ myOut.packed.xor();
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -209,6 +226,13 @@ void main() {
 
     await SimCompare.checkFunctionalVector(mod, vectors);
     SimCompare.checkIverilogVector(mod, vectors);
+  });
+
+  test('packed struct output inside and outside of module', () async {
+    final mod = ParentModuleWithPackingSubModuleOutput(Logic());
+
+    // just building will detect if there was a bad reuse of packed
+    await mod.build();
   });
 
   group('const typed ports', () {


### PR DESCRIPTION

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a bug where if the `packed` getter for a `LogicStructure` (or `LogicArray`) which was also an `output` of a `Module` was used both inside and outside of the parent module of that port, it would cause a trace failure during build.  This is because the `packed` was cached and reused across calls, so the `Swizzle` module was reused in two different modules.

This PR fixes the bug by not caching `packed` if the signal `isOutput`.

The bug only applies to outputs because inputs and inOuts don't allow the same signal to be reused both inside and outside of a module and hence this cannot happen (since creation of those ports requires a source).

## Related Issue(s)

N/A

## Testing

Added tests for both `LogicStructure`s and `LogicArray`s that failed prior to fixing.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, though hardware generated may become duplicated if `packed` is reused multiple times on an output in a way that did not hit this bug.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
