### PR TITLE
Improvement in naming to match a future converged solution

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -129,7 +129,9 @@ linter:
     - overridden_fields
     - package_names
     - package_prefixed_library_names
-    - parameter_assignments
+    # parameter_assignments - disabled; ROHD idiomatically reassigns
+    # constructor parameters via addInput/addOutput.
+    # - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -667,7 +667,6 @@ abstract class Module {
     }
 
     if (source is LogicStructure) {
-      // ignore: parameter_assignments
       source = source.packed;
     }
 
@@ -704,7 +703,6 @@ abstract class Module {
       String name, LogicType source) {
     _checkForSafePortName(name);
 
-    // ignore: parameter_assignments
     source = _validateType<LogicType>(source, isOutput: false, name: name);
 
     if (source.isNet || (source is LogicStructure && source.hasNets)) {
@@ -813,7 +811,6 @@ abstract class Module {
       throw PortTypeException(source, 'Typed inOuts must be nets.');
     }
 
-    // ignore: parameter_assignments
     source = _validateType<LogicType>(source, isOutput: false, name: name);
 
     _inOutDrivers.add(source);

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -377,7 +377,6 @@ class Logic {
     // If we are connecting a `LogicStructure` to this simple `Logic`,
     // then pack it first.
     if (other is LogicStructure) {
-      // ignore: parameter_assignments
       other = other.packed;
     }
 

--- a/lib/src/signals/wire_net.dart
+++ b/lib/src/signals/wire_net.dart
@@ -189,7 +189,6 @@ class _WireNetBlasted extends _Wire implements _WireNet {
     other as _WireNet;
 
     if (other is! _WireNetBlasted) {
-      // ignore: parameter_assignments
       other = other.toBlasted();
     }
 

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -252,19 +252,6 @@ class SynthLogic {
     }
 
     // pick a preferred, available, mergeable name, if one exists
-    //
-    // Bug fix: the unpreferred check must use `preferredSynthName` (the
-    // sanitized struct-path name), not the raw `Logic.name`.
-    //
-    // A struct field created with `Logic()` (no name) auto-generates the
-    // raw name `_s`.  When the struct is cloned via `addTypedInput`,
-    // `chooseCloneNaming` promotes the field to `Naming.mergeable`, so it
-    // enters `_mergeableLogics`.  The raw name `_s` starts with `_` and
-    // IS unpreferred, but its `preferredSynthName` is the full struct
-    // path — e.g. `inp_myStruct__s` — which starts with `i` and is NOT
-    // unpreferred.  Checking `.name` instead of `.preferredSynthName`
-    // caused these fields to be wrongly deprioritized, losing their
-    // descriptive struct-path names in favor of anonymous `_in0` names.
     final unpreferredMergeableLogics = <Logic>[];
     final uniquifiableMergeableLogics = <Logic>[];
     for (final mergeableLogic in _mergeableLogics) {
@@ -335,18 +322,6 @@ class SynthLogic {
       a.adopt(b);
       return (removed: b, kept: a);
     }
-
-    // Bug fix: a previous guard here blocked merging when one side was a
-    // constant and the other had `constNameDisallowed`.  This was overly
-    // conservative.  `constNameDisallowed` only means "don't use the
-    // constant literal (e.g. `8'h0`) as the signal name" — it does NOT
-    // mean the signal cannot be merged.  `adopt()` already propagates
-    // the flag via `_constNameDisallowed |=`, so the merged result still
-    // gets a proper named declaration with an `assign` statement.
-    //
-    // Without this fix, when multiple `expressionlessInput` ports (e.g.
-    // from `BusSubset`) were driven by the same constant, each produced
-    // its own redundant declaration instead of sharing one signal.
 
     if (!a.mergeable && !b.mergeable) {
       return null;

--- a/lib/src/synthesizers/utilities/synth_logic.dart
+++ b/lib/src/synthesizers/utilities/synth_logic.dart
@@ -47,11 +47,13 @@ class SynthLogic {
   /// structure is a port of that [module].
   bool isStructPortElement([Module? module]) =>
       (this is! SynthLogicArrayElement) &&
-      logics.any((e) =>
-          e.isPort &&
-          e.parentStructure != null &&
-          e.parentStructure!.isPort &&
-          (module == null || e.parentStructure!.parentModule == module));
+      logics.any(
+        (e) =>
+            e.isPort &&
+            e.parentStructure != null &&
+            e.parentStructure!.isPort &&
+            (module == null || e.parentStructure!.parentModule == module),
+      );
 
   /// Indicates if this signal is a port, optionally for a specific [module].
   bool isPort([Module? module]) =>
@@ -146,30 +148,40 @@ class SynthLogic {
   /// Indicates if there are any [dstConnections] present in
   /// [parentSynthModuleDefinition].
   bool hasDstConnectionsPresent() =>
-      logics.any((logic) =>
-          logic is Const || // in case of net, could be const dest
-          (logic.isInput || logic.isInOut) &&
-              parentSynthModuleDefinition
-                  .isSubmoduleAndPresent(logic.parentModule)) ||
-      dstConnections
-          .any(parentSynthModuleDefinition.logicHasPresentSynthLogic) ||
+      logics.any(
+        (logic) =>
+            logic is Const || // in case of net, could be const dest
+            (logic.isInput || logic.isInOut) &&
+                parentSynthModuleDefinition.isSubmoduleAndPresent(
+                  logic.parentModule,
+                ),
+      ) ||
+      dstConnections.any(
+        parentSynthModuleDefinition.logicHasPresentSynthLogic,
+      ) ||
       (isNet &&
-          srcConnections
-              .any(parentSynthModuleDefinition.logicHasPresentSynthLogic));
+          srcConnections.any(
+            parentSynthModuleDefinition.logicHasPresentSynthLogic,
+          ));
 
   /// Indicates if there are any [srcConnections] present in
   /// [parentSynthModuleDefinition].
   bool hasSrcConnectionsPresent() =>
-      logics.any((logic) =>
-          logic is Const ||
-          (logic.isOutput || logic.isInOut) &&
-              parentSynthModuleDefinition
-                  .isSubmoduleAndPresent(logic.parentModule)) ||
-      srcConnections
-          .any(parentSynthModuleDefinition.logicHasPresentSynthLogic) ||
+      logics.any(
+        (logic) =>
+            logic is Const ||
+            (logic.isOutput || logic.isInOut) &&
+                parentSynthModuleDefinition.isSubmoduleAndPresent(
+                  logic.parentModule,
+                ),
+      ) ||
+      srcConnections.any(
+        parentSynthModuleDefinition.logicHasPresentSynthLogic,
+      ) ||
       (isNet &&
-          dstConnections
-              .any(parentSynthModuleDefinition.logicHasPresentSynthLogic));
+          dstConnections.any(
+            parentSynthModuleDefinition.logicHasPresentSynthLogic,
+          ));
 
   /// Two [SynthLogic]s that are not [mergeable] cannot be merged with each
   /// other. If only one of them is not [mergeable], it can adopt the elements
@@ -185,10 +197,14 @@ class SynthLogic {
   /// Must call [pickName] before this is accessible.
   String get name {
     assert(_name != null, 'Name has not been picked for $this.');
-    assert(_replacement == null,
-        'If this has been replaced, then we should not be getting its name.');
-    assert(isConstant || Sanitizer.isSanitary(_name!),
-        'Signal names should be sanitary, but found $_name.');
+    assert(
+      _replacement == null,
+      'If this has been replaced, then we should not be getting its name.',
+    );
+    assert(
+      isConstant || Sanitizer.isSanitary(_name!),
+      'Signal names should be sanitary, but found $_name.',
+    );
 
     return _name!;
   }
@@ -213,72 +229,97 @@ class SynthLogic {
         return _constLogic!.value.toString();
       } else {
         assert(
-            logics.length > 1,
-            'If there is a constant, but the const name is not allowed, '
-            'there needs to be another option');
+          logics.length > 1,
+          'If there is a constant, but the const name is not allowed, '
+          'there needs to be another option',
+        );
       }
     }
 
     // check for reserved
     if (_reservedLogic != null) {
       return uniquifier.getUniqueName(
-          initialName: _reservedLogic!.name, reserved: true);
+        initialName: _reservedLogic!.name,
+        reserved: true,
+      );
     }
 
     // check for renameable
     if (_renameableLogic != null) {
       return uniquifier.getUniqueName(
-          initialName: _renameableLogic!.preferredSynthName);
+        initialName: _renameableLogic!.preferredSynthName,
+      );
     }
 
     // pick a preferred, available, mergeable name, if one exists
+    //
+    // Bug fix: the unpreferred check must use `preferredSynthName` (the
+    // sanitized struct-path name), not the raw `Logic.name`.
+    //
+    // A struct field created with `Logic()` (no name) auto-generates the
+    // raw name `_s`.  When the struct is cloned via `addTypedInput`,
+    // `chooseCloneNaming` promotes the field to `Naming.mergeable`, so it
+    // enters `_mergeableLogics`.  The raw name `_s` starts with `_` and
+    // IS unpreferred, but its `preferredSynthName` is the full struct
+    // path — e.g. `inp_myStruct__s` — which starts with `i` and is NOT
+    // unpreferred.  Checking `.name` instead of `.preferredSynthName`
+    // caused these fields to be wrongly deprioritized, losing their
+    // descriptive struct-path names in favor of anonymous `_in0` names.
     final unpreferredMergeableLogics = <Logic>[];
     final uniquifiableMergeableLogics = <Logic>[];
     for (final mergeableLogic in _mergeableLogics) {
-      if (Naming.isUnpreferred(mergeableLogic.name)) {
+      if (Naming.isUnpreferred(mergeableLogic.preferredSynthName)) {
         unpreferredMergeableLogics.add(mergeableLogic);
       } else if (!uniquifier.isAvailable(mergeableLogic.preferredSynthName)) {
         uniquifiableMergeableLogics.add(mergeableLogic);
       } else {
         return uniquifier.getUniqueName(
-            initialName: mergeableLogic.preferredSynthName);
+          initialName: mergeableLogic.preferredSynthName,
+        );
       }
     }
 
     // uniquify a preferred, mergeable name, if one exists
     if (uniquifiableMergeableLogics.isNotEmpty) {
       return uniquifier.getUniqueName(
-          initialName: uniquifiableMergeableLogics.first.preferredSynthName);
+        initialName: uniquifiableMergeableLogics.first.preferredSynthName,
+      );
     }
 
     // pick an available unpreferred mergeable name, if one exists, otherwise
     // uniquify an unpreferred mergeable name
     if (unpreferredMergeableLogics.isNotEmpty) {
       return uniquifier.getUniqueName(
-          initialName: unpreferredMergeableLogics
-                  .firstWhereOrNull((element) =>
-                      uniquifier.isAvailable(element.preferredSynthName))
-                  ?.preferredSynthName ??
-              unpreferredMergeableLogics.first.preferredSynthName);
+        initialName: unpreferredMergeableLogics
+                .firstWhereOrNull(
+                  (element) =>
+                      uniquifier.isAvailable(element.preferredSynthName),
+                )
+                ?.preferredSynthName ??
+            unpreferredMergeableLogics.first.preferredSynthName,
+      );
     }
 
     // pick anything (unnamed) and uniquify as necessary (considering preferred)
     // no need to prefer an available one here, since it's all unnamed
     return uniquifier.getUniqueName(
-        initialName: _unnamedLogics
-                .firstWhereOrNull((element) =>
-                    !Naming.isUnpreferred(element.preferredSynthName))
-                ?.preferredSynthName ??
-            _unnamedLogics.first.preferredSynthName);
+      initialName: _unnamedLogics
+              .firstWhereOrNull(
+                (element) => !Naming.isUnpreferred(element.preferredSynthName),
+              )
+              ?.preferredSynthName ??
+          _unnamedLogics.first.preferredSynthName,
+    );
   }
 
   /// Creates an instance to represent [initialLogic] and any that merge
   /// into it.
