### PR TITLE
Restore SystemVerilog port defaults and add per-direction type configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next release
 
 - Improved generated SystemVerilog to collapse contiguous partial array and range assignments into packed slice assignments when safe (<https://github.com/intel/rohd/pull/676>).
-- Added configurable explicit or implicit object and data types for generated SystemVerilog ports, defaulting to `input wire logic`, `output var logic`, and `inout wire logic` (<https://github.com/intel/rohd/pull/678>).
+- Added per-direction configuration of explicit or implicit object and data types for generated SystemVerilog ports. Defaults preserve the existing `input logic`, `output logic`, and `inout wire` declarations (<https://github.com/intel/rohd/pull/678>).
 - Improved `Logic.getRange` and `slice` on filled `Const`s to return direct constants instead of constructing `BusSubset` modules (<https://github.com/intel/rohd/pull/677>).
 - Improved generated SystemVerilog for swizzles to compact adjacent bit selections into legal slice expressions (<https://github.com/intel/rohd/pull/674>).
 - Improved generated SystemVerilog to collapse a variety of intermediate `LogicArray`s and net buses (e.g. from bit-blasting, aggregate connections, `assignSubset`) into inline concatenations on their consuming connections, eliminating unnecessary intermediate declarations, `assign`s, and `net_connect`s when it is safe to do so (<https://github.com/intel/rohd/pull/663>).

--- a/doc/user_guide/_docs/A21-generation.md
+++ b/doc/user_guide/_docs/A21-generation.md
@@ -30,13 +30,23 @@ The `generateSynth` function will return a `String` with the SystemVerilog `modu
 
 ## Controlling port types
 
-Generated ports have explicit object and data types by default: inputs are `input wire logic`, outputs are `output var logic`, and inouts are `inout wire logic`. Use a `SystemVerilogSynthesizerConfiguration` to omit either category and rely on SystemVerilog's implicit types:
+Generated ports default to `input logic`, `output logic`, and `inout wire`, preserving the traditional ROHD declarations. Use a `SystemVerilogSynthesizerConfiguration` to independently control whether object types, such as `wire` and `var`, and data types, such as `logic`, are explicit for each port direction:
 
 ```dart
 final generatedSv = myModule.generateSynth(
   configuration: const SystemVerilogSynthesizerConfiguration(
-    portObjectType: SystemVerilogPortType.implicit,
-    portDataType: SystemVerilogPortType.implicit,
+    inputPortType: SystemVerilogPortTypeConfiguration(
+      objectType: SystemVerilogPortType.explicit,
+      dataType: SystemVerilogPortType.implicit,
+    ),
+    outputPortType: SystemVerilogPortTypeConfiguration(
+      objectType: SystemVerilogPortType.implicit,
+      dataType: SystemVerilogPortType.implicit,
+    ),
+    inOutPortType: SystemVerilogPortTypeConfiguration(
+      objectType: SystemVerilogPortType.implicit,
+      dataType: SystemVerilogPortType.explicit,
+    ),
   ),
 );
 ```

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesis_result.dart
@@ -117,7 +117,7 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
   Iterable<String> _verilogInputs() => _synthModuleDefinition.inputs.map((sig) {
         assert(module.tryInput(sig.name) != null,
             'Named input ${sig.name} not found in module ${module.name}.');
-        return _verilogPort('input', 'wire', sig);
+        return _verilogPort('input', 'wire', configuration.inputPortType, sig);
       });
 
   /// Representation of all output port declarations in generated SV.
@@ -125,23 +125,23 @@ class SystemVerilogSynthesisResult extends SynthesisResult {
       _synthModuleDefinition.outputs.map((sig) {
         assert(module.tryOutput(sig.name) != null,
             'Named output ${sig.name} not found in module ${module.name}.');
-        return _verilogPort('output', 'var', sig);
+        return _verilogPort('output', 'var', configuration.outputPortType, sig);
       });
 
   /// Representation of all inout port declarations in generated SV.
   Iterable<String> _verilogInOuts() => _synthModuleDefinition.inOuts.map((sig) {
         assert(module.tryInOut(sig.name) != null,
             'Named inOut ${sig.name} not found in module ${module.name}.');
-        return _verilogPort('inout', 'wire', sig);
+        return _verilogPort('inout', 'wire', configuration.inOutPortType, sig);
       });
 
   /// Representation of a port declaration in generated SV.
-  String _verilogPort(String direction, String objectType, SynthLogic sig) => [
+  String _verilogPort(String direction, String objectType,
+          SystemVerilogPortTypeConfiguration portType, SynthLogic sig) =>
+      [
         direction,
-        if (configuration.portObjectType == SystemVerilogPortType.explicit)
-          objectType,
-        if (configuration.portDataType == SystemVerilogPortType.explicit)
-          'logic',
+        if (portType.objectType == SystemVerilogPortType.explicit) objectType,
+        if (portType.dataType == SystemVerilogPortType.explicit) 'logic',
         sig.definitionName(),
       ].join(' ');
 

--- a/lib/src/synthesizers/systemverilog/systemverilog_synthesizer_configuration.dart
+++ b/lib/src/synthesizers/systemverilog/systemverilog_synthesizer_configuration.dart
@@ -16,17 +16,43 @@ enum SystemVerilogPortType {
   implicit,
 }
 
+/// Configuration for types in a SystemVerilog port declaration.
+class SystemVerilogPortTypeConfiguration {
+  /// Whether the object type, such as `wire` or `var`, is explicit.
+  final SystemVerilogPortType objectType;
+
+  /// Whether the data type, such as `logic`, is explicit.
+  final SystemVerilogPortType dataType;
+
+  /// Creates a new configuration for types in a SystemVerilog port
+  /// declaration.
+  const SystemVerilogPortTypeConfiguration({
+    this.objectType = SystemVerilogPortType.explicit,
+    this.dataType = SystemVerilogPortType.explicit,
+  });
+}
+
 /// Configuration for SystemVerilog synthesis.
 class SystemVerilogSynthesizerConfiguration {
-  /// Whether port object types, such as `wire` and `var`, are explicit.
-  final SystemVerilogPortType portObjectType;
+  /// Type configuration for input ports.
+  final SystemVerilogPortTypeConfiguration inputPortType;
 
-  /// Whether port data types, such as `logic`, are explicit.
-  final SystemVerilogPortType portDataType;
+  /// Type configuration for output ports.
+  final SystemVerilogPortTypeConfiguration outputPortType;
+
+  /// Type configuration for inout ports.
+  final SystemVerilogPortTypeConfiguration inOutPortType;
 
   /// Creates a new configuration for SystemVerilog synthesis.
   const SystemVerilogSynthesizerConfiguration({
-    this.portObjectType = SystemVerilogPortType.explicit,
-    this.portDataType = SystemVerilogPortType.explicit,
+    this.inputPortType = const SystemVerilogPortTypeConfiguration(
+      objectType: SystemVerilogPortType.implicit,
+    ),
+    this.outputPortType = const SystemVerilogPortTypeConfiguration(
+      objectType: SystemVerilogPortType.implicit,
+    ),
+    this.inOutPortType = const SystemVerilogPortTypeConfiguration(
+      dataType: SystemVerilogPortType.implicit,
+    ),
   });
 }

--- a/test/logic_array_test.dart
+++ b/test/logic_array_test.dart
@@ -847,8 +847,8 @@ void main() {
 
         // ensure ports with interface are still an array
         final sv = mod.generateSynth();
-        expect(sv, contains('input wire logic [2:0][1:0][2:0][7:0] laIn'));
-        expect(sv, contains('output var logic [2:0][1:0][2:0][7:0] laOut'));
+        expect(sv, contains('input logic [2:0][1:0][2:0][7:0] laIn'));
+        expect(sv, contains('output logic [2:0][1:0][2:0][7:0] laOut'));
       });
 
       test('3 dimensions with interface and unpacked', () async {
@@ -862,8 +862,8 @@ void main() {
 
         // ensure ports with interface are still an array
         final sv = mod.generateSynth();
-        expect(sv, contains('input wire logic [1:0][2:0][7:0] laIn [2:0]'));
-        expect(sv, contains('output var logic [1:0][2:0][7:0] laOut [2:0]'));
+        expect(sv, contains('input logic [1:0][2:0][7:0] laIn [2:0]'));
+        expect(sv, contains('output logic [1:0][2:0][7:0] laOut [2:0]'));
       });
     });
 

--- a/test/naming_cases_test.dart
+++ b/test/naming_cases_test.dart
@@ -557,8 +557,8 @@ void main() {
       final sv = mod.generateSynth();
 
       // Port declarations.
-      expect(sv, contains('input wire logic [7:0] inp'));
-      expect(sv, contains('output var logic [7:0] out'));
+      expect(sv, contains('input logic [7:0] inp'));
+      expect(sv, contains('output logic [7:0] out'));
       expect(sv, contains('_uinp'));
       expect(sv, contains('mport'));
       expect(sv, contains('_muprt'));

--- a/test/pair_interface_hier_test.dart
+++ b/test/pair_interface_hier_test.dart
@@ -95,7 +95,7 @@ void main() {
 
     expect(sv, contains('HierConsumer  unnamed_module'));
     expect(sv, contains('HierProducer  unnamed_module'));
-    expect(sv, contains('inout wire logic io_0'));
-    expect(sv, contains('inout wire logic [2:0] io_arr_0'));
+    expect(sv, contains('inout wire io_0'));
+    expect(sv, contains('inout wire [2:0] io_arr_0'));
   });
 }

--- a/test/pair_interface_hier_w_modify_test.dart
+++ b/test/pair_interface_hier_w_modify_test.dart
@@ -97,7 +97,7 @@ void main() {
 
     expect(sv, contains('HierConsumer  unnamed_module'));
     expect(sv, contains('HierProducer  unnamed_module'));
-    expect(sv, contains('inout wire logic io_0'));
-    expect(sv, contains('inout wire logic [2:0] io_arr_0'));
+    expect(sv, contains('inout wire io_0'));
+    expect(sv, contains('inout wire [2:0] io_arr_0'));
   });
 }

--- a/test/pair_interface_test.dart
+++ b/test/pair_interface_test.dart
@@ -193,7 +193,7 @@ void main() {
 
     // Make sure the "modify" went through:
     final sv = mod.generateSynth();
-    expect(sv, contains('input wire logic simple_clk'));
+    expect(sv, contains('input logic simple_clk'));
   });
 
   group('drive and receive other', () {

--- a/test/provider_consumer_test.dart
+++ b/test/provider_consumer_test.dart
@@ -178,37 +178,41 @@ void main() {
 
     final sv = mod.generateSynth();
 
-    expect(sv, contains('''
-module Provider (
-input wire logic clk,
-input wire logic reset,
-input wire logic wd0_ready_req,
-input wire logic wd1_ready_req,
-input wire logic [31:0] rd_data_rsp,
-input wire logic rd_valid_rsp,
-output var logic [31:0] wd0_data_req,
-output var logic wd0_valid_req,
-output var logic [31:0] wd1_data_req,
-output var logic wd1_valid_req,
-output var logic rd_ready_rsp
-);
-'''));
+    expect(
+        sv,
+        contains([
+          'module Provider (',
+          'input logic clk,',
+          'input logic reset,',
+          'input logic wd0_ready_req,',
+          'input logic wd1_ready_req,',
+          'input logic [31:0] rd_data_rsp,',
+          'input logic rd_valid_rsp,',
+          'output logic [31:0] wd0_data_req,',
+          'output logic wd0_valid_req,',
+          'output logic [31:0] wd1_data_req,',
+          'output logic wd1_valid_req,',
+          'output logic rd_ready_rsp',
+          ');',
+        ].join('\n')));
 
-    expect(sv, contains('''
-module Consumer (
-input wire logic clk,
-input wire logic reset,
-input wire logic [31:0] wd0_data_req,
-input wire logic wd0_valid_req,
-input wire logic [31:0] wd1_data_req,
-input wire logic wd1_valid_req,
-input wire logic rd_ready_rsp,
-output var logic wd0_ready_req,
-output var logic wd1_ready_req,
-output var logic [31:0] rd_data_rsp,
-output var logic rd_valid_rsp
-);
-'''));
+    expect(
+        sv,
+        contains([
+          'module Consumer (',
+          'input logic clk,',
+          'input logic reset,',
+          'input logic [31:0] wd0_data_req,',
+          'input logic wd0_valid_req,',
+          'input logic [31:0] wd1_data_req,',
+          'input logic wd1_valid_req,',
+          'input logic rd_ready_rsp,',
+          'output logic wd0_ready_req,',
+          'output logic wd1_ready_req,',
+          'output logic [31:0] rd_data_rsp,',
+          'output logic rd_valid_rsp',
+          ');',
+        ].join('\n')));
 
     await SimCompare.checkFunctionalVector(mod, vectors);
     SimCompare.checkIverilogVector(mod, vectors);

--- a/test/provider_consumer_w_modify_test.dart
+++ b/test/provider_consumer_w_modify_test.dart
@@ -148,37 +148,41 @@ void main() {
 
     final sv = mod.generateSynth();
 
-    expect(sv, contains('''
-module Provider (
-input wire logic clk,
-input wire logic reset,
-input wire logic wd0_ready_req,
-input wire logic wd1_ready_req,
-input wire logic [31:0] rd_data_rsp,
-input wire logic rd_valid_rsp,
-output var logic [31:0] wd0_data_req,
-output var logic wd0_valid_req,
-output var logic [31:0] wd1_data_req,
-output var logic wd1_valid_req,
-output var logic rd_ready_rsp
-);
-'''));
+    expect(
+        sv,
+        contains([
+          'module Provider (',
+          'input logic clk,',
+          'input logic reset,',
+          'input logic wd0_ready_req,',
+          'input logic wd1_ready_req,',
+          'input logic [31:0] rd_data_rsp,',
+          'input logic rd_valid_rsp,',
+          'output logic [31:0] wd0_data_req,',
+          'output logic wd0_valid_req,',
+          'output logic [31:0] wd1_data_req,',
+          'output logic wd1_valid_req,',
+          'output logic rd_ready_rsp',
+          ');',
+        ].join('\n')));
 
-    expect(sv, contains('''
-module Consumer (
-input wire logic clk,
-input wire logic reset,
-input wire logic [31:0] wd0_data_req,
-input wire logic wd0_valid_req,
-input wire logic [31:0] wd1_data_req,
-input wire logic wd1_valid_req,
-input wire logic rd_ready_rsp,
-output var logic wd0_ready_req,
-output var logic wd1_ready_req,
-output var logic [31:0] rd_data_rsp,
-output var logic rd_valid_rsp
-);
-'''));
+    expect(
+        sv,
+        contains([
+          'module Consumer (',
+          'input logic clk,',
+          'input logic reset,',
+          'input logic [31:0] wd0_data_req,',
+          'input logic wd0_valid_req,',
+          'input logic [31:0] wd1_data_req,',
+          'input logic wd1_valid_req,',
+          'input logic rd_ready_rsp,',
+          'output logic wd0_ready_req,',
+          'output logic wd1_ready_req,',
+          'output logic [31:0] rd_data_rsp,',
+          'output logic rd_valid_rsp',
+          ');',
+        ].join('\n')));
 
     await SimCompare.checkFunctionalVector(mod, vectors);
     SimCompare.checkIverilogVector(mod, vectors);

--- a/test/sv_gen_test.dart
+++ b/test/sv_gen_test.dart
@@ -885,13 +885,16 @@ void main() {
     expect(sv, isNot(contains('replicate')));
     expect(sv, isNot(contains('subset')));
 
-    expect(sv, contains('''
-module ModWithUselessWireMods (
-input wire logic [7:0] a,
-input wire logic [7:0] b
-);
-
-endmodule : ModWithUselessWireMods'''));
+    expect(
+        sv,
+        contains([
+          'module ModWithUselessWireMods (',
+          'input logic [7:0] a,',
+          'input logic [7:0] b',
+          ');',
+          '',
+          'endmodule : ModWithUselessWireMods',
+        ].join('\n')));
   });
 
   test('partial array assignment sv', () async {

--- a/test/systemverilog_port_types_test.dart
+++ b/test/systemverilog_port_types_test.dart
@@ -63,39 +63,60 @@ void main() {
 
   final testCases = [
     (
-      name: 'explicit object and data types by default',
+      name: 'historical port types by default',
       configuration: const SystemVerilogSynthesizerConfiguration(),
+      inputPrefix: 'input logic',
+      outputPrefix: 'output logic',
+      inOutPrefix: 'inout wire',
+    ),
+    (
+      name: 'explicit object and data types',
+      configuration: const SystemVerilogSynthesizerConfiguration(
+        inputPortType: SystemVerilogPortTypeConfiguration(),
+        outputPortType: SystemVerilogPortTypeConfiguration(),
+        inOutPortType: SystemVerilogPortTypeConfiguration(),
+      ),
       inputPrefix: 'input wire logic',
       outputPrefix: 'output var logic',
       inOutPrefix: 'inout wire logic',
     ),
     (
-      name: 'implicit object and explicit data types',
-      configuration: const SystemVerilogSynthesizerConfiguration(
-        portObjectType: SystemVerilogPortType.implicit,
-      ),
-      inputPrefix: 'input logic',
-      outputPrefix: 'output logic',
-      inOutPrefix: 'inout logic',
-    ),
-    (
-      name: 'explicit object and implicit data types',
-      configuration: const SystemVerilogSynthesizerConfiguration(
-        portDataType: SystemVerilogPortType.implicit,
-      ),
-      inputPrefix: 'input wire',
-      outputPrefix: 'output var',
-      inOutPrefix: 'inout wire',
-    ),
-    (
       name: 'implicit object and data types',
       configuration: const SystemVerilogSynthesizerConfiguration(
-        portObjectType: SystemVerilogPortType.implicit,
-        portDataType: SystemVerilogPortType.implicit,
+        inputPortType: SystemVerilogPortTypeConfiguration(
+          objectType: SystemVerilogPortType.implicit,
+          dataType: SystemVerilogPortType.implicit,
+        ),
+        outputPortType: SystemVerilogPortTypeConfiguration(
+          objectType: SystemVerilogPortType.implicit,
+          dataType: SystemVerilogPortType.implicit,
+        ),
+        inOutPortType: SystemVerilogPortTypeConfiguration(
+          objectType: SystemVerilogPortType.implicit,
+          dataType: SystemVerilogPortType.implicit,
+        ),
       ),
       inputPrefix: 'input',
       outputPrefix: 'output',
       inOutPrefix: 'inout',
+    ),
+    (
+      name: 'independently configured port directions',
+      configuration: const SystemVerilogSynthesizerConfiguration(
+        inputPortType: SystemVerilogPortTypeConfiguration(
+          dataType: SystemVerilogPortType.implicit,
+        ),
+        outputPortType: SystemVerilogPortTypeConfiguration(
+          objectType: SystemVerilogPortType.implicit,
+          dataType: SystemVerilogPortType.implicit,
+        ),
+        inOutPortType: SystemVerilogPortTypeConfiguration(
+          objectType: SystemVerilogPortType.implicit,
+        ),
+      ),
+      inputPrefix: 'input wire',
+      outputPrefix: 'output',
+      inOutPrefix: 'inout logic',
     ),
   ];
 

--- a/test/typed_port_test.dart
+++ b/test/typed_port_test.dart
@@ -233,8 +233,8 @@ void main() {
 
     expect(sv, isNot(contains('internal_struct')));
 
-    expect(sv, contains('input wire logic [1:0] myIn'));
-    expect(sv, contains('output var logic [1:0] myOut'));
+    expect(sv, contains('input logic [1:0] myIn'));
+    expect(sv, contains('output logic [1:0] myOut'));
 
     final vectors = [
       Vector({'a1': 0, 'a2': 1}, {'b1': 1, 'b2': 0}),
@@ -253,8 +253,8 @@ void main() {
 
     final sv = mod.generateSynth();
 
-    expect(sv, contains('input wire logic [3:0][1:0] anyIn'));
-    expect(sv, contains('output var logic [3:0][1:0] anyOut'));
+    expect(sv, contains('input logic [3:0][1:0] anyIn'));
+    expect(sv, contains('output logic [3:0][1:0] anyOut'));
     expect(sv, contains('assign anyOut = anyIn;'));
   });
 
@@ -284,14 +284,13 @@ void main() {
         sv, isNot(contains(RegExp(r'\b(?:input|output|inout)\s+.*BADNAME'))));
 
     // if name is renamed/uniquified, it won't be an exact match
-    expect(sv,
-        contains(RegExp(r'^\s*input wire logic inp[,\s]*$', multiLine: true)));
-    expect(sv,
-        contains(RegExp(r'^\s*output var logic out1[,\s]*$', multiLine: true)));
-    expect(sv,
-        contains(RegExp(r'^\s*output var logic out2[,\s]*$', multiLine: true)));
-    expect(sv,
-        contains(RegExp(r'^\s*inout wire logic io[,\s]*$', multiLine: true)));
+    expect(
+        sv, contains(RegExp(r'^\s*input logic inp[,\s]*$', multiLine: true)));
+    expect(
+        sv, contains(RegExp(r'^\s*output logic out1[,\s]*$', multiLine: true)));
+    expect(
+        sv, contains(RegExp(r'^\s*output logic out2[,\s]*$', multiLine: true)));
+    expect(sv, contains(RegExp(r'^\s*inout wire io[,\s]*$', multiLine: true)));
   });
 
   test('packed struct output inside and outside of module', () async {
@@ -362,8 +361,8 @@ void main() {
 
       expect(sv, isNot(contains('internal_struct')));
 
-      expect(sv, contains('inout wire logic [1:0] myIn'));
-      expect(sv, contains('inout wire logic [1:0] myOut'));
+      expect(sv, contains('inout wire [1:0] myIn'));
+      expect(sv, contains('inout wire [1:0] myOut'));
 
       return mod;
     }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The explicit/implicit port type configuration added in #678 changed the default generated SystemVerilog from ROHD's historical port declarations:

- `input logic`
- `output logic`
- `inout wire`

to fully explicit declarations:

- `input wire logic`
- `output var logic`
- `inout wire logic`

This caused compatibility issues in some downstream flows. It also exposed a limitation in the original configuration: a single object/data type policy cannot represent the historical defaults because inout ports require different settings from input and output ports.

This PR restores the historical generated declarations by default and makes object and data type emission independently configurable for each port direction.

- Adds `SystemVerilogPortTypeConfiguration` for controlling object and data type emission together.
- Adds separate `inputPortType`, `outputPortType`, and `inOutPortType` settings to `SystemVerilogSynthesizerConfiguration`.
- Restores the default generated declarations to:
  - `input logic`
  - `output logic`
  - `inout wire`
- Supports independently configuring explicit or implicit object and data types for each port direction.
- Updates generated-SystemVerilog expectations throughout the test suite.
- Updates the generation documentation and changelog.

## Related Issue(s)

https://github.com/intel/rohd/pull/678

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No (previous PR changes are not released yet)

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, included
