### PR TITLE
Fix bug where const assignments could be lost in some disallowed const scenarios

### DIFF
--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -302,8 +302,7 @@ class SynthLogic {
     if ((a.isConstant && b.constNameDisallowed) ||
         (b.isConstant && a.constNameDisallowed)) {
       // we cannot merge a constant if the other disallows the constant name
-      // since we can lose a constant assignment (note: this doesn't guarantee
-      // we end up with the nicest name)
+      // since we can lose a constant assignment
       return null;
     }
 

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -346,13 +346,6 @@ class SynthLogic {
     assert(
         other != this, 'Suspicious attempt to merge a SynthLogic into itself.');
 
-//TODO TMP
-    // print('***\n  $this -- is adopting \n  $other');
-
-    // if (this.toString().contains('const_0')) {
-    //   print('here');
-    // }
-
     _constNameDisallowed |= other._constNameDisallowed;
 
     // only take one of the other's items if we don't have it already

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -172,7 +172,7 @@ class SynthLogic {
               .any(parentSynthModuleDefinition.logicHasPresentSynthLogic));
 
   /// Two [SynthLogic]s that are not [mergeable] cannot be merged with each
-  /// other. If onlyt one of them is not [mergeable], it can adopt the elements
+  /// other. If only one of them is not [mergeable], it can adopt the elements
   /// from the other.
   bool get mergeable =>
       _reservedLogic == null && _constLogic == null && _renameableLogic == null;
@@ -292,6 +292,20 @@ class SynthLogic {
       a.adopt(b);
       return (removed: b, kept: a);
     }
+    // else if ((a.isConstant && b is SynthLogicArrayElement) ||
+    //     (b.isConstant && a is SynthLogicArrayElement)) {
+    //   // we don't want to lose any constant assignments when signals aren't
+    //   // guaranteed to be declared
+    //   return null;
+    // }
+
+    if ((a.isConstant && b.constNameDisallowed) ||
+        (b.isConstant && a.constNameDisallowed)) {
+      // we cannot merge a constant if the other disallows the constant name
+      // since we can lose a constant assignment (note: this doesn't guarantee
+      // we end up with the nicest name)
+      return null;
+    }
 
     if (!a.mergeable && !b.mergeable) {
       return null;
@@ -331,6 +345,13 @@ class SynthLogic {
         'Cannot merge logics of different widths: $width vs ${other.width}');
     assert(
         other != this, 'Suspicious attempt to merge a SynthLogic into itself.');
+
+//TODO TMP
+    // print('***\n  $this -- is adopting \n  $other');
+
+    // if (this.toString().contains('const_0')) {
+    //   print('here');
+    // }
 
     _constNameDisallowed |= other._constNameDisallowed;
 

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // synth_logic.dart
@@ -292,12 +292,6 @@ class SynthLogic {
       a.adopt(b);
       return (removed: b, kept: a);
     }
-    // else if ((a.isConstant && b is SynthLogicArrayElement) ||
-    //     (b.isConstant && a is SynthLogicArrayElement)) {
-    //   // we don't want to lose any constant assignments when signals aren't
-    //   // guaranteed to be declared
-    //   return null;
-    // }
 
     if ((a.isConstant && b.constNameDisallowed) ||
         (b.isConstant && a.constNameDisallowed)) {

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -885,7 +885,12 @@ class SynthModuleDefinition {
     while (prevAssignmentCount != assignments.length) {
       // keep looping until it stops shrinking
       final reducedAssignments = <SynthAssignment>[];
-      for (final assignment in assignments) {
+      for (final assignment in CombinedIterableView([
+        // we look at non-constant assignments first to maximize merging in case
+        // some constant merge scenario is disallowed by
+        assignments.where((a) => !a.src.isConstant && !a.dst.isConstant),
+        assignments.where((a) => a.src.isConstant || a.dst.isConstant),
+      ])) {
         assert(assignment is! PartialSynthAssignment,
             'Partial assignments should have been removed before this.');
 

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -897,6 +897,13 @@ class SynthModuleDefinition {
         final dst = assignment.dst;
         final src = assignment.src;
 
+        if (src == dst && src.isConstant) {
+          // looks like this assignment does nothing -- some sort of circular
+          // constant assignment, can just remove it
+
+          continue;
+        }
+
         assert(dst != src,
             'No circular assignment allowed between $dst and $src.');
 

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // synth_module_definition.dart
@@ -887,7 +887,7 @@ class SynthModuleDefinition {
       final reducedAssignments = <SynthAssignment>[];
       for (final assignment in CombinedIterableView([
         // we look at non-constant assignments first to maximize merging in case
-        // some constant merge scenario is disallowed by
+        // some constant merge scenario is disallowed by a module (e.g. subset)
         assignments.where((a) => !a.src.isConstant && !a.dst.isConstant),
         assignments.where((a) => a.src.isConstant || a.dst.isConstant),
       ])) {

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -564,8 +564,10 @@ void main() {
         final sv = mod.generateSynth();
         print(sv);
 
-        expect(sv, contains("assign apple_tieoff = 2'h0;"));
-        expect(sv, contains("assign banana_tieoff = 2'h0;"));
+        // expect(sv, contains("assign apple_tieoff = 2'h0;"));
+        // expect(sv, contains("assign banana_tieoff = 2'h0;"));
+
+        //TODO: do a simcompare to see the actual values in SV sim
       });
     }
   });

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -572,7 +572,8 @@ void main() {
 
         final sv = mod.generateSynth();
 
-        expect(sv, contains(RegExp("assign .* = 2'h0;")));
+        expect(sv, contains("assign banana_tieoff = 2'h0;"));
+        expect(sv, contains("assign apple_tieoff = 2'h0;"));
 
         // simcompare to make sure simulation works as expected
         final vectors = [


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a rare bug where if "disallowed" constant signals were assigned to parts/slices of constant signals, and assignment collapsing order got unlucky, sometimes a constant assignment could be lost.  This PR fixes the bug.

## Related Issue(s)

N/A

## Testing

Added new tests, plus existing tests cover nothing broke

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