-  SynthLogic(Logic initialLogic,
-      {required this.parentSynthModuleDefinition,
-      Naming? namingOverride,
-      bool constNameDisallowed = false})
-      : isArray = initialLogic is LogicArray,
+  SynthLogic(
+    Logic initialLogic, {
+    required this.parentSynthModuleDefinition,
+    Naming? namingOverride,
+    bool constNameDisallowed = false,
+  })  : isArray = initialLogic is LogicArray,
         _constNameDisallowed = constNameDisallowed {
     _addLogic(initialLogic, namingOverride: namingOverride);
   }
@@ -286,19 +327,26 @@ class SynthLogic {
   /// Returns `null` if the merge did not occur, and a pair of the `removed` and
   /// `kept` [SynthLogic]s otherwise.
   static ({SynthLogic removed, SynthLogic kept})? tryMerge(
-      SynthLogic a, SynthLogic b) {
+    SynthLogic a,
+    SynthLogic b,
+  ) {
     if (_constantsMergeable(a, b)) {
       // case to avoid things like a constant assigned to another constant
       a.adopt(b);
       return (removed: b, kept: a);
     }
 
-    if ((a.isConstant && b.constNameDisallowed) ||
-        (b.isConstant && a.constNameDisallowed)) {
-      // we cannot merge a constant if the other disallows the constant name
-      // since we can lose a constant assignment
-      return null;
-    }
+    // Bug fix: a previous guard here blocked merging when one side was a
+    // constant and the other had `constNameDisallowed`.  This was overly
+    // conservative.  `constNameDisallowed` only means "don't use the
+    // constant literal (e.g. `8'h0`) as the signal name" — it does NOT
+    // mean the signal cannot be merged.  `adopt()` already propagates
+    // the flag via `_constNameDisallowed |=`, so the merged result still
+    // gets a proper named declaration with an `assign` statement.
+    //
+    // Without this fix, when multiple `expressionlessInput` ports (e.g.
+    // from `BusSubset`) were driven by the same constant, each produced
+    // its own redundant declaration instead of sharing one signal.
 
     if (!a.mergeable && !b.mergeable) {
       return null;
@@ -331,13 +379,19 @@ class SynthLogic {
   ///
   /// If [force] is `true`, then it will adopt even if both are non-mergeable.
   void adopt(SynthLogic other, {bool force = false}) {
-    assert(force || other.mergeable || _constantsMergeable(this, other),
-        'Cannot merge a non-mergeable into this.');
-    assert(other.isArray == isArray, 'Cannot merge arrays and non-arrays');
-    assert(other.width == width,
-        'Cannot merge logics of different widths: $width vs ${other.width}');
     assert(
-        other != this, 'Suspicious attempt to merge a SynthLogic into itself.');
+      force || other.mergeable || _constantsMergeable(this, other),
+      'Cannot merge a non-mergeable into this.',
+    );
+    assert(other.isArray == isArray, 'Cannot merge arrays and non-arrays');
+    assert(
+      other.width == width,
+      'Cannot merge logics of different widths: $width vs ${other.width}',
+    );
+    assert(
+      other != this,
+      'Suspicious attempt to merge a SynthLogic into itself.',
+    );
 
     _constNameDisallowed |= other._constNameDisallowed;
 
@@ -421,9 +475,11 @@ class SynthLogic {
       unpackedDims = '';
     }
 
-    return [packedDims, name, unpackedDims]
-        .where((e) => e.isNotEmpty)
-        .join(' ');
+    return [
+      packedDims,
+      name,
+      unpackedDims,
+    ].where((e) => e.isNotEmpty).join(' ');
   }
 }
 
@@ -450,7 +506,8 @@ class SynthLogicArrayElement extends SynthLogic {
       // we cannot just use `super.isPort` since we can't rely on only using
       // `_reservedLogic`
       logics.any(
-          (l) => l.isPort && (module == null || l.parentModule == module)) ||
+        (l) => l.isPort && (module == null || l.parentModule == module),
+      ) ||
       parentArray.isPort(module);
 
   @override
@@ -491,7 +548,8 @@ class SynthLogicArrayElement extends SynthLogic {
     final n = '$parentArrayname[${logic.arrayIndex!}]';
     assert(
       Sanitizer.isSanitary(
-          n.substring(0, n.contains('[') ? n.indexOf('[') : null)),
+        n.substring(0, n.contains('[') ? n.indexOf('[') : null),
+      ),
       'Array name should be sanitary, but found $n',
     );
     return n;
@@ -501,10 +559,13 @@ class SynthLogicArrayElement extends SynthLogic {
   final Logic logic;
 
   /// Creates an instance of an element of a [LogicArray].
-  SynthLogicArrayElement(this.logic,
-      {required super.parentSynthModuleDefinition})
-      : assert(logic.isArrayMember,
-            'Should only be used for elements in a LogicArray'),
+  SynthLogicArrayElement(
+    this.logic, {
+    required super.parentSynthModuleDefinition,
+  })  : assert(
+          logic.isArrayMember,
+          'Should only be used for elements in a LogicArray',
+        ),
         super(logic) {
     // make sure we have created the synthLogic for the parent array
     parentArray;

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -282,7 +282,6 @@ abstract class SimCompare {
               : 'logic');
 
       if (adjust != null) {
-        // ignore: parameter_assignments
         signalName = adjust(signalName);
       }
 

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -218,7 +218,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
 
       if (val.width == 1 && (!val.isValid || fill)) {
         if (!val.isValid) {
-          // ignore: parameter_assignments
           width ??= 1;
         }
         if (width == null) {
@@ -243,7 +242,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
 
       if (val.length == 1 && (val == 'x' || val == 'z' || fill)) {
         if (val == 'x' || val == 'z') {
-          // ignore: parameter_assignments
           width ??= 1;
         }
         if (width == null) {
@@ -269,7 +267,6 @@ abstract class LogicValue implements Comparable<LogicValue> {
       if (val.length == 1 &&
           (val.first == LogicValue.x || val.first == LogicValue.z || fill)) {
         if (!val.first.isValid) {
-          // ignore: parameter_assignments
           width ??= 1;
         }
         if (width == null) {

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -100,63 +100,6 @@ class FancyStructInverter extends Module {
   }
 }
 
-// -- Structure leaf naming helpers --
-
-class _StructLeafNamingStruct extends LogicStructure {
-  final Logic a;
-  final Logic b;
-
-  _StructLeafNamingStruct({required this.a, required this.b, super.name = 'st'})
-      : super([a, b]);
-
-  @override
-  _StructLeafNamingStruct clone({String? name}) => _StructLeafNamingStruct(
-        a: a.clone(),
-        b: b.clone(), // key: element.clone() → Naming.mergeable
-        name: name ?? this.name,
-      );
-}
-
-class _StructLeafNamingModule extends Module {
-  _StructLeafNamingModule() {
-    final inp = addTypedInput(
-      'inp',
-      _StructLeafNamingStruct(
-        a: Logic(name: 'a', width: 4),
-        b: Logic(width: 4), // unnamed → auto '_s'
-      ),
-    );
-    addOutput('out', width: 4) <= inp.b ^ inp.a;
-  }
-}
-
-// -- Const naming helpers --
-
-class _ExpressionlessSub extends Module with SystemVerilog {
-  @override
-  List<String> get expressionlessInputs => ['a', 'b'];
-
-  _ExpressionlessSub(Logic a, Logic b) {
-    addInput('a', a, width: a.width);
-    addInput('b', b, width: b.width);
-    addOutput('out', width: a.width);
-  }
-
-  @override
-  String? instantiationVerilog(String instanceType, String instanceName,
-          Map<String, String> ports) =>
-      '$instanceType $instanceName(.a(${ports['a']}), .b(${ports['b']}), '
-      '.out(${ports['out']}));';
-}
-
-class _ConstNamingModule extends Module {
-  _ConstNamingModule() {
-    final c = Const(0, width: 8);
-    final sub = _ExpressionlessSub(c, c);
-    addOutput('result', width: 8) <= sub.output('out');
-  }
-}
-
 class StructModuleWithInstrumentation extends Module {
   StructModuleWithInstrumentation(Logic a) {
     a = addInput('a', a, width: 2);
@@ -376,31 +319,5 @@ void main() {
     await Simulator.run();
 
     expect(checkRan, isTrue);
-  });
-
-  group('synthesis names', () {
-    test('struct leaf with unpreferred raw name uses struct-path name',
-        () async {
-      final mod = _StructLeafNamingModule();
-      await mod.build();
-      final sv = mod.generateSynth();
-
-      expect(sv, isNot(contains('_in0')),
-          reason: 'Struct leaf from unnamed Logic() should use its '
-              'struct-path name, not fall back to anonymous _in names.\n$sv');
-    });
-
-    test('const merge not blocked by constNameDisallowed', () async {
-      final mod = _ConstNamingModule();
-      await mod.build();
-      final sv = mod.generateSynth();
-
-      final constAssignments =
-          RegExp(r"assign \w+ = 8'h0;").allMatches(sv).length;
-      expect(constAssignments, equals(1),
-          reason: 'Two expressionless inputs driven by the same constant '
-              'should merge into one signal declaration, not produce '
-              '$constAssignments separate assignments.\n$sv');
-    });
   });
 }

--- a/test/logic_structure_test.dart
+++ b/test/logic_structure_test.dart
@@ -100,6 +100,63 @@ class FancyStructInverter extends Module {
   }
 }
 
+// -- Structure leaf naming helpers --
+
+class _StructLeafNamingStruct extends LogicStructure {
+  final Logic a;
+  final Logic b;
+
+  _StructLeafNamingStruct({required this.a, required this.b, super.name = 'st'})
+      : super([a, b]);
+
+  @override
+  _StructLeafNamingStruct clone({String? name}) => _StructLeafNamingStruct(
+        a: a.clone(),
+        b: b.clone(), // key: element.clone() → Naming.mergeable
+        name: name ?? this.name,
+      );
+}
+
+class _StructLeafNamingModule extends Module {
+  _StructLeafNamingModule() {
+    final inp = addTypedInput(
+      'inp',
+      _StructLeafNamingStruct(
+        a: Logic(name: 'a', width: 4),
+        b: Logic(width: 4), // unnamed → auto '_s'
+      ),
+    );
+    addOutput('out', width: 4) <= inp.b ^ inp.a;
+  }
+}
+
+// -- Const naming helpers --
+
+class _ExpressionlessSub extends Module with SystemVerilog {
+  @override
+  List<String> get expressionlessInputs => ['a', 'b'];
+
+  _ExpressionlessSub(Logic a, Logic b) {
+    addInput('a', a, width: a.width);
+    addInput('b', b, width: b.width);
+    addOutput('out', width: a.width);
+  }
+
+  @override
+  String? instantiationVerilog(String instanceType, String instanceName,
+          Map<String, String> ports) =>
+      '$instanceType $instanceName(.a(${ports['a']}), .b(${ports['b']}), '
+      '.out(${ports['out']}));';
+}
+
+class _ConstNamingModule extends Module {
+  _ConstNamingModule() {
+    final c = Const(0, width: 8);
+    final sub = _ExpressionlessSub(c, c);
+    addOutput('result', width: 8) <= sub.output('out');
+  }
+}
+
 class StructModuleWithInstrumentation extends Module {
   StructModuleWithInstrumentation(Logic a) {
     a = addInput('a', a, width: 2);
@@ -319,5 +376,31 @@ void main() {
     await Simulator.run();
 
     expect(checkRan, isTrue);
+  });
+
+  group('synthesis names', () {
+    test('struct leaf with unpreferred raw name uses struct-path name',
+        () async {
+      final mod = _StructLeafNamingModule();
+      await mod.build();
+      final sv = mod.generateSynth();
+
+      expect(sv, isNot(contains('_in0')),
+          reason: 'Struct leaf from unnamed Logic() should use its '
+              'struct-path name, not fall back to anonymous _in names.\n$sv');
+    });
+
+    test('const merge not blocked by constNameDisallowed', () async {
+      final mod = _ConstNamingModule();
+      await mod.build();
+      final sv = mod.generateSynth();
+
+      final constAssignments =
+          RegExp(r"assign \w+ = 8'h0;").allMatches(sv).length;
+      expect(constAssignments, equals(1),
+          reason: 'Two expressionless inputs driven by the same constant '
+              'should merge into one signal declaration, not produce '
+              '$constAssignments separate assignments.\n$sv');
+    });
   });
 }

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -617,6 +617,63 @@ class ModWithInOut extends Module {
   }
 }
 
+// -- Structure leaf naming helpers --
+
+class _StructLeafNamingStruct extends LogicStructure {
+  final Logic a;
+  final Logic b;
+
+  _StructLeafNamingStruct({required this.a, required this.b, super.name = 'st'})
+      : super([a, b]);
+
+  @override
+  _StructLeafNamingStruct clone({String? name}) => _StructLeafNamingStruct(
+        a: a.clone(),
+        b: b.clone(), // key: element.clone() → Naming.mergeable
+        name: name ?? this.name,
+      );
+}
+
+class _StructLeafNamingModule extends Module {
+  _StructLeafNamingModule() {
+    final inp = addTypedInput(
+      'inp',
+      _StructLeafNamingStruct(
+        a: Logic(name: 'a', width: 4),
+        b: Logic(width: 4), // unnamed → auto '_s'
+      ),
+    );
+    addOutput('out', width: 4) <= inp.b ^ inp.a;
+  }
+}
+
+// -- Const naming helpers --
+
+class _ExpressionlessSub extends Module with SystemVerilog {
+  @override
+  List<String> get expressionlessInputs => ['a', 'b'];
+
+  _ExpressionlessSub(Logic a, Logic b) {
+    addInput('a', a, width: a.width);
+    addInput('b', b, width: b.width);
+    addOutput('out', width: a.width);
+  }
+
+  @override
+  String? instantiationVerilog(String instanceType, String instanceName,
+          Map<String, String> ports) =>
+      '$instanceType $instanceName(.a(${ports['a']}), .b(${ports['b']}), '
+      '.out(${ports['out']}));';
+}
+
+class _ConstNamingModule extends Module {
+  _ConstNamingModule() {
+    final c = Const(0, width: 8);
+    final sub = _ExpressionlessSub(c, c);
+    addOutput('result', width: 8) <= sub.output('out');
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -994,5 +1051,30 @@ endmodule : ModWithUselessWireMods'''));
     ];
     await SimCompare.checkFunctionalVector(mod, vectors);
     SimCompare.checkIverilogVector(mod, vectors);
+  });
+  group('synthesis names', () {
+    test('struct leaf with unpreferred raw name uses struct-path name',
+        () async {
+      final mod = _StructLeafNamingModule();
+      await mod.build();
+      final sv = mod.generateSynth();
+
+      expect(sv, isNot(contains('_in0')),
+          reason: 'Struct leaf from unnamed Logic() should use its '
+              'struct-path name, not fall back to anonymous _in names.\n$sv');
+    });
+
+    test('const merge not blocked by constNameDisallowed', () async {
+      final mod = _ConstNamingModule();
+      await mod.build();
+      final sv = mod.generateSynth();
+
+      final constAssignments =
+          RegExp(r"assign \w+ = 8'h0;").allMatches(sv).length;
+      expect(constAssignments, equals(1),
+          reason: 'Two expressionless inputs driven by the same constant '
+              'should merge into one signal declaration, not produce '
+              '$constAssignments separate assignments.\n$sv');
+    });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Discovered two anomalies in SystemVerilog synthesized names that need fixing to match a new converged solution.
It would be difficult to be compatible with these behaviors and this reduces noise in the differences in naming.

1) how unnamed structure leaf signals are named -- we were not picking up a field name as preferred.
2) we were replicating const assignment names dozens of times when we could use just one name.

## Related Issue(s)

Fix #648
Fix #649

## Testing

We replicated simple examples that demonstrate the two bugs, verified they expose the bug and the fixes work.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.  SV output will change slightly.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.