### PR TITLE
Throw an exception for duplicate interface port names

### DIFF
--- a/lib/src/exceptions/interface/duplicate_port_name_exception.dart
+++ b/lib/src/exceptions/interface/duplicate_port_name_exception.dart
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// duplicate_port_name_exception.dart
+// Definition for an exception thrown when a port name is already in use on an
+// interface.
+//
+// 2026 August 5
+// Author: Aisha Salimgereyeva <aishasalimg@gmail.com>
+
+import 'package:rohd/src/exceptions/rohd_exception.dart';
+
+/// An [Exception] thrown when a port is added to an interface with a name that
+/// is already in use by another port on that same interface.
+class DuplicatePortNameException extends RohdException {
+  /// Constructs a new [Exception] for when a port named [portName] already
+  /// exists on the interface it is being added to.
+  DuplicatePortNameException(String portName)
+      : super('Port named "$portName" already exists on this interface.');
+}

--- a/lib/src/exceptions/interface/interface_exceptions.dart
+++ b/lib/src/exceptions/interface/interface_exceptions.dart
@@ -1,5 +1,6 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
+export 'duplicate_port_name_exception.dart';
 export 'interface_name_exception.dart';
 export 'interface_type_exception.dart';

--- a/lib/src/interfaces/interface.dart
+++ b/lib/src/interfaces/interface.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface.dart
@@ -176,8 +176,9 @@ class Interface<TagType extends Enum> {
   void _setPort(Logic port, {Iterable<TagType>? tags, String? portName}) {
     portName ??= port.name;
 
-    assert(!_ports.containsKey(portName),
-        'Port named $portName already exists on this interface.');
+    if (_ports.containsKey(portName)) {
+      throw DuplicatePortNameException(portName);
+    }
 
     _ports[portName] = port;
     if (tags != null) {

--- a/test/interface_test.dart
+++ b/test/interface_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Intel Corporation
+// Copyright (C) 2021-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // interface_test.dart
@@ -65,6 +65,16 @@ class UncleanPortInterface extends Interface<MyDirection> {
 
   @override
   UncleanPortInterface clone() => UncleanPortInterface();
+}
+
+class DuplicatePortInterface extends Interface<MyDirection> {
+  DuplicatePortInterface() {
+    setPorts([Logic.port('dup')], [MyDirection.dir1]);
+    setPorts([Logic.port('dup')], [MyDirection.dir2]);
+  }
+
+  @override
+  DuplicatePortInterface clone() => DuplicatePortInterface();
 }
 
 class MaybePortInterface extends Interface<MyDirection> {
@@ -148,6 +158,11 @@ void main() {
     expect(() async {
       UncleanPortInterface();
     }, throwsException);
+  });
+
+  test('adding a port with a name already on the interface throws', () {
+    expect(
+        DuplicatePortInterface.new, throwsA(isA<DuplicatePortNameException>()));
   });
 
   group('bad net args intf', () {


### PR DESCRIPTION
Fixes #514.

`Interface._setPort` caught a port name that already exists on the interface with an `assert`:

```dart
assert(!_ports.containsKey(portName),
    'Port named $portName already exists on this interface.');
```

Asserts are stripped in release mode, so outside of tests the duplicate silently replaced the earlier entry in `_ports` and the interface ended up carrying a port the caller never intended.

This replaces it with a `DuplicatePortNameException`, a new `RohdException` alongside the existing `InterfaceNameException` and `InterfaceTypeException` in `lib/src/exceptions/interface/`, so the collision is reported in every build mode.

### Testing

New test in `interface_test.dart` builds an interface that declares the same port name twice and expects the exception. Confirmed it fails against unmodified `interface.dart` first — it threw `_AssertionError` rather than a `RohdException` — so the test genuinely covers the change.

Full gate locally: `dart test` 1320 passed, `dart format` 0 changed, `dart analyze --fatal-infos` clean, `dart doc` 0 warnings and 0 errors, `pana` 160/160.

### Note

This is a behavior change for release-mode builds that were unknowingly relying on the silent overwrite — that is the point of the issue, but flagging it since it could surface in downstream code. Happy to rename the exception or reword the message if you would prefer something different.
