### PR TITLE
Make slicing a const where all bits equal return a const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Improved `Logic.getRange` and `slice` on filled `Const`s to return direct constants instead of constructing `BusSubset` modules (<https://github.com/intel/rohd/pull/677>).
 - Improved generated SystemVerilog for swizzles to compact adjacent bit selections into legal slice expressions (<https://github.com/intel/rohd/pull/674>).
 - Improved generated SystemVerilog to collapse a variety of intermediate `LogicArray`s and net buses (e.g. from bit-blasting, aggregate connections, `assignSubset`) into inline concatenations on their consuming connections, eliminating unnecessary intermediate declarations, `assign`s, and `net_connect`s when it is safe to do so (<https://github.com/intel/rohd/pull/663>).
 

--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -768,8 +768,29 @@ class Logic {
       return this;
     }
 
+    final constantFillValue = _constantFillValueOf(this);
+    if (constantFillValue != null) {
+      return Const(
+        LogicValue.filled(
+          (modifiedEndIndex - modifiedStartIndex).abs() + 1,
+          constantFillValue,
+        ),
+      );
+    }
+
     // Create a new bus subset
     return BusSubset(this, modifiedStartIndex, modifiedEndIndex).subset;
+  }
+
+  static LogicValue? _constantFillValueOf(Logic logic) {
+    if (logic is! Const || logic.width == 0) {
+      return null;
+    }
+
+    final fillValue = logic.value[0];
+    return logic.value == LogicValue.filled(logic.width, fillValue)
+        ? fillValue
+        : null;
   }
 
   /// Returns a version of this [Logic] with the bit order reversed.

--- a/test/logic_test.dart
+++ b/test/logic_test.dart
@@ -15,4 +15,26 @@ void main() {
     final logic = Logic();
     expect(logic.packed, logic);
   });
+
+  test('getRange on filled constants returns a constant', () {
+    for (final fillValue in [
+      LogicValue.zero,
+      LogicValue.one,
+      LogicValue.x,
+      LogicValue.z,
+    ]) {
+      final range = Const(LogicValue.filled(8, fillValue)).getRange(2, 5);
+
+      expect(range, isA<Const>());
+      expect(range.value, LogicValue.filled(3, fillValue));
+      expect(range.parentModule, isNull);
+    }
+  });
+
+  test('getRange on mixed constants still uses BusSubset', () {
+    final range = Const(LogicValue.ofString('10101010')).getRange(2, 5);
+
+    expect(range, isNot(isA<Const>()));
+    expect(range.parentModule, isA<BusSubset>());
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Short-circuit `Logic.getRange`/`slice` on filled `Const`s to return a narrower constant directly.
- Covers all-0, all-1, all-x, and all-z constants while preserving the existing `BusSubset` path for mixed constants.

## Related Issue(s)

N/A

## Testing

- Adds focused tests for filled and mixed constant range behavior.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
