### PR TITLE
Return the original signal when replicating by 1

### DIFF
--- a/lib/src/signals/logic.dart
+++ b/lib/src/signals/logic.dart
@@ -962,8 +962,16 @@ class Logic {
   /// The input [multiplier] cannot be negative or 0; an exception will be
   /// thrown, otherwise.
   ///
+  /// If [multiplier] is 1, then this signal is returned directly, since
+  /// replicating once is a no-op and would otherwise generate a redundant
+  /// `1{...}` in the output SystemVerilog.
+  ///
   /// If [isNet], then the result will also be a net.
   Logic replicate(int multiplier) {
+    if (multiplier == 1) {
+      return this;
+    }
+
     if (isNet) {
       // many SV simulators don't support replication of nets
       return List.generate(multiplier, (i) => this).swizzle();

--- a/test/replication_test.dart
+++ b/test/replication_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // replication_test.dart
@@ -18,6 +18,13 @@ class ReplicationOpModule extends Module {
     final b = addOutput('b', width: newWidth < 1 ? a.width : newWidth);
 
     b <= a.replicate(multiplier);
+  }
+}
+
+class SignExtendModule extends Module {
+  SignExtendModule(Logic a, int newWidth) {
+    a = addInput('a', a, width: a.width);
+    addOutput('b', width: newWidth) <= a.signExtend(newWidth);
   }
 }
 
@@ -50,6 +57,27 @@ void main() {
           Vector({'a': 0xf}, {'b': 0xf}),
           Vector({'a': 0x5}, {'b': 0x5}),
         ], 1, originalWidth: 4);
+      });
+
+      test('multiply by 1 returns the original signal', () {
+        final a = Logic(width: 4);
+        expect(identical(a.replicate(1), a), isTrue);
+      });
+
+      test('multiply by 1 generates no replication in SystemVerilog', () async {
+        final mod = ReplicationOpModule(Logic(width: 4), 1);
+        await mod.build();
+        final sv = mod.generateSynth();
+        expect(sv, contains('assign b = a;'));
+        expect(sv, isNot(contains('{1{')));
+      });
+
+      test('signExtend of a 1-bit signal by 1 generates no replication',
+          () async {
+        final mod = SignExtendModule(Logic(), 1);
+        await mod.build();
+        final sv = mod.generateSynth();
+        expect(sv, isNot(contains('{1{')));
       });
 
       test('multiply by 2 replicates the input signal twice', () async {


### PR DESCRIPTION
`Logic.replicate(1)` built a `ReplicationOp`, which emits a redundant `{1{...}}` in the generated SystemVerilog:

    assign rep1 = {1{a}};

Replicating once is a no-op, so return the signal directly instead. The generated output becomes:

    assign rep1 = a;

`signExtend` already routes through `replicate`, so it inherits the same benefit: sign-extending a 1-bit signal to width 1, or any signal to its existing width, no longer emits a replication.

Validation of non-positive multipliers is unaffected; those still reach `ReplicationOp` and throw `InvalidMultiplierException`.

Adds tests for the returned signal identity and for the absence of `{1{` in generated SystemVerilog. The existing "multiply by 1" test only checked simulated values, which pass either way.

Fixes #522

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

<!-- Please describe how you tested your changes. -->

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
