### PR TITLE
trial run for Node v24

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Setup Pana source analysis
         run: tool/gh_actions/install_pana.sh

--- a/README.md
+++ b/README.md
@@ -68,6 +68,5 @@ One of ROHD's goals is to help grow an open-source community around reusable har
 ROHD is under active development.  If you're interested in contributing, have feedback or a question, or found a bug, please see [CONTRIBUTING.md](https://github.com/intel/rohd/blob/main/CONTRIBUTING.md).
 
 ----------------
-
 Copyright (C) 2021-2026 Intel Corporation  
 SPDX-License-Identifier: BSD-3-Clause

--- a/tool/gh_actions/install_node.sh
+++ b/tool/gh_actions/install_node.sh
@@ -16,6 +16,6 @@ set -euo pipefail
 
 sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-NODE_MAJOR=20
+NODE_MAJOR=24
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 sudo apt-get update && sudo apt-get install nodejs -y


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Node 20 will be deprecated and we are using advanced node features in future PRs.

## Related Issue(s)

None.

## Testing

We have been using Node 24 in local testing.  This is a workflow CI test.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

None needed.
