### PR TITLE
Add support for preferred radix on `Const`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Added per-`Const` preferred radix control for generated literals, normalized `Const` names to reflect their displayed radix, and enhanced `LogicValue.toRadixString` to omit its width and radix decorator or digit separators (<https://github.com/intel/rohd/issues/601>).
 - Improved generated SystemVerilog to collapse contiguous partial array and range assignments into packed slice assignments when safe (<https://github.com/intel/rohd/pull/676>).
 - Added configurable explicit or implicit object and data types for generated SystemVerilog ports, defaulting to `input wire logic`, `output var logic`, and `inout wire logic` (<https://github.com/intel/rohd/pull/678>).
 - Improved `Logic.getRange` and `slice` on filled `Const`s to return direct constants instead of constructing `BusSubset` modules (<https://github.com/intel/rohd/pull/677>).

--- a/doc/user_guide/_docs/A03-constant.md
+++ b/doc/user_guide/_docs/A03-constant.md
@@ -2,7 +2,7 @@
 title: "Constants"
 permalink: /docs/constant/
 excerpt: "Constants"
-last_modified_at: 2022-12-06
+last_modified_at: 2026-07-14
 toc: true
 ---
 
@@ -10,13 +10,28 @@ Constants can often be inferred by ROHD automatically, but can also be explicitl
 
 ```dart
 // a 16 bit constant with value 5
-var x = Const(5, width:16);
+var x = Const(5, width: 16);
 ```
+
+## Preferred radix
+
+The optional `preferredRadix` controls how a `Const` is displayed in generated outputs. Supported radices are binary (2), octal (8), decimal (10), and hexadecimal (16). The radix only affects formatting, not the value of the constant.
+
+```dart
+var binary = Const(42, width: 8, preferredRadix: 2);     // 8'b101010
+var octal = Const(42, width: 8, preferredRadix: 8);      // 8'o52
+var decimal = Const(42, width: 8, preferredRadix: 10);   // 8'd42
+var hexadecimal = Const(42, width: 8, preferredRadix: 16); // 8'h2a
+```
+
+Constants containing `x` or `z` may fall back to binary so all bit states can be represented.
+
+## Binary integer conversion
 
 There is a convenience function for converting binary to an integer:
 
 ```dart
-// this is equvialent to and shorter than int.parse('010101', radix:2)
+// this is equivalent to and shorter than int.parse('010101', radix: 2)
 // you can put underscores to help with readability, they are ignored
 bin('01_0101')
 ```

--- a/lib/src/signals/const.dart
+++ b/lib/src/signals/const.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // const.dart
@@ -9,8 +9,51 @@
 
 part of 'signals.dart';
 
+/// Returns [preferredRadix] if it is supported for generated literals.
+///
+/// Throws a [LogicValueConversionException] for unsupported radices.
+int? _validatePreferredRadix(int? preferredRadix) {
+  if (preferredRadix != null &&
+      !const {2, 8, 10, 16}.contains(preferredRadix)) {
+    throw LogicValueConversionException(
+        'Unsupported preferred radix: $preferredRadix');
+  }
+
+  return preferredRadix;
+}
+
+/// Creates an identifier-friendly name for a constant [value].
+///
+/// Fully known values use [preferredRadix], or decimal if none is
+/// preferred. Values containing `x` or `z` use binary so no state is lost.
+String _constName(LogicValue value, int? preferredRadix) {
+  final radix = value.isValid ? preferredRadix ?? 10 : 2;
+  final digits = value.toRadixString(
+    radix: radix,
+    includeWidth: false,
+    sepChar: '',
+  );
+  final prefix = switch (radix) {
+    2 => '0b',
+    8 => '0o',
+    10 => '',
+    16 => '0x',
+    _ => throw StateError('Unexpected radix: $radix'),
+  };
+
+  return 'const_$prefix$digits';
+}
+
 /// Represents a [Logic] that never changes value.
 class Const extends Logic {
+  /// The preferred radix for displaying this constant in generated outputs.
+  ///
+  /// Supported radices are binary (2), octal (8), decimal (10), and
+  /// hexadecimal (16). If omitted, generated outputs select a radix
+  /// automatically. A generator may fall back to another radix when the
+  /// preferred radix cannot represent this constant's value.
+  final int? preferredRadix;
+
   /// Constructs a [Const] with the specified value.
   ///
   /// [val] should be processable by [LogicValue.of].
@@ -18,18 +61,39 @@ class Const extends Logic {
   /// If a [width] is provided, the [Const] will be that width.  If not, and
   /// [val] is a [LogicValue], the [Const] will be the width of [val].
   /// Otherwise, the [Const] will be 1 bit wide.
-  Const(dynamic val, {int? width, bool fill = false})
+  ///
+  /// [preferredRadix] controls how the constant is displayed in generated
+  /// outputs and its normalized name. Supported values are 2, 8, 10, and 16.
+  /// If omitted, generated outputs select a radix automatically and the name
+  /// uses decimal. Values containing `x` or `z` may fall back to binary.
+  Const(
+    dynamic val, {
+    int? width,
+    bool fill = false,
+    int? preferredRadix,
+  }) : this._(
+          LogicValue.of(
+            val,
+            width: width ?? (val is LogicValue ? val.width : 1),
+            fill: fill,
+          ),
+          preferredRadix: _validatePreferredRadix(preferredRadix),
+        );
+
+  /// Constructs a [Const] from an already normalized [value].
+  Const._(LogicValue value, {required this.preferredRadix})
       : super(
-          name: 'const_$val',
-          width: width ?? (val is LogicValue ? val.width : 1),
+          name: _constName(value, preferredRadix),
+          width: value.width,
           // we don't care about maintaining this node unless necessary
           naming: Naming.unnamed,
         ) {
-    _wire.put(val, fill: fill, signalName: name);
+    _wire.put(value, signalName: name);
 
     makeUnassignable(reason: '`Const` signals are unassignable.');
   }
 
   @override
-  Const clone({String? name}) => Const(value, width: width);
+  Const clone({String? name}) =>
+      Const(value, width: width, preferredRadix: preferredRadix);
 }

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -588,7 +588,10 @@ class SynthModuleDefinition {
         // as completely undriven).
 
         // make a new const node, it will merge away if not needed
-        final newReceiverConst = getSynthLogic(Const(receiver.value))!;
+        final newReceiverConst = getSynthLogic(Const(
+          receiver.value,
+          preferredRadix: receiver.preferredRadix,
+        ))!;
         internalSignals.add(newReceiverConst);
         assignments.add(SynthAssignment(newReceiverConst, synthReceiver));
       }

--- a/lib/src/utilities/namer.dart
+++ b/lib/src/utilities/namer.dart
@@ -165,6 +165,12 @@ class Namer {
     bool constNameDisallowed = false,
   }) {
     if (constValue != null && !constNameDisallowed) {
+      final preferredRadix = constValue.preferredRadix;
+      if (preferredRadix != null && constValue.value.isValid) {
+        return constValue.value
+            .toRadixString(radix: preferredRadix, sepChar: '');
+      }
+
       return constValue.value.toString();
     }
 

--- a/lib/src/values/logic_value.dart
+++ b/lib/src/values/logic_value.dart
@@ -607,12 +607,16 @@ abstract class LogicValue implements Comparable<LogicValue> {
   static String _reverse(String inString) =>
       String.fromCharCodes(inString.runes.toList().reversed);
 
-  /// Return the radix encoding of the current [LogicValue] as a sequence
-  /// of radix characters prefixed by the length and encoding format.
-  /// Output format is: `<len>'<format><encoded-value>`.
+  /// Return the radix encoding of the current [LogicValue] as a sequence of
+  /// radix characters. By default, the output is prefixed by the length and
+  /// encoding format: `<len>'<format><encoded-value>`.
   ///
-  /// [ofRadixString] can parse a [String] produced by [toRadixString] and
-  /// construct a [LogicValue].
+  /// If [includeWidth] is `false`, the length and encoding format are omitted.
+  /// The resulting string is not self-describing and cannot be parsed by
+  /// [ofRadixString] without restoring that information.
+  ///
+  /// [ofRadixString] can parse a decorated [String] produced by
+  /// [toRadixString] and construct a [LogicValue].
   ///
   /// Here is the number 1492 printed as a radix string:
   /// - Binary: `15'b101_1101_0100`
@@ -624,7 +628,8 @@ abstract class LogicValue implements Comparable<LogicValue> {
   /// Separators are output according to [chunkSize] starting from the
   /// LSB(right), default is 4 characters.  The default separator is '_'.
   /// [sepChar] can be set to another character, but not in [radixStringChars],
-  /// otherwise it will throw an exception.
+  /// or to an empty string to disable separators. Otherwise, it will throw an
+  /// exception.
   ///  - [chunkSize] = default: `61'h2_9ebc_5f06_5bf7`
   ///  - [chunkSize] = 10: `61'h29e_bc5f065bf7`
   ///
@@ -650,8 +655,9 @@ abstract class LogicValue implements Comparable<LogicValue> {
       {int radix = 2,
       int chunkSize = 4,
       bool leadingZeros = false,
+      bool includeWidth = true,
       String sepChar = '_'}) {
-    if (radixStringChars.contains(sepChar)) {
+    if (sepChar.isNotEmpty && radixStringChars.contains(sepChar)) {
       throw LogicValueConversionException('separation character invalid');
     }
     final radixStr = switch (radix) {
@@ -730,7 +736,7 @@ abstract class LogicValue implements Comparable<LogicValue> {
             ? spaceString.substring(1, spaceString.length)
             : spaceString
         : '0';
-    return '$width$radixStr$fullString';
+    return '${includeWidth ? '$width$radixStr' : ''}$fullString';
   }
 
   /// Create a [LogicValue] from a length/radix-encoded string of the

--- a/test/const_radix_test.dart
+++ b/test/const_radix_test.dart
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// const_radix_test.dart
+// Tests for preferred radix formatting of constants.
+//
+// 2026 July 14
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:test/test.dart';
+
+/// Exposes constants in each supported radix through generated outputs.
+class _ConstRadixModule extends Module {
+  _ConstRadixModule() : super(name: 'constRadix') {
+    addOutput('autoHex', width: 8) <= Const(42, width: 8);
+    addOutput('binaryValue', width: 8) <=
+        Const(42, width: 8, preferredRadix: 2);
+    addOutput('octalValue', width: 8) <= Const(42, width: 8, preferredRadix: 8);
+    addOutput('decimalValue', width: 8) <=
+        Const(42, width: 8, preferredRadix: 10);
+    addOutput('hexValue', width: 8) <= Const(42, width: 8, preferredRadix: 16);
+    addOutput('invalidValue', width: 4) <=
+        Const(
+          LogicValue.ofString('10xz'),
+          preferredRadix: 16,
+        );
+  }
+}
+
+/// Requires its input connection to be a signal rather than an expression.
+class _ExpressionlessRadixSub extends Module with SystemVerilog {
+  @override
+  List<String> get expressionlessInputs => const ['in'];
+
+  _ExpressionlessRadixSub(Logic input) : super(name: 'expressionlessRadix') {
+    input = addInput('in', input, width: input.width);
+    addOutput('out', width: input.width) <= input;
+  }
+}
+
+/// Drives an expressionless submodule input with a radix-preferred constant.
+class _ExpressionlessRadixTop extends Module {
+  _ExpressionlessRadixTop() : super(name: 'expressionlessRadixTop') {
+    final sub = _ExpressionlessRadixSub(
+      Const(42, width: 8, preferredRadix: 10),
+    );
+    addOutput('out', width: 8) <= sub.output('out');
+  }
+}
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  group('Const preferred radix', () {
+    test('normalizes names using the displayed radix', () {
+      expect(Const(42, width: 8).name, 'const_42');
+      expect(
+        Const(42, width: 8, preferredRadix: 2).name,
+        'const_0b101010',
+      );
+      expect(
+        Const(42, width: 8, preferredRadix: 8).name,
+        'const_0o52',
+      );
+      expect(
+        Const(42, width: 8, preferredRadix: 10).name,
+        'const_42',
+      );
+      expect(
+        Const(42, width: 8, preferredRadix: 16).name,
+        'const_0x2a',
+      );
+    });
+
+    test('derives names from the normalized stored value', () {
+      expect(
+        Const(-1, width: 8, preferredRadix: 16).name,
+        'const_0xff',
+      );
+      expect(
+        Const(BigInt.from(42), width: 8, preferredRadix: 8).name,
+        'const_0o52',
+      );
+      expect(
+        Const(
+          LogicValue.ofInt(42, 8),
+          preferredRadix: 10,
+        ).name,
+        'const_42',
+      );
+      expect(
+        Const(1, width: 8, fill: true, preferredRadix: 16).name,
+        'const_0xff',
+      );
+      expect(
+        Const(
+          LogicValue.ofString('10xz'),
+          preferredRadix: 16,
+        ).name,
+        'const_0b10xz',
+      );
+    });
+
+    test('rejects unsupported radices', () {
+      for (final radix in [3, 4, 12]) {
+        expect(
+          () => Const(1, preferredRadix: radix),
+          throwsA(isA<LogicValueConversionException>()),
+        );
+      }
+    });
+
+    test('clone preserves the preference and normalized name', () {
+      final original = Const(42, width: 8, preferredRadix: 2);
+      final clone = original.clone();
+
+      expect(clone.preferredRadix, 2);
+      expect(clone.name, original.name);
+      expect(clone.value, original.value);
+    });
+
+    test('toString remains a Logic diagnostic', () {
+      expect(
+        Const(42, width: 8, preferredRadix: 10).toString(),
+        'Logic(8): const_42',
+      );
+    });
+
+    test('normalized names compose into expression names', () {
+      final result =
+          Logic(name: 'a', width: 8) + Const(42, width: 8, preferredRadix: 16);
+
+      expect(result.name, contains('const_0x2a'));
+    });
+
+    test('controls generated SystemVerilog literals', () async {
+      final module = _ConstRadixModule();
+      await module.build();
+
+      final systemVerilog = module.generateSynth();
+
+      expect(systemVerilog, contains("assign autoHex = 8'h2a;"));
+      expect(systemVerilog, contains("assign binaryValue = 8'b101010;"));
+      expect(systemVerilog, contains("assign octalValue = 8'o52;"));
+      expect(systemVerilog, contains("assign decimalValue = 8'd42;"));
+      expect(systemVerilog, contains("assign hexValue = 8'h2a;"));
+      expect(systemVerilog, contains("assign invalidValue = 4'b10xz;"));
+    });
+
+    test('preserves the preference for expressionless inputs', () async {
+      final module = _ExpressionlessRadixTop();
+      await module.build();
+
+      final systemVerilog = module.generateSynth();
+
+      expect(systemVerilog, contains("assign in = 8'd42;"));
+      expect(systemVerilog, contains('.in(in)'));
+      expect(systemVerilog, isNot(contains(".in(8'd42)")));
+    });
+  });
+}

--- a/test/logic_value_test.dart
+++ b/test/logic_value_test.dart
@@ -2088,6 +2088,8 @@ void main() {
     test('radixString binary expansion', () {
       final lv = LogicValue.ofRadixString("12'b10z111011z00");
       expect(lv.toRadixString(radix: 16), equals("12'h<10z1>d<1z00>"));
+      expect(lv.toRadixString(radix: 16, includeWidth: false),
+          equals('<10z1>d<1z00>'));
       for (final i in [2, 4, 8, 16]) {
         expect(
             LogicValue.ofRadixString(lv.toRadixString(radix: i)), equals(lv));
@@ -2097,13 +2099,20 @@ void main() {
     test('radixString leading zero', () {
       final lv = LogicValue.ofRadixString("10'b00_0010_0111");
       expect(lv.toRadixString(), equals("10'b10_0111"));
+      expect(lv.toRadixString(sepChar: ''), equals("10'b100111"));
+      expect(
+          lv.toRadixString(includeWidth: false, sepChar: ''), equals('100111'));
       expect(lv.toRadixString(leadingZeros: true), equals("10'b00_0010_0111"));
       expect(lv.toRadixString(radix: 4), equals("10'q213"));
+      expect(lv.toRadixString(radix: 4, includeWidth: false), equals('213'));
       expect(lv.toRadixString(radix: 8), equals("10'o47"));
+      expect(lv.toRadixString(radix: 8, includeWidth: false), equals('47'));
       expect(lv.toRadixString(radix: 10), equals("10'd39"));
+      expect(lv.toRadixString(radix: 10, includeWidth: false), equals('39'));
       expect(
           lv.toRadixString(radix: 10, leadingZeros: true), equals("10'd0039"));
       expect(lv.toRadixString(radix: 16), equals("10'h27"));
+      expect(lv.toRadixString(radix: 16, includeWidth: false), equals('27'));
       expect(
           lv.toRadixString(radix: 16, leadingZeros: true), equals("10'h027"));
       for (final i in [2, 4, 8, 10, 16]) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds support for a `preferredRadix` on `Const`

## Related Issue(s)

Fix #601 

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, included
