### PR TITLE
Prevent stack overflow when synthesizing combinational loops

### DIFF
--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -836,9 +836,13 @@ class SynthModuleDefinition {
       activeIndices[candidate] = activePath.length;
       activePath.add(candidate);
 
-      for (final input in [
+      final resultSignalName =
+          (candidate.module as InlineSystemVerilog).resultSignalName;
+      for (final input in <SynthLogic>[
         ...candidate.inputMapping.values,
-        ...candidate.inOutMapping.values,
+        ...candidate.inOutMapping.entries
+            .where((entry) => entry.key != resultSignalName)
+            .map((entry) => entry.value),
       ]) {
         final dependency = candidateByResult[input.resolved];
         if (dependency == null) {

--- a/lib/src/synthesizers/utilities/synth_module_definition.dart
+++ b/lib/src/synthesizers/utilities/synth_module_definition.dart
@@ -810,13 +810,61 @@ class SynthModuleDefinition {
       }
     }
 
-    return inlineableSubmoduleInstantiations.where((subModuleInstantiation) {
-      final resultSynthLogic = _inlineResultLogic(subModuleInstantiation);
+    final collapseCandidates = inlineableSubmoduleInstantiations.where(
+      (subModuleInstantiation) {
+        final resultSynthLogic = _inlineResultLogic(subModuleInstantiation);
 
-      return resultSynthLogic != null &&
-          singleUseSignals.contains(resultSynthLogic) &&
-          subModuleInstantiation.needsInstantiation;
-    });
+        return resultSynthLogic != null &&
+            singleUseSignals.contains(resultSynthLogic) &&
+            subModuleInstantiation.needsInstantiation;
+      },
+    ).toList();
+
+    // Keep every module in an inline dependency cycle materialized so that
+    // rendering expressions cannot recurse through the cycle indefinitely.
+    final candidateByResult = <SynthLogic, SynthSubModuleInstantiation>{
+      for (final candidate in collapseCandidates)
+        _inlineResultLogic(candidate)!.resolved: candidate,
+    };
+    final visited = <SynthSubModuleInstantiation>{};
+    final activeIndices = <SynthSubModuleInstantiation, int>{};
+    final activePath = <SynthSubModuleInstantiation>[];
+    final cyclicCandidates = <SynthSubModuleInstantiation>{};
+
+    void findCycles(SynthSubModuleInstantiation candidate) {
+      visited.add(candidate);
+      activeIndices[candidate] = activePath.length;
+      activePath.add(candidate);
+
+      for (final input in [
+        ...candidate.inputMapping.values,
+        ...candidate.inOutMapping.values,
+      ]) {
+        final dependency = candidateByResult[input.resolved];
+        if (dependency == null) {
+          continue;
+        }
+
+        final cycleStart = activeIndices[dependency];
+        if (cycleStart != null) {
+          cyclicCandidates.addAll(activePath.skip(cycleStart));
+        } else if (!visited.contains(dependency)) {
+          findCycles(dependency);
+        }
+      }
+
+      activePath.removeLast();
+      activeIndices.remove(candidate);
+    }
+
+    for (final candidate in collapseCandidates) {
+      if (!visited.contains(candidate)) {
+        findCycles(candidate);
+      }
+    }
+
+    return collapseCandidates
+        .where((candidate) => !cyclicCandidates.contains(candidate));
   }
 
   SynthLogic? _inlineResultLogic(SynthSubModuleInstantiation instantiation) {

--- a/test/collapse_test.dart
+++ b/test/collapse_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // collapse_test.dart
@@ -38,6 +38,15 @@ class CollapseTestModule extends Module {
   }
 }
 
+class CombinationalLoopCollapseModule extends Module {
+  CombinationalLoopCollapseModule(Logic a) {
+    a = addInput('a', a);
+    final loop = Logic();
+    loop <= loop | a;
+    addOutput('out') <= loop.eq(a);
+  }
+}
+
 void main() {
   tearDown(() async {
     await Simulator.reset();
@@ -63,5 +72,14 @@ void main() {
     expect(sv, contains(RegExp('e.*=.*a.*&.*b.*&.*c')));
 
     expect(sv, contains(RegExp('internal.*=.*~z')));
+  });
+
+  test('combinational loop does not recurse while collapsing', () async {
+    final mod = CombinationalLoopCollapseModule(Logic());
+    await mod.build();
+
+    final sv = mod.generateSynth();
+    expect(sv, contains(' | a'));
+    expect(sv, contains(' == a'));
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Detect dependency cycles among inlineable SystemVerilog submodules.
- Keep cyclic modules materialized instead of recursively expanding them.
- Preserve combinational loops in generated SystemVerilog without changing circuit behavior.

## Related Issue(s)

Fixes #641 

## Testing

- Add a non-constant regression test that reproduces the original stack overflow.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

N/A
