### PR TITLE
Configurable SV generation, port object and data types

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 
   "updateContentCommand": "tool/gh_codespaces/run_setup.sh",
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Added configurable explicit or implicit object and data types for generated SystemVerilog ports, defaulting to `input wire logic`, `output var logic`, and `inout wire logic`.
+- Added configurable explicit or implicit object and data types for generated SystemVerilog ports, defaulting to `input wire logic`, `output var logic`, and `inout wire logic` (<https://github.com/intel/rohd/pull/678>).
 - Improved `Logic.getRange` and `slice` on filled `Const`s to return direct constants instead of constructing `BusSubset` modules (<https://github.com/intel/rohd/pull/677>).
 - Improved generated SystemVerilog for swizzles to compact adjacent bit selections into legal slice expressions (<https://github.com/intel/rohd/pull/674>).
 - Improved generated SystemVerilog to collapse a variety of intermediate `LogicArray`s and net buses (e.g. from bit-blasting, aggregate connections, `assignSubset`) into inline concatenations on their consuming connections, eliminating unnecessary intermediate declarations, `assign`s, and `net_connect`s when it is safe to do so (<https://github.com/intel/rohd/pull/663>).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Added configurable explicit or implicit object and data types for generated SystemVerilog ports, defaulting to `input wire logic`, `output var logic`, and `inout wire logic`.
 - Improved `Logic.getRange` and `slice` on filled `Const`s to return direct constants instead of constructing `BusSubset` modules (<https://github.com/intel/rohd/pull/677>).
 - Improved generated SystemVerilog for swizzles to compact adjacent bit selections into legal slice expressions (<https://github.com/intel/rohd/pull/674>).
 - Improved generated SystemVerilog to collapse a variety of intermediate `LogicArray`s and net buses (e.g. from bit-blasting, aggregate connections, `assignSubset`) into inline concatenations on their consuming connections, eliminating unnecessary intermediate declarations, `assign`s, and `net_connect`s when it is safe to do so (<https://github.com/intel/rohd/pull/663>).

--- a/doc/user_guide/_docs/A21-generation.md
+++ b/doc/user_guide/_docs/A21-generation.md
@@ -28,6 +28,21 @@ void main() async {
 
 The `generateSynth` function will return a `String` with the SystemVerilog `module` definitions for the top-level it is called on, as well as any sub-modules (recursively).  You can dump the entire contents to a file and use it anywhere you would any other SystemVerilog.
 
+## Controlling port types
+
+Generated ports have explicit object and data types by default: inputs are `input wire logic`, outputs are `output var logic`, and inouts are `inout wire logic`. Use a `SystemVerilogSynthesizerConfiguration` to omit either category and rely on SystemVerilog's implicit types:
+
+```dart
+final generatedSv = myModule.generateSynth(
+  configuration: const SystemVerilogSynthesizerConfiguration(
+    portObjectType: SystemVerilogPortType.implicit,
+    portDataType: SystemVerilogPortType.implicit,
+  ),
+);
+```
+
+The same configuration can be passed directly to `SystemVerilogSynthesizer` when using `SynthBuilder`.
+
 ## Controlling naming
 
 ### Modules

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -1137,7 +1137,12 @@ abstract class Module {
   ///
   /// Currently returns one long file in SystemVerilog, but in the future
   /// may have other output formats, languages, files, etc.
-  String generateSynth() {
+  ///
+  /// The [configuration] controls options specific to SystemVerilog output.
+  String generateSynth({
+    SystemVerilogSynthesizerConfiguration configuration =
+        const SystemVerilogSynthesizerConfiguration(),
+  }) {
     if (!_hasBuilt) {
       throw ModuleNotBuiltException(this);
     }
@@ -1151,9 +1156,10 @@ abstract class Module {
 
 ''';
     return synthHeader +
-        SynthBuilder(this, SystemVerilogSynthesizer())
-            .getSynthFileContents()
-            .join('\n\n////////////////////\n\n');
+        SynthBuilder(
+          this,
+          SystemVerilogSynthesizer(configuration: configuration),
+        ).getSynthFileContents().join('\n\n////////////////////\n\n');
   }
 }
 

--- a/lib/src/synthesizers/systemverilog/systemverilog.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog.dart
@@ -1,5 +1,6 @@
-// Copyright (C) 2021-2024 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
 export 'systemverilog_mixins.dart';
 export 'systemverilog_synthesizer.dart';
+export 'systemverilog_synthesizer_configuration.dart';

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // systemverilog_synthesis_result.dart
@@ -58,6 +58,9 @@ class SystemVerilogCustomDefinitionSynthesisResult extends SynthesisResult {
 /// A [SynthesisResult] representing a conversion of a [Module] to
 /// SystemVerilog.
 class SystemVerilogSynthesisResult extends SynthesisResult {
+  /// Configuration controlling generated SystemVerilog.
+  final SystemVerilogSynthesizerConfiguration configuration;
+
   /// A cached copy of the generated ports.
   late final String _portsString;
 
@@ -75,8 +78,11 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
       _synthModuleDefinition.supportingModules;
 
   /// Creates a new [SystemVerilogSynthesisResult] for the given [module].
-  SystemVerilogSynthesisResult(super.module, super.getInstanceTypeOfModule)
-      : _synthModuleDefinition = SystemVerilogSynthModuleDefinition(module) {
+  SystemVerilogSynthesisResult(
+    super.module,
+    super.getInstanceTypeOfModule, {
+    this.configuration = const SystemVerilogSynthesizerConfiguration(),
+  }) : _synthModuleDefinition = SystemVerilogSynthModuleDefinition(module) {
     _portsString = _verilogPorts();
     _moduleContentsString = _verilogModuleContents(getInstanceTypeOfModule);
     _parameterString = _verilogParameters(module);
@@ -111,7 +117,7 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
   Iterable<String> _verilogInputs() => _synthModuleDefinition.inputs.map((sig) {
         assert(module.tryInput(sig.name) != null,
             'Named input ${sig.name} not found in module ${module.name}.');
-        return 'input ${sig.definitionType()} ${sig.definitionName()}';
+        return _verilogPort('input', 'wire', sig);
       });
 
   /// Representation of all output port declarations in generated SV.
@@ -119,15 +125,25 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
       _synthModuleDefinition.outputs.map((sig) {
         assert(module.tryOutput(sig.name) != null,
             'Named output ${sig.name} not found in module ${module.name}.');
-        return 'output ${sig.definitionType()} ${sig.definitionName()}';
+        return _verilogPort('output', 'var', sig);
       });
 
   /// Representation of all inout port declarations in generated SV.
   Iterable<String> _verilogInOuts() => _synthModuleDefinition.inOuts.map((sig) {
         assert(module.tryInOut(sig.name) != null,
             'Named inOut ${sig.name} not found in module ${module.name}.');
-        return 'inout ${sig.definitionType()} ${sig.definitionName()}';
+        return _verilogPort('inout', 'wire', sig);
       });
+
+  /// Representation of a port declaration in generated SV.
+  String _verilogPort(String direction, String objectType, SynthLogic sig) => [
+        direction,
+        if (configuration.portObjectType == SystemVerilogPortType.explicit)
+          objectType,
+        if (configuration.portDataType == SystemVerilogPortType.explicit)
+          'logic',
+        sig.definitionName(),
+      ].join(' ');
 
   /// Representation of all internal net declarations in generated SV.
   String _verilogInternalSignals() {

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesizer.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesizer.dart
@@ -15,6 +15,14 @@ import 'package:rohd/src/synthesizers/systemverilog/systemverilog_synthesis_resu
 ///
 /// Attempts to maintain signal naming and structure as much as possible.
 class SystemVerilogSynthesizer extends Synthesizer {
+  /// Configuration controlling generated SystemVerilog.
+  final SystemVerilogSynthesizerConfiguration configuration;
+
+  /// Creates a SystemVerilog synthesizer with the specified [configuration].
+  SystemVerilogSynthesizer({
+    this.configuration = const SystemVerilogSynthesizerConfiguration(),
+  });
+
   @override
   bool generatesDefinition(Module module) =>
       // ignore: deprecated_member_use_from_same_package
@@ -147,6 +155,10 @@ class SystemVerilogSynthesizer extends Synthesizer {
             module.generatedDefinitionType == DefinitionGenerationType.custom
         ? SystemVerilogCustomDefinitionSynthesisResult(
             module, getInstanceTypeOfModule)
-        : SystemVerilogSynthesisResult(module, getInstanceTypeOfModule);
+        : SystemVerilogSynthesisResult(
+            module,
+            getInstanceTypeOfModule,
+            configuration: configuration,
+          );
   }
 }

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesizer_configuration.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesizer_configuration.dart
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// systemverilog_synthesizer_configuration.dart
+// Configuration for SystemVerilog synthesis.
+//
+// 2026 July 10
+// Author: Max Korbel <max.korbel@intel.com>
+
+/// Controls whether a type is included in a SystemVerilog port declaration.
+enum SystemVerilogPortType {
+  /// The type is included in the port declaration.
+  explicit,
+
+  /// The type is inferred according to SystemVerilog's defaults.
+  implicit,
+}
+
+/// Configuration for SystemVerilog synthesis.
+class SystemVerilogSynthesizerConfiguration {
+  /// Whether port object types, such as `wire` and `var`, are explicit.
+  final SystemVerilogPortType portObjectType;
+
+  /// Whether port data types, such as `logic`, are explicit.
+  final SystemVerilogPortType portDataType;
+
+  /// Creates a new configuration for SystemVerilog synthesis.
+  const SystemVerilogSynthesizerConfiguration({
+    this.portObjectType = SystemVerilogPortType.explicit,
+    this.portDataType = SystemVerilogPortType.explicit,
+  });
+}

--- a/lib/src/utilities/simcompare.dart
+++ b/lib/src/utilities/simcompare.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // simcompare.dart
@@ -240,6 +240,8 @@ abstract class SimCompare {
     bool maskKnownWarnings = true,
     bool enableChecking = true,
     bool buildOnly = false,
+    SystemVerilogSynthesizerConfiguration synthesizerConfiguration =
+        const SystemVerilogSynthesizerConfiguration(),
   }) {
     final result = iverilogVector(module, vectors,
         moduleName: moduleName,
@@ -248,7 +250,8 @@ abstract class SimCompare {
         iverilogExtraArgs: iverilogExtraArgs,
         allowWarnings: allowWarnings,
         maskKnownWarnings: maskKnownWarnings,
-        buildOnly: buildOnly);
+        buildOnly: buildOnly,
+        synthesizerConfiguration: synthesizerConfiguration);
     if (enableChecking) {
       expect(result, true);
     }
@@ -265,6 +268,8 @@ abstract class SimCompare {
     bool allowWarnings = false,
     bool maskKnownWarnings = true,
     bool buildOnly = false,
+    SystemVerilogSynthesizerConfiguration synthesizerConfiguration =
+        const SystemVerilogSynthesizerConfiguration(),
   }) {
     if (kIsWeb) {
       // if running in web mode, then we can't run icarus verilog
@@ -342,7 +347,9 @@ abstract class SimCompare {
         allSignals.map((e) => '.$e(${logicToWireMapping[e] ?? e})').join(', ');
     final moduleInstance = '$topModule dut($moduleConnections);';
     final stimulus = vectors.map((e) => e.toTbVerilog(module)).join('\n');
-    final generatedVerilog = module.generateSynth();
+    final generatedVerilog = module.generateSynth(
+      configuration: synthesizerConfiguration,
+    );
 
     // so that when they run in parallel, they dont step on each other
     final uniqueId =

--- a/test/logic_array_test.dart
+++ b/test/logic_array_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // logic_array_test.dart
@@ -847,8 +847,8 @@ void main() {
 
         // ensure ports with interface are still an array
         final sv = mod.generateSynth();
-        expect(sv, contains('input logic [2:0][1:0][2:0][7:0] laIn'));
-        expect(sv, contains('output logic [2:0][1:0][2:0][7:0] laOut'));
+        expect(sv, contains('input wire logic [2:0][1:0][2:0][7:0] laIn'));
+        expect(sv, contains('output var logic [2:0][1:0][2:0][7:0] laOut'));
       });
 
       test('3 dimensions with interface and unpacked', () async {
@@ -862,8 +862,8 @@ void main() {
 
         // ensure ports with interface are still an array
         final sv = mod.generateSynth();
-        expect(sv, contains('input logic [1:0][2:0][7:0] laIn [2:0]'));
-        expect(sv, contains('output logic [1:0][2:0][7:0] laOut [2:0]'));
+        expect(sv, contains('input wire logic [1:0][2:0][7:0] laIn [2:0]'));
+        expect(sv, contains('output var logic [1:0][2:0][7:0] laOut [2:0]'));
       });
     });
 

--- a/test/naming_cases_test.dart
+++ b/test/naming_cases_test.dart
@@ -557,8 +557,8 @@ void main() {
       final sv = mod.generateSynth();
 
       // Port declarations.
-      expect(sv, contains('input logic [7:0] inp'));
-      expect(sv, contains('output logic [7:0] out'));
+      expect(sv, contains('input wire logic [7:0] inp'));
+      expect(sv, contains('output var logic [7:0] out'));
       expect(sv, contains('_uinp'));
       expect(sv, contains('mport'));
       expect(sv, contains('_muprt'));

--- a/test/pair_interface_hier_test.dart
+++ b/test/pair_interface_hier_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface_hier_test.dart
@@ -95,7 +95,7 @@ void main() {
 
     expect(sv, contains('HierConsumer  unnamed_module'));
     expect(sv, contains('HierProducer  unnamed_module'));
-    expect(sv, contains('inout wire io_0'));
-    expect(sv, contains('inout wire [2:0] io_arr_0'));
+    expect(sv, contains('inout wire logic io_0'));
+    expect(sv, contains('inout wire logic [2:0] io_arr_0'));
   });
 }

--- a/test/pair_interface_hier_w_modify_test.dart
+++ b/test/pair_interface_hier_w_modify_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface_hier_w_modify_test.dart
@@ -97,7 +97,7 @@ void main() {
 
     expect(sv, contains('HierConsumer  unnamed_module'));
     expect(sv, contains('HierProducer  unnamed_module'));
-    expect(sv, contains('inout wire io_0'));
-    expect(sv, contains('inout wire [2:0] io_arr_0'));
+    expect(sv, contains('inout wire logic io_0'));
+    expect(sv, contains('inout wire logic [2:0] io_arr_0'));
   });
 }

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // pair_interface_test.dart
@@ -193,7 +193,7 @@ void main() {
 
     // Make sure the "modify" went through:
     final sv = mod.generateSynth();
-    expect(sv, contains('input logic simple_clk'));
+    expect(sv, contains('input wire logic simple_clk'));
   });
 
   group('drive and receive other', () {

--- a/test/provider_consumer_test.dart
+++ b/test/provider_consumer_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // provider_consumer_test.dart
@@ -180,33 +180,33 @@ void main() {
 
     expect(sv, contains('''
 module Provider (
-input logic clk,
-input logic reset,
-input logic wd0_ready_req,
-input logic wd1_ready_req,
-input logic [31:0] rd_data_rsp,
-input logic rd_valid_rsp,
-output logic [31:0] wd0_data_req,
-output logic wd0_valid_req,
-output logic [31:0] wd1_data_req,
-output logic wd1_valid_req,
-output logic rd_ready_rsp
+input wire logic clk,
+input wire logic reset,
+input wire logic wd0_ready_req,
+input wire logic wd1_ready_req,
+input wire logic [31:0] rd_data_rsp,
+input wire logic rd_valid_rsp,
+output var logic [31:0] wd0_data_req,
+output var logic wd0_valid_req,
+output var logic [31:0] wd1_data_req,
+output var logic wd1_valid_req,
+output var logic rd_ready_rsp
 );
 '''));
 
     expect(sv, contains('''
 module Consumer (
-input logic clk,
-input logic reset,
-input logic [31:0] wd0_data_req,
-input logic wd0_valid_req,
-input logic [31:0] wd1_data_req,
-input logic wd1_valid_req,
-input logic rd_ready_rsp,
-output logic wd0_ready_req,
-output logic wd1_ready_req,
-output logic [31:0] rd_data_rsp,
-output logic rd_valid_rsp
+input wire logic clk,
+input wire logic reset,
+input wire logic [31:0] wd0_data_req,
+input wire logic wd0_valid_req,
+input wire logic [31:0] wd1_data_req,
+input wire logic wd1_valid_req,
+input wire logic rd_ready_rsp,
+output var logic wd0_ready_req,
+output var logic wd1_ready_req,
+output var logic [31:0] rd_data_rsp,
+output var logic rd_valid_rsp
 );
 '''));
 

--- a/test/provider_consumer_w_modify_test.dart
+++ b/test/provider_consumer_w_modify_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // provider_consumer_w_modify_test.dart
@@ -150,33 +150,33 @@ void main() {
 
     expect(sv, contains('''
 module Provider (
-input logic clk,
-input logic reset,
-input logic wd0_ready_req,
-input logic wd1_ready_req,
-input logic [31:0] rd_data_rsp,
-input logic rd_valid_rsp,
-output logic [31:0] wd0_data_req,
-output logic wd0_valid_req,
-output logic [31:0] wd1_data_req,
-output logic wd1_valid_req,
-output logic rd_ready_rsp
+input wire logic clk,
+input wire logic reset,
+input wire logic wd0_ready_req,
+input wire logic wd1_ready_req,
+input wire logic [31:0] rd_data_rsp,
+input wire logic rd_valid_rsp,
+output var logic [31:0] wd0_data_req,
+output var logic wd0_valid_req,
+output var logic [31:0] wd1_data_req,
+output var logic wd1_valid_req,
+output var logic rd_ready_rsp
 );
 '''));
 
     expect(sv, contains('''
 module Consumer (
-input logic clk,
-input logic reset,
-input logic [31:0] wd0_data_req,
-input logic wd0_valid_req,
-input logic [31:0] wd1_data_req,
-input logic wd1_valid_req,
-input logic rd_ready_rsp,
-output logic wd0_ready_req,
-output logic wd1_ready_req,
-output logic [31:0] rd_data_rsp,
-output logic rd_valid_rsp
+input wire logic clk,
+input wire logic reset,
+input wire logic [31:0] wd0_data_req,
+input wire logic wd0_valid_req,
+input wire logic [31:0] wd1_data_req,
+input wire logic wd1_valid_req,
+input wire logic rd_ready_rsp,
+output var logic wd0_ready_req,
+output var logic wd1_ready_req,
+output var logic [31:0] rd_data_rsp,
+output var logic rd_valid_rsp
 );
 '''));
 

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -887,8 +887,8 @@ void main() {
 
     expect(sv, contains('''
 module ModWithUselessWireMods (
-input logic [7:0] a,
-input logic [7:0] b
+input wire logic [7:0] a,
+input wire logic [7:0] b
 );
 
 endmodule : ModWithUselessWireMods'''));

--- a/test/systemverilog_port_types_test.dart
+++ b/test/systemverilog_port_types_test.dart
@@ -8,6 +8,7 @@
 // Author: Max Korbel <max.korbel@intel.com>
 
 import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:test/test.dart';
 
 class _PortStructure extends LogicStructure {
@@ -31,7 +32,7 @@ class _PortStructure extends LogicStructure {
 }
 
 class _PortTypesModule extends Module {
-  _PortTypesModule() {
+  _PortTypesModule({bool includeUnpackedInOut = true}) {
     final scalarIn = addInput('scalarIn', Logic(width: 8), width: 8);
     addOutput('scalarOut', width: 8) <= scalarIn;
     addInOut('scalarInOut', LogicNet(width: 8), width: 8);
@@ -48,8 +49,10 @@ class _PortTypesModule extends Module {
         'unpackedArrayIn', LogicArray([2, 3], 4, numUnpackedDimensions: 1));
     addTypedOutput('unpackedArrayOut', unpackedArrayIn.clone) <=
         unpackedArrayIn;
-    addTypedInOut('unpackedArrayInOut',
-        LogicArray.net([2, 3], 4, numUnpackedDimensions: 1));
+    if (includeUnpackedInOut) {
+      addTypedInOut('unpackedArrayInOut',
+          LogicArray.net([2, 3], 4, numUnpackedDimensions: 1));
+    }
   }
 }
 
@@ -130,6 +133,15 @@ void main() {
           expect(sv, contains('$prefix $suffix'));
         }
       }
+
+      final iverilogModule = _PortTypesModule(includeUnpackedInOut: false);
+      await iverilogModule.build();
+      SimCompare.checkIverilogVector(
+        iverilogModule,
+        [],
+        buildOnly: true,
+        synthesizerConfiguration: testCase.configuration,
+      );
     });
   }
 }

--- a/test/systemverilog_port_types_test.dart
+++ b/test/systemverilog_port_types_test.dart
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// systemverilog_port_types_test.dart
+// Tests for SystemVerilog port object and data types.
+//
+// 2026 July
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+class _PortStructure extends LogicStructure {
+  final bool asNet;
+
+  factory _PortStructure({String? name, bool asNet = false}) =>
+      _PortStructure._(
+        (asNet ? LogicNet.new : Logic.new)(width: 2, name: 'first'),
+        (asNet ? LogicNet.new : Logic.new)(width: 6, name: 'second'),
+        name: name,
+        asNet: asNet,
+      );
+
+  _PortStructure._(Logic first, Logic second,
+      {required String? name, required this.asNet})
+      : super([first, second], name: name ?? 'portStructure');
+
+  @override
+  _PortStructure clone({String? name}) =>
+      _PortStructure(name: name ?? this.name, asNet: asNet);
+}
+
+class _PortTypesModule extends Module {
+  _PortTypesModule() {
+    final scalarIn = addInput('scalarIn', Logic(width: 8), width: 8);
+    addOutput('scalarOut', width: 8) <= scalarIn;
+    addInOut('scalarInOut', LogicNet(width: 8), width: 8);
+
+    final structureIn = addTypedInput('structureIn', _PortStructure());
+    addTypedOutput('structureOut', structureIn.clone) <= structureIn;
+    addTypedInOut('structureInOut', _PortStructure(asNet: true));
+
+    final packedArrayIn = addTypedInput('packedArrayIn', LogicArray([2, 3], 4));
+    addTypedOutput('packedArrayOut', packedArrayIn.clone) <= packedArrayIn;
+    addTypedInOut('packedArrayInOut', LogicArray.net([2, 3], 4));
+
+    final unpackedArrayIn = addTypedInput(
+        'unpackedArrayIn', LogicArray([2, 3], 4, numUnpackedDimensions: 1));
+    addTypedOutput('unpackedArrayOut', unpackedArrayIn.clone) <=
+        unpackedArrayIn;
+    addTypedInOut('unpackedArrayInOut',
+        LogicArray.net([2, 3], 4, numUnpackedDimensions: 1));
+  }
+}
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  final testCases = [
+    (
+      name: 'explicit object and data types by default',
+      configuration: const SystemVerilogSynthesizerConfiguration(),
+      inputPrefix: 'input wire logic',
+      outputPrefix: 'output var logic',
+      inOutPrefix: 'inout wire logic',
+    ),
+    (
+      name: 'implicit object and explicit data types',
+      configuration: const SystemVerilogSynthesizerConfiguration(
+        portObjectType: SystemVerilogPortType.implicit,
+      ),
+      inputPrefix: 'input logic',
+      outputPrefix: 'output logic',
+      inOutPrefix: 'inout logic',
+    ),
+    (
+      name: 'explicit object and implicit data types',
+      configuration: const SystemVerilogSynthesizerConfiguration(
+        portDataType: SystemVerilogPortType.implicit,
+      ),
+      inputPrefix: 'input wire',
+      outputPrefix: 'output var',
+      inOutPrefix: 'inout wire',
+    ),
+    (
+      name: 'implicit object and data types',
+      configuration: const SystemVerilogSynthesizerConfiguration(
+        portObjectType: SystemVerilogPortType.implicit,
+        portDataType: SystemVerilogPortType.implicit,
+      ),
+      inputPrefix: 'input',
+      outputPrefix: 'output',
+      inOutPrefix: 'inout',
+    ),
+  ];
+
+  for (final testCase in testCases) {
+    test(testCase.name, () async {
+      final module = _PortTypesModule();
+      await module.build();
+
+      final sv = module.generateSynth(configuration: testCase.configuration);
+
+      final declarations = {
+        testCase.inputPrefix: [
+          '[7:0] scalarIn',
+          '[7:0] structureIn',
+          '[1:0][2:0][3:0] packedArrayIn',
+          '[2:0][3:0] unpackedArrayIn [1:0]',
+        ],
+        testCase.outputPrefix: [
+          '[7:0] scalarOut',
+          '[7:0] structureOut',
+          '[1:0][2:0][3:0] packedArrayOut',
+          '[2:0][3:0] unpackedArrayOut [1:0]',
+        ],
+        testCase.inOutPrefix: [
+          '[7:0] scalarInOut',
+          '[7:0] structureInOut',
+          '[1:0][2:0][3:0] packedArrayInOut',
+          '[2:0][3:0] unpackedArrayInOut [1:0]',
+        ],
+      };
+
+      for (final MapEntry(key: prefix, value: suffixes)
+          in declarations.entries) {
+        for (final suffix in suffixes) {
+          expect(sv, contains('$prefix $suffix'));
+        }
+      }
+    });
+  }
+}

--- a/test/typed_port_test.dart
+++ b/test/typed_port_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // typed_port_test.dart
@@ -233,8 +233,8 @@ void main() {
 
     expect(sv, isNot(contains('internal_struct')));
 
-    expect(sv, contains('input logic [1:0] myIn'));
-    expect(sv, contains('output logic [1:0] myOut'));
+    expect(sv, contains('input wire logic [1:0] myIn'));
+    expect(sv, contains('output var logic [1:0] myOut'));
 
     final vectors = [
       Vector({'a1': 0, 'a2': 1}, {'b1': 1, 'b2': 0}),
@@ -253,8 +253,8 @@ void main() {
 
     final sv = mod.generateSynth();
 
-    expect(sv, contains('input logic [3:0][1:0] anyIn'));
-    expect(sv, contains('output logic [3:0][1:0] anyOut'));
+    expect(sv, contains('input wire logic [3:0][1:0] anyIn'));
+    expect(sv, contains('output var logic [3:0][1:0] anyOut'));
     expect(sv, contains('assign anyOut = anyIn;'));
   });
 
@@ -284,13 +284,14 @@ void main() {
         sv, isNot(contains(RegExp(r'\b(?:input|output|inout)\s+.*BADNAME'))));
 
     // if name is renamed/uniquified, it won't be an exact match
-    expect(
-        sv, contains(RegExp(r'^\s*input logic inp[,\s]*$', multiLine: true)));
-    expect(
-        sv, contains(RegExp(r'^\s*output logic out1[,\s]*$', multiLine: true)));
-    expect(
-        sv, contains(RegExp(r'^\s*output logic out2[,\s]*$', multiLine: true)));
-    expect(sv, contains(RegExp(r'^\s*inout wire io[,\s]*$', multiLine: true)));
+    expect(sv,
+        contains(RegExp(r'^\s*input wire logic inp[,\s]*$', multiLine: true)));
+    expect(sv,
+        contains(RegExp(r'^\s*output var logic out1[,\s]*$', multiLine: true)));
+    expect(sv,
+        contains(RegExp(r'^\s*output var logic out2[,\s]*$', multiLine: true)));
+    expect(sv,
+        contains(RegExp(r'^\s*inout wire logic io[,\s]*$', multiLine: true)));
   });
 
   test('packed struct output inside and outside of module', () async {
@@ -361,8 +362,8 @@ void main() {
 
       expect(sv, isNot(contains('internal_struct')));
 
-      expect(sv, contains('inout wire [1:0] myIn'));
-      expect(sv, contains('inout wire [1:0] myOut'));
+      expect(sv, contains('inout wire logic [1:0] myIn'));
+      expect(sv, contains('inout wire logic [1:0] myOut'));
 
       return mod;
     }

--- a/tool/run_checks.sh
+++ b/tool/run_checks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2022-2023 Intel Corporation
+# Copyright (C) 2022-2026 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # run_checks.sh
@@ -53,7 +53,7 @@ if which iverilog; then
   echo 'Icarus Verilog found!'
 else
   declare -r exit_code=${?}
-  declare -r iverilog_recommended_version='11'
+  declare -r iverilog_recommended_version='12'
   echo 'Icarus Verilog not found: please install Icarus Verilog'\
     "(iverilog; recommended version: ${iverilog_recommended_version})!"
   exit ${exit_code}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds configurable object and data type declarations for generated SystemVerilog ports.

Generated ports now default to fully explicit declarations:

- Inputs: `input wire logic`
- Outputs: `output var logic`
- Inouts: `inout wire logic`

A new `SystemVerilogSynthesizerConfiguration` allows object and data types to be independently explicit or implicit using `SystemVerilogPortType`.

The configuration can be supplied through either `Module.generateSynth` or `SystemVerilogSynthesizer`:

```dart
final sv = module.generateSynth(
  configuration: const SystemVerilogSynthesizerConfiguration(
    portObjectType: SystemVerilogPortType.implicit,
    portDataType: SystemVerilogPortType.explicit,
  ),
);
```

The configuration passed to SystemVerilogSynthesisResult is an optional named argument with a default value, preserving compatibility with existing constructor calls.

This also updates the generation documentation, changelog, and existing SystemVerilog expectations.

## Related Issue(s)

N/A

## Testing

Added new tests and updated tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

This adds to the API for SV synth stack as a new feature, should be backwards compatible.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No, API docs updated
