### PR TITLE
new dart analyzer failure with bad override

### DIFF
--- a/doc/tutorials/chapter_6/answers/exercise_2_n_bit_subtractor.dart
+++ b/doc/tutorials/chapter_6/answers/exercise_2_n_bit_subtractor.dart
@@ -7,7 +7,6 @@ import '../../chapter_3/answers/helper.dart';
 import '../../chapter_5/answers/full_subtractor.dart';
 
 class FullSubtractorComb extends FullSubtractor {
-  @override
   FullSubtractorComb(super.a, super.b, super.borrowIn) {
     // Declare input and output
     final a = input('a');


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

New PRs cannot run with new dart version because of old override that is a failure in lint

## Related Issue(s)

None

## Testing

Ran analyze under new dart

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

This is a single line change in the tutorial section which uses an override spuriously.